### PR TITLE
Always honor firewall dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ options:
 
 To use the supply-chain firewall, just prepend `scfw` to the `pip install` or `npm install` command you want to run.
 
-```bash
+```
 $ scfw npm install react
 $ scfw pip install -r requirements.txt
 ```
@@ -73,11 +73,11 @@ To set up for testing and development, create a fresh `virtualenv`, activate it 
 
 The test suite may be executed in the development environment by running `make test`.  To additionally view code coverage, run `make coverage`.
 
-To facilitate testing "in the wild", `scfw` provides a `--dry-run` option that will verify any installation targets and exit without executing the given install command:
+To facilitate testing "in the wild", `scfw` provides a `--dry-run` option that will verify any installation targets and exit without executing the given package manager command:
 
-```bash
+```
 $ scfw --dry-run npm install axios
-Exiting without installing, no issues found for installation targets.
+Dry-run: no issues found, exiting without running command.
 ```
 
 Of course, one can always test inside a container or VM for an added layer of protection, if desired.

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -118,16 +118,14 @@ def run_firewall() -> int:
                 print("\nThe installation request was blocked. No changes have been made.")
                 return 0
 
-            if args.dry_run:
-                _log.info("Firewall dry-run mode enabled: no packages will be installed")
-                print("Exiting without installing, no issues found for installation targets.")
-                return 0
-
-        dd_log.info(
-            f"Running '{' '.join(args.command)}'",
-            extra={"targets": map(lambda x: x.show(), targets)}
-        )
-        command.run()
+        if args.dry_run:
+            _log.info("Firewall dry-run mode enabled: command will not be run")
+            print("Dry-run: no issues found, exiting without running command.")
+        else:
+            dd_log.info(
+                f"Running '{' '.join(args.command)}'", extra={"targets": map(lambda x: x.show(), targets)}
+            )
+            command.run()
         return 0
 
     except Exception as e:


### PR DESCRIPTION
This PR changes the behavior of the firewall `--dry-run` option so that it always applies, regardless of whether the given package manager command would install new packages or not.  Previously, the option was only activated if the command would install and did not block.

Closes #9 