### PR TITLE
Allow configuration via command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To check whether the installation succeeded, run the following command and verif
 
 ```bash
 $ scfw --version
-1.0.2
+1.1.0
 ```
 
 ### Post-installation steps

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -10,6 +10,7 @@ from typing import Callable, Optional
 
 import scfw
 from scfw.ecosystem import ECOSYSTEM
+from scfw.logger import FirewallAction
 from scfw.parser import ArgumentError, ArgumentParser
 
 _LOG_LEVELS = list(
@@ -28,7 +29,33 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
     Args:
         parser: The `ArgumentParser` to which the `configure` command line will be added.
     """
-    return
+    parser.add_argument(
+        "--alias-pip",
+        action="store_true",
+        help="Add shell aliases to always run pip commands through Supply-Chain Firewall"
+    )
+
+    parser.add_argument(
+        "--alias-npm",
+        action="store_true",
+        help="Add shell aliases to always run npm commands through Supply-Chain Firewall"
+    )
+
+    parser.add_argument(
+        "--dd-api-key",
+        type=str,
+        default=None,
+        metavar="KEY",
+        help="API key to use when forwarding logs to Datadog"
+    )
+
+    parser.add_argument(
+        "--dd-log-level",
+        type=str,
+        choices=[action.value for action in FirewallAction],
+        metavar="LEVEL",
+        help="Desired logging level for Datadog log forwarding (options: %(choices)s)"
+    )
 
 
 def _add_run_cli(parser: ArgumentParser) -> None:
@@ -72,13 +99,13 @@ class Subcommand(Enum):
             case Subcommand.Configure:
                 return {
                     "exit_on_error": False,
-                    "description": "Configure the environment for using the supply-chain firewall."
+                    "description": "Configure the environment for using Supply-Chain Firewall."
                 }
             case Subcommand.Run:
                 return {
                     "usage": "%(prog)s [options] COMMAND",
                     "exit_on_error": False,
-                    "description": "Run a package manager command through the supply-chain firewall."
+                    "description": "Run a package manager command through Supply-Chain Firewall."
                 }
 
     def _cli_spec(self) -> Callable[[ArgumentParser], None]:

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -2,7 +2,7 @@
 Defines the supply-chain firewall's command-line interface and performs argument parsing.
 """
 
-from argparse import Namespace
+from argparse import ArgumentError, Namespace
 from enum import Enum
 import logging
 import sys
@@ -11,7 +11,7 @@ from typing import Callable, Optional
 import scfw
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction
-from scfw.parser import ArgumentError, ArgumentParser
+from scfw.parser import ArgumentParser
 
 _LOG_LEVELS = list(
     map(
@@ -200,14 +200,14 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
         # the user selected the `run` subcommand
         match Subcommand(args.subcommand), argv[hinge:]:
             case Subcommand.Run, []:
-                raise ArgumentError
+                raise ArgumentError(None, "Missing required package manager command")
             case Subcommand.Run, _:
                 args_dict = vars(args)
                 args_dict["command"] = argv[hinge:]
             case _, []:
                 pass
             case _:
-                raise ArgumentError
+                raise ArgumentError(None, "Received unexpected package manager command")
 
         return args, help_msg
 

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -53,7 +53,7 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
         "--dd-log-level",
         type=str,
         default=None,
-        choices=[action.value for action in FirewallAction],
+        choices=[str(action) for action in FirewallAction],
         metavar="LEVEL",
         help="Desired logging level for Datadog log forwarding (options: %(choices)s)"
     )
@@ -87,6 +87,15 @@ class Subcommand(Enum):
     """
     Configure = "configure"
     Run = "run"
+
+    def __str__(self) -> str:
+        """
+        Format a `Subcommand` for printing.
+
+        Returns:
+            A `str` representing the given `Subcommand` suitable for printing.
+        """
+        return self.value
 
     def _parser_spec(self) -> dict:
         """
@@ -161,7 +170,7 @@ def _cli() -> ArgumentParser:
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
     for subcommand in Subcommand:
-        subparser = subparsers.add_parser(subcommand.value, **subcommand._parser_spec())
+        subparser = subparsers.add_parser(str(subcommand), **subcommand._parser_spec())
         subcommand._cli_spec()(subparser)
 
     return parser
@@ -186,7 +195,7 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
     hinge = len(argv)
     for ecosystem in ECOSYSTEM:
         try:
-            hinge = min(hinge, argv.index(ecosystem.value))
+            hinge = min(hinge, argv.index(str(ecosystem)))
         except ValueError:
             pass
 

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -202,8 +202,7 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
             case Subcommand.Run, []:
                 raise ArgumentError(None, "Missing required package manager command")
             case Subcommand.Run, _:
-                args_dict = vars(args)
-                args_dict["command"] = argv[hinge:]
+                args.command = argv[hinge:]
             case _, []:
                 pass
             case _:

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -52,6 +52,7 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
     parser.add_argument(
         "--dd-log-level",
         type=str,
+        default=None,
         choices=[action.value for action in FirewallAction],
         metavar="LEVEL",
         help="Desired logging level for Datadog log forwarding (options: %(choices)s)"

--- a/scfw/commands/__init__.py
+++ b/scfw/commands/__init__.py
@@ -31,10 +31,13 @@ def get_package_manager_command(
     """
     if not command:
         raise ValueError("Missing package manager command")
-    match command[0]:
-        case ECOSYSTEM.PIP.value:
-            return ECOSYSTEM.PIP, PipCommand(command, executable)
-        case ECOSYSTEM.NPM.value:
-            return ECOSYSTEM.NPM, NpmCommand(command, executable)
-        case other:
-            raise ValueError(f"Unsupported package manager '{other}'")
+
+    try:
+        match (ecosystem := ECOSYSTEM(command[0])):
+            case ECOSYSTEM.PIP:
+                return ecosystem, PipCommand(command, executable)
+            case ECOSYSTEM.NPM:
+                return ecosystem, NpmCommand(command, executable)
+
+    except ValueError:
+        raise ValueError(f"Unsupported package manager '{command[0]}'")

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -49,13 +49,13 @@ def run_configure(args: Namespace) -> int:
     Returns:
         An integer status code, 0 or 1.
     """
-    answers = vars(args)
-
-    interactive = not any(option for _, option in answers.items())
+    interactive = not any({args.alias_pip, args.alias_npm, args.dd_api_key, args.dd_log_level})
 
     if interactive:
         print(_GREETING)
         answers = inquirer.prompt(_get_questions())
+    else:
+        answers = vars(args)
 
     for file in [Path.home() / file for file in _CONFIG_FILES]:
         if file.exists():

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -103,7 +103,7 @@ def _get_questions() -> list[inquirer.questions.Question]:
         inquirer.List(
             name="dd_log_level",
             message="Select the desired log level for Datadog logging",
-            choices=[action.value for action in FirewallAction],
+            choices=[str(action) for action in FirewallAction],
             ignore=lambda answers: not has_dd_api_key and not answers["enable_dd_logs"]
         )
     ]

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -25,10 +25,10 @@ _BLOCK_START = "# BEGIN SCFW MANAGED BLOCK"
 _BLOCK_END = "# END SCFW MANAGED BLOCK"
 
 _GREETING = (
-    "Thank you for using scfw, Datadog's supply-chain firewall!\n\n"
+    "Thank you for using scfw, the Supply-Chain Firewall by Datadog!\n\n"
     "scfw is a tool for preventing the installation of malicious PyPI and npm packages.\n\n"
     "This script will walk you through setting up your environment to get the most out\n"
-    "of the firewall. You can rerun this script at any time.\n"
+    "of scfw. You can rerun this script at any time.\n"
 )
 
 _EPILOGUE = (

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -49,14 +49,20 @@ def run_configure(args: Namespace) -> int:
     Returns:
         An integer status code, 0 or 1.
     """
-    print(_GREETING)
+    answers = vars(args)
 
-    answers = inquirer.prompt(_get_questions())
+    interactive = not any(option for _, option in answers.items())
+
+    if interactive:
+        print(_GREETING)
+        answers = inquirer.prompt(_get_questions())
+
     for file in [Path.home() / file for file in _CONFIG_FILES]:
         if file.exists():
             _update_config_file(file, _format_answers(answers))
 
-    print(_EPILOGUE)
+    if interactive:
+        print(_EPILOGUE)
 
     return 0
 

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import re
 import tempfile
 
+from scfw.logger import FirewallAction
+
 DD_API_KEY_VAR = "DD_API_KEY"
 """
 The environment variable under which the firewall looks for a Datadog API key.
@@ -95,7 +97,7 @@ def _get_questions() -> list[inquirer.questions.Question]:
         inquirer.List(
             name="dd_log_level",
             message="Select the desired log level for Datadog logging",
-            choices=["BLOCK", "ABORT", "ALLOW"],
+            choices=[action.value for action in FirewallAction],
             ignore=lambda answers: not has_dd_api_key and not answers["enable_dd_logs"]
         )
     ]

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -11,3 +11,12 @@ class ECOSYSTEM(Enum):
     """
     PIP = "pip"
     NPM = "npm"
+
+    def __str__(self) -> str:
+        """
+        Format an `ECOSYSTEM` for printing.
+
+        Returns:
+            A `str` representing the given `ECOSYSTEM` suitable for printing.
+        """
+        return self.value

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -48,6 +48,15 @@ class FirewallAction(Enum):
             case _:
                 return False
 
+    def __str__(self) -> str:
+        """
+        Format a `FirewallAction` for printing.
+
+        Returns:
+            A `str` representing the given `FirewallAction` suitable for printing.
+        """
+        return self.value
+
 
 class FirewallLogger(metaclass=ABCMeta):
     """

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -98,7 +98,7 @@ class DDLogger(FirewallLogger):
         try:
             self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
         except ValueError:
-            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
+            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT.value}")
             self._level = _DD_LOG_LEVEL_DEFAULT
 
     def log(

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -98,7 +98,7 @@ class DDLogger(FirewallLogger):
         try:
             self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
         except ValueError:
-            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT.value}")
+            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
             self._level = _DD_LOG_LEVEL_DEFAULT
 
     def log(
@@ -130,7 +130,7 @@ class DDLogger(FirewallLogger):
 
         self._logger.info(
             message,
-            extra={"ecosystem": ecosystem.value, "targets": map(str, targets)}
+            extra={"ecosystem": str(ecosystem), "targets": map(str, targets)}
         )
 
 

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -19,6 +19,8 @@ from datadog_api_client.v2.model.http_log import HTTPLog
 from datadog_api_client.v2.model.http_log_item import HTTPLogItem
 import dotenv
 
+_log = logging.getLogger(__name__)
+
 _DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] - %(message)s"
 
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
@@ -96,6 +98,7 @@ class DDLogger(FirewallLogger):
         try:
             self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
         except ValueError:
+            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
             self._level = _DD_LOG_LEVEL_DEFAULT
 
     def log(

--- a/scfw/parser.py
+++ b/scfw/parser.py
@@ -5,13 +5,6 @@ A drop-in replacement for `argparse.ArgumentParser`.
 import argparse
 
 
-class ArgumentError(Exception):
-    """
-    An exception for `ArgumentParser` to raise.
-    """
-    pass
-
-
 class ArgumentParser(argparse.ArgumentParser):
     """
     A drop-in replacement for `argparse.ArgumentParser` with a patched
@@ -26,4 +19,4 @@ class ArgumentParser(argparse.ArgumentParser):
         Args:
             message: The error message.
         """
-        raise ArgumentError(message)
+        raise argparse.ArgumentError(None, message)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,25 @@ def test_cli_no_options_no_command():
     """
     argv = ["scfw"]
     args, _ = _parse_command_line(argv)
-    assert args == None
+    assert args is None
+
+
+def test_cli_all_options_no_command():
+    """
+    Invocation with all top-level options and no subcommand.
+    """
+    argv = ["scfw", "--log-level", "DEBUG"]
+    args, _ = _parse_command_line(argv)
+    assert args is None
+
+
+def test_cli_incorrect_subcommand():
+    """
+    Invocation with a nonexistent subcommand.
+    """
+    argv = ["scfw", "nonexistent"]
+    args, _ = _parse_command_line(argv)
+    assert args is None
 
 
 def test_cli_all_options_no_command():
@@ -43,7 +61,7 @@ def test_cli_all_options_no_command():
     executable = "/usr/bin/python"
     argv = ["scfw", "run", "--executable", executable, "--dry-run"]
     args, _ = _parse_command_line(argv)
-    assert args == None
+    assert args is None
 
 
 def test_cli_all_options_pip():


### PR DESCRIPTION
This PR adds command-line options to the `scfw configure` subcommand so that users may configure the command non-interactively via scripting.

```bash
usage: scfw configure [-h] [--alias-pip] [--alias-npm] [--dd-api-key KEY] [--dd-log-level LEVEL]

Configure the environment for using Supply-Chain Firewall.

options:
  -h, --help            show this help message and exit
  --alias-pip           Add shell aliases to always run pip commands through Supply-Chain Firewall
  --alias-npm           Add shell aliases to always run npm commands through Supply-Chain Firewall
  --dd-api-key KEY      API key to use when forwarding logs to Datadog
  --dd-log-level LEVEL  Desired logging level for Datadog log forwarding (options: ALLOW, ABORT, BLOCK)
```

If no command-line options are present, the interactive script runs as it did previously.  Otherwise, the command-line configuration is used and no output is printed.

The PR also performs various small refactoring.