### PR TITLE
Add default logger for local Datadog Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ scfw configure
 
 In keeping with its goal of blocking 100% of known-malicious package installations, `scfw` will refuse to run with an incompatible version of a supported package manager.  Please upgrade to or verify that you are running a compatible version before using this tool.
 
-Currently, Supply-Chain Firewall is only fully supported on macOS systems, though it should run as intended on most common Linux distributions.  It is currently not supported on Windows.
+Currently, Supply-Chain Firewall is only fully supported on macOS systems, though it should run as intended on common Linux distributions.  It is currently not supported on Windows.
 
 ## Usage
 
@@ -76,15 +76,15 @@ For `pip install` commands, packages will be installed in the same environment (
 
 Unlike `pip`, a variety of `npm` operations beyond `npm install` can end up installing new packages.  For now, only `npm install` commands are in Supply-Chain Firewall's scope.  We are hoping to extend the tool's purview to other "installish" `npm` commands over time.
 
-## Datadog Logs integration
+## Datadog Log Management integration
 
 Supply-Chain Firewall can optionally send logs of blocked and successful installations to Datadog.
 
 ![scfw datadog log](https://github.com/DataDog/supply-chain-firewall/blob/main/images/datadog_log.png?raw=true)
 
-To opt in, set the environment variable `DD_API_KEY` to your Datadog API key, either directly in your shell environment or in a `.env` file in the current working directory.  A logging level may also be selected by setting the environment variable `SCFW_DD_LOG_LEVEL` to one of `ALLOW`, `ABORT` or `BLOCK`.  The `BLOCK` level only logs blocked installations, `ABORT` logs blocked and aborted installations, and `ALLOW` logs these as well as successful installations.  The `BLOCK` level is set by default, i.e., when `SCFW_DD_LOG_LEVEL` is either not set or does not contain a valid log level.
+Users can configure their environments so that Supply-Chain Firewall forwards logs either via the Datadog HTTP API (requires an API key) or to a local Datadog Agent process.  Configuration consists of setting necessary environment variables and, for Agent log forwarding, configuring the Datadog Agent to accept logs from Supply-Chain Firewall.
 
-You can also use the `scfw configure` command to walk through the steps of configuring your environment for Datadog logging.
+To opt in, use the `scfw configure` command to interactively or non-interactively configure your environment for Datadog logging.
 
 Supply-Chain Firewall can integrate with user-supplied loggers.  A template for implementating a custom logger may be found in `examples/logger.py`. Refer to the API documentation for details.
 

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -42,9 +42,11 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
     )
 
     parser.add_argument(
-        "--dd-agent-logging",
-        action="store_true",
-        help="Enable log forwarding to the local Datadog Agent"
+        "--dd-agent-port",
+        type=str,
+        default=None,
+        metavar="PORT",
+        help="Configure log forwarding to the local Datadog Agent on the given port"
     )
 
     parser.add_argument(

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -46,7 +46,7 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
         type=str,
         default=None,
         metavar="KEY",
-        help="API key to use when forwarding logs to Datadog"
+        help="API key to use when forwarding logs via the Datadog API"
     )
 
     parser.add_argument(
@@ -56,6 +56,12 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
         choices=[str(action) for action in FirewallAction],
         metavar="LEVEL",
         help="Desired logging level for Datadog log forwarding (options: %(choices)s)"
+    )
+
+    parser.add_argument(
+        "--enable-agent-logging",
+        action="store_true",
+        help="Enable log forwarding to the local Datadog Agent"
     )
 
 

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -42,6 +42,12 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
     )
 
     parser.add_argument(
+        "--dd-agent-logging",
+        action="store_true",
+        help="Enable log forwarding to the local Datadog Agent"
+    )
+
+    parser.add_argument(
         "--dd-api-key",
         type=str,
         default=None,
@@ -56,12 +62,6 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
         choices=[str(action) for action in FirewallAction],
         metavar="LEVEL",
         help="Desired logging level for Datadog log forwarding (options: %(choices)s)"
-    )
-
-    parser.add_argument(
-        "--enable-agent-logging",
-        action="store_true",
-        help="Enable log forwarding to the local Datadog Agent"
     )
 
 

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -33,6 +33,8 @@ The environment variable under which the firewall looks for a port number on whi
 forward firewall logs to the local Datadog Agent.
 """
 
+_DD_AGENT_DEFAULT_LOG_PORT = "10365"
+
 _CONFIG_FILES = [".bashrc", ".zshrc"]
 
 _BLOCK_START = "# BEGIN SCFW MANAGED BLOCK"
@@ -115,19 +117,20 @@ def _get_questions() -> list[inquirer.questions.Question]:
         ),
         inquirer.Confirm(
             name="dd_agent_logging",
-            message="Would you like to enable sending firewall logs to your local Datadog Agent?",
+            message="If you have the Datadog Agent installed locally, would you like to forward firewall logs to it?",
             default=False
         ),
         inquirer.Text(
             name="dd_agent_port",
             message="Enter the local port where the Agent will receive logs",
+            default=_DD_AGENT_DEFAULT_LOG_PORT,
             ignore=lambda answers: not answers["dd_agent_logging"]
         ),
         inquirer.Confirm(
             name="dd_api_logging",
-            message="Would you like to enable sending firewall logs to Datadog?",
+            message="Would you like to enable sending firewall logs to Datadog using an API key?",
             default=False,
-            ignore=lambda _: has_dd_api_key
+            ignore=lambda answers: has_dd_api_key or answers["dd_agent_logging"]
         ),
         inquirer.Text(
             name="dd_api_key",

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -137,7 +137,7 @@ def _get_questions() -> list[inquirer.questions.Question]:
             name="dd_log_level",
             message="Select the desired log level for Datadog logging",
             choices=[str(action) for action in FirewallAction],
-            ignore=lambda answers: not(answers["dd_agent_logging"] or has_dd_api_key or answers["dd_api_logging"])
+            ignore=lambda answers: not (answers["dd_agent_logging"] or has_dd_api_key or answers["dd_api_logging"])
         )
     ]
 

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -218,7 +218,7 @@ def _configure_agent_logging():
         )
         agent_config_dir = json.loads(agent_status.stdout).get("config", {}).get("confd_path", "")
     except subprocess.CalledProcessError:
-        raise Exception("Unable to query Datadog Agent status. Ensure the Agent is running before retrying.")
+        raise RuntimeError("Unable to query Datadog Agent status. Ensure the Agent is running before retrying.")
 
     scfw_config_dir = Path(agent_config_dir) / "scfw.d"
     scfw_config_file = scfw_config_dir / "conf.yaml"
@@ -237,4 +237,6 @@ def _configure_agent_logging():
         time.sleep(1)
         subprocess.run(["launchctl", "start", "com.datadoghq.agent"], check=True)
     except subprocess.CalledProcessError:
-        raise Exception("Unable to restart Datadog Agent. Please retry this command or restart the Agent manually.")
+        raise RuntimeError(
+            "Unable to restart Datadog Agent. Please retry this command or restart the Agent manually."
+        )

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import re
 import subprocess
 import tempfile
-import time
 
 from scfw.logger import FirewallAction
 

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -202,7 +202,7 @@ def _configure_agent_logging():
     config_yaml = (
         "logs:\n"
         "  - type: tcp\n"
-       f"    port: {DD_AGENT_PORT}\n"
+        f"    port: {DD_AGENT_PORT}\n"
         '    service: "scfw"\n'
         '    source: "scfw"\n'
     )

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -257,13 +257,14 @@ def _get_farewell(answers: dict) -> str:
         A `str` farewell message to print in interactive mode.
     """
     farewell = (
-        "The environment was successfully configured. Make sure to update your current shell\n"
-        "environment by running, e.g.:\n\n    source ~/.bashrc\n\n"
+        "The environment was successfully configured for Supply-Chain Firewall.\n\n"
+        "Post-configuration tasks:\n"
+        "* Update your current shell environment by sourcing from your .bashrc/.zshrc file."
     )
 
     if answers.get("dd_agent_logging"):
-        farewell += "The Datadog Agent must also be restarted in order for it to accept firewall logs.\n\n"
+        farewell += "\n* Restart the Datadog Agent in order for it to accept firewall logs."
 
-    farewell += "Good luck!"
+    farewell += "\n\nGood luck!"
 
     return farewell

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -169,7 +169,7 @@ def _format_answers(answers: dict) -> str:
     if answers["alias_npm"]:
         config += '\nalias npm="scfw run npm"'
     if answers["dd_agent_logging"]:
-        config += f'\nexport {DD_AGENT_LOG_VAR}="Enabled"'
+        config += f'\nexport {DD_AGENT_LOG_VAR}="True"'
     if answers["dd_api_key"]:
         config += f'\nexport {DD_API_KEY_VAR}="{answers["dd_api_key"]}"'
     if answers["dd_log_level"]:
@@ -226,10 +226,13 @@ def _configure_agent_logging():
         _log.info("Found existing Datadog Agent configuration file for Supply-Chain Firewall")
         return
 
-    if not scfw_config_dir.is_dir():
-        scfw_config_dir.mkdir()
-    with open(scfw_config_file, 'w') as f:
-        f.write(_DD_AGENT_CONFIG_FILE)
+    try:
+        if not scfw_config_dir.is_dir():
+            scfw_config_dir.mkdir()
+        with open(scfw_config_file, 'w') as f:
+            f.write(_DD_AGENT_CONFIG_FILE)
+    except PermissionError:
+        raise RuntimeError("Unable to create Datadog Agent configuration file for Supply-Chain Firewall")
 
     # Agent must be restarted for changes to take effect
     try:

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -115,8 +115,7 @@ def _get_answers_interactive() -> dict:
         ),
         inquirer.Text(
             name="dd_agent_port",
-            message="Enter the local port where the Agent will receive logs",
-            default=_DD_AGENT_DEFAULT_LOG_PORT,
+            message=f"Enter the local port where the Agent will receive logs (default: {_DD_AGENT_DEFAULT_LOG_PORT})",
             ignore=lambda answers: not answers["dd_agent_logging"]
         ),
         inquirer.Confirm(

--- a/scfw/configure.py
+++ b/scfw/configure.py
@@ -257,9 +257,9 @@ def _get_farewell(answers: dict) -> str:
         A `str` farewell message to print in interactive mode.
     """
     farewell = (
-        "The environment was successfully configured for Supply-Chain Firewall.\n\n"
-        "Post-configuration tasks:\n"
-        "* Update your current shell environment by sourcing from your .bashrc/.zshrc file."
+        "The environment was successfully configured for Supply-Chain Firewall."
+        "\n\nPost-configuration tasks:"
+        "\n* Update your current shell environment by sourcing from your .bashrc/.zshrc file."
     )
 
     if answers.get("dd_agent_logging"):

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -46,6 +46,6 @@ def get_firewall_loggers() -> list[FirewallLogger]:
         except ModuleNotFoundError:
             _log.warning(f"Failed to load module {module} while collecting loggers")
         except AttributeError:
-            _log.warning(f"Module {module} does not export a logger")
+            _log.info(f"Module {module} does not export a logger")
 
     return loggers

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -7,8 +7,6 @@ import logging
 import os
 import socket
 
-import dotenv
-
 import scfw
 from scfw.configure import DD_AGENT_LOG_VAR, DD_AGENT_PORT
 from scfw.logger import FirewallLogger
@@ -70,7 +68,6 @@ class _DDLogHandler(logging.Handler):
 
 
 # Configure a single logging handle for all `DDAgentLogger` instances to share
-dotenv.load_dotenv()
 _handler = _DDLogHandler() if os.getenv(DD_AGENT_LOG_VAR) else logging.NullHandler()
 _handler.setFormatter(_DDLogFormatter())
 

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -8,7 +8,7 @@ import os
 import socket
 
 import scfw
-from scfw.configure import DD_AGENT_LOG_VAR, DD_AGENT_PORT
+from scfw.configure import DD_AGENT_PORT_VAR
 from scfw.logger import FirewallLogger
 from scfw.loggers.dd_logger import DDLogger
 
@@ -51,6 +51,20 @@ class _DDLogHandler(logging.Handler):
     """
     A custom log handler for forwarding firewall logs to a local Datadog Agent.
     """
+    def __init__(self, port: str):
+        """
+        Initialize a new `_DDLogHandler`.
+
+        Args:
+            port: The local port number where the firewall logs will be sent to the Agent.
+
+        Raises:
+            ValueError: An invalid port number was provided.
+        """
+        if not (0 < int(port) < 65536):
+            raise ValueError("Invalid port number provided for Datadog Agent logging")
+        self._port = port
+
     def emit(self, record):
         """
         Format and send a log to the Datadog Agent.
@@ -61,14 +75,15 @@ class _DDLogHandler(logging.Handler):
         message = self.format(record).encode()
 
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.connect(("localhost", DD_AGENT_PORT))
+        s.connect(("localhost", self._port))
         if s.send(message) != len(message):
             _log.warning("Failed to log firewall action to Datadog Agent")
         s.close()
 
 
 # Configure a single logging handle for all `DDAgentLogger` instances to share
-_handler = _DDLogHandler() if os.getenv(DD_AGENT_LOG_VAR) else logging.NullHandler()
+_agent_port = os.getenv(DD_AGENT_PORT_VAR)
+_handler = _DDLogHandler(_agent_port) if _agent_port else logging.NullHandler()
 _handler.setFormatter(_DDLogFormatter())
 
 _ddlog = logging.getLogger(_DD_LOG_NAME)

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -1,0 +1,127 @@
+"""
+Configures a logger for sending firewall logs to a local Datadog Agent.
+"""
+
+import json
+import logging
+import os
+import socket
+
+import dotenv
+
+from scfw.configure import DD_LOG_LEVEL_VAR
+from scfw.ecosystem import ECOSYSTEM
+from scfw.logger import FirewallAction, FirewallLogger
+from scfw.target import InstallTarget
+
+_log = logging.getLogger(__name__)
+
+_DD_LOG_NAME = "dd_agent_log"
+
+_DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
+
+DD_AGENT_PORT = 10518
+"""TCP port where the Datadog Agent receives logs from custom integrations"""
+
+
+class _DDLogFormatter(logging.Formatter):
+    """
+    A custom JSON formatter for firewall logs.
+    """
+    def format(self, record) -> str:
+        """
+        Format a log record as a JSON string.
+
+        Args:
+            record: The log record to be formatted.
+        """
+        return json.dumps(record.__dict__)
+
+
+class _DDLogHandler(logging.Handler):
+    """
+    A custom log handler for forwarding firewall logs to a local Datadog Agent.
+    """
+    def emit(self, record):
+        """
+        Format and send a log to the Datadog Agent.
+
+        Args:
+            record: The log record to be forwarded.
+        """
+        message = self.format(record).encode()
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(("localhost", DD_AGENT_PORT))
+        if s.send(message) != len(message):
+            _log.warning("Failed to log firewall action to Datadog Agent")
+        s.close()
+
+
+# Configure a single logging handle for all `DDAgentLogger` instances to share
+dotenv.load_dotenv()
+_handler = _DDLogHandler()
+_handler.setFormatter(_DDLogFormatter())
+
+_ddlog = logging.getLogger(_DD_LOG_NAME)
+_ddlog.setLevel(logging.INFO)
+_ddlog.addHandler(_handler)
+
+
+class DDAgentLogger(FirewallLogger):
+    """
+    An implementation of `FirewallLogger` for sending logs to a local Datadog Agent.
+    """
+    def __init__(self):
+        """
+        Initialize a new `DDAgentLogger`.
+        """
+        self._logger = _ddlog
+
+        try:
+            self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
+        except ValueError:
+            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
+            self._level = _DD_LOG_LEVEL_DEFAULT
+
+    def log(
+        self,
+        action: FirewallAction,
+        ecosystem: ECOSYSTEM,
+        command: list[str],
+        targets: list[InstallTarget]
+    ):
+        """
+        Receive and log data about a completed firewall run.
+
+        Args:
+            action: The action taken by the firewall.
+            ecosystem: The ecosystem of the inspected package manager command.
+            command: The package manager command line provided to the firewall.
+            targets: The installation targets relevant to firewall's action.
+        """
+        if not self._level or action < self._level:
+            return
+
+        match action:
+            case FirewallAction.ALLOW:
+                message = f"Command '{' '.join(command)}' was allowed"
+            case FirewallAction.ABORT:
+                message = f"Command '{' '.join(command)}' was aborted"
+            case FirewallAction.BLOCK:
+                message = f"Command '{' '.join(command)}' was blocked"
+
+        self._logger.info(
+            message,
+            extra={"ecosystem": str(ecosystem), "targets": list(map(str, targets))}
+        )
+
+
+def load_logger() -> FirewallLogger:
+    """
+    Export `DDAgentLogger` for discovery by the firewall.
+
+    Returns:
+        A `DDAgentLogger` for use in a run of the firewall.
+    """
+    return DDAgentLogger()

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -10,7 +10,7 @@ import socket
 import dotenv
 
 import scfw
-from scfw.configure import DD_LOG_LEVEL_VAR
+from scfw.configure import DD_AGENT_LOG_VAR, DD_AGENT_PORT, DD_LOG_LEVEL_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.target import InstallTarget
@@ -20,9 +20,6 @@ _log = logging.getLogger(__name__)
 _DD_LOG_NAME = "dd_agent_log"
 
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
-
-DD_AGENT_PORT = 10518
-"""TCP port where the Datadog Agent receives logs from custom integrations"""
 
 
 class _DDLogFormatter(logging.Formatter):
@@ -77,7 +74,7 @@ class _DDLogHandler(logging.Handler):
 
 # Configure a single logging handle for all `DDAgentLogger` instances to share
 dotenv.load_dotenv()
-_handler = _DDLogHandler()
+_handler = _DDLogHandler() if os.getenv(DD_AGENT_LOG_VAR) else logging.NullHandler()
 _handler.setFormatter(_DDLogFormatter())
 
 _ddlog = logging.getLogger(_DD_LOG_NAME)

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -6,18 +6,18 @@ import logging
 import os
 import socket
 
-import scfw
-from scfw.configure import DD_API_KEY_VAR, DD_LOG_LEVEL_VAR
-from scfw.ecosystem import ECOSYSTEM
-from scfw.logger import FirewallAction, FirewallLogger
-from scfw.target import InstallTarget
-
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.v2.api.logs_api import LogsApi
 from datadog_api_client.v2.model.content_encoding import ContentEncoding
 from datadog_api_client.v2.model.http_log import HTTPLog
 from datadog_api_client.v2.model.http_log_item import HTTPLogItem
 import dotenv
+
+import scfw
+from scfw.configure import DD_API_KEY_VAR, DD_LOG_LEVEL_VAR
+from scfw.ecosystem import ECOSYSTEM
+from scfw.logger import FirewallAction, FirewallLogger
+from scfw.target import InstallTarget
 
 _log = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ dotenv.load_dotenv()
 _handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
 _handler.setFormatter(logging.Formatter(_DD_LOG_FORMAT))
 
-_ddlog = logging.getLogger(_DD_API_LOG)
+_ddlog = logging.getLogger(_DD_LOG_NAME)
 _ddlog.setLevel(logging.INFO)
 _ddlog.addHandler(_handler)
 

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -31,7 +31,7 @@ _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
 class _DDLogHandler(logging.Handler):
     """
     A log handler for adding tags and forwarding firewall logs of blocked and
-    permitted package installation requests to Datadog.
+    permitted package installation requests to the Datadog API.
 
     In addition to USM tags, install targets are tagged with the `target` tag and included.
     """
@@ -77,7 +77,7 @@ class _DDLogHandler(logging.Handler):
             api_instance.submit_log(content_encoding=ContentEncoding.DEFLATE, body=body)
 
 
-# Configure a single logging handle for all `DDLogger` instances to share
+# Configure a single logging handle for all `DDAPILogger` instances to share
 dotenv.load_dotenv()
 _handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
 _handler.setFormatter(logging.Formatter(_DD_LOG_FORMAT))
@@ -87,13 +87,13 @@ _ddlog.setLevel(logging.INFO)
 _ddlog.addHandler(_handler)
 
 
-class DDLogger(FirewallLogger):
+class DDAPILogger(FirewallLogger):
     """
-    An implementation of `FirewallLogger` for sending logs to Datadog.
+    An implementation of `FirewallLogger` for sending logs to the Datadog API.
     """
     def __init__(self):
         """
-        Initialize a new `DDLogger`.
+        Initialize a new `DDAPILogger`.
         """
         self._logger = _ddlog
 
@@ -138,9 +138,9 @@ class DDLogger(FirewallLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDLogger` for discovery by the firewall.
+    Export `DDAPILogger` for discovery by the firewall.
 
     Returns:
-        A `DDLogger` for use in a run of the supply chain firewall.
+        A `DDAPILogger` for use in a run of the firewall.
     """
-    return DDLogger()
+    return DDAPILogger()

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -1,5 +1,5 @@
 """
-Configures a logger for sending firewall logs to Datadog.
+Configures a logger for sending firewall logs to Datadog's API over HTTP.
 """
 
 import logging

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -11,7 +11,6 @@ from datadog_api_client.v2.api.logs_api import LogsApi
 from datadog_api_client.v2.model.content_encoding import ContentEncoding
 from datadog_api_client.v2.model.http_log import HTTPLog
 from datadog_api_client.v2.model.http_log_item import HTTPLogItem
-import dotenv
 
 import scfw
 from scfw.configure import DD_API_KEY_VAR
@@ -44,10 +43,8 @@ class _DDLogHandler(logging.Handler):
         Args:
             record: The log record to be forwarded.
         """
-        if not (env := os.getenv("DD_ENV")):
-            env = self.DD_ENV
-        if not (service := os.getenv("DD_SERVICE")):
-            service = record.__dict__.get("ecosystem", self.DD_SOURCE)
+        env = os.getenv("DD_ENV", self.DD_ENV)
+        service = os.getenv("DD_SERVICE", record.__dict__.get("ecosystem", self.DD_SOURCE))
 
         usm_tags = {f"env:{env}", f"version:{self.DD_VERSION}"}
 
@@ -73,7 +70,6 @@ class _DDLogHandler(logging.Handler):
 
 
 # Configure a single logging handle for all `DDAPILogger` instances to share
-dotenv.load_dotenv()
 _handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
 _handler.setFormatter(logging.Formatter(_DD_LOG_FORMAT))
 

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -21,6 +21,8 @@ import dotenv
 
 _log = logging.getLogger(__name__)
 
+_DD_LOG_NAME = "dd_api_log"
+
 _DD_LOG_FORMAT = "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] - %(message)s"
 
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
@@ -80,7 +82,7 @@ dotenv.load_dotenv()
 _handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
 _handler.setFormatter(logging.Formatter(_DD_LOG_FORMAT))
 
-_ddlog = logging.getLogger("ddlog")
+_ddlog = logging.getLogger(_DD_API_LOG)
 _ddlog.setLevel(logging.INFO)
 _ddlog.addHandler(_handler)
 

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -5,6 +5,8 @@ Provides a `FirewallLogger` class for sending logs to Datadog.
 import logging
 import os
 
+import dotenv
+
 from scfw.configure import DD_LOG_LEVEL_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
@@ -13,6 +15,9 @@ from scfw.target import InstallTarget
 _log = logging.getLogger(__name__)
 
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
+
+
+dotenv.load_dotenv()
 
 
 class DDLogger(FirewallLogger):

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -1,0 +1,67 @@
+"""
+Provides a `FirewallLogger` class for sending logs to Datadog.
+"""
+
+import logging
+import os
+
+from scfw.configure import DD_LOG_LEVEL_VAR
+from scfw.ecosystem import ECOSYSTEM
+from scfw.logger import FirewallAction, FirewallLogger
+from scfw.target import InstallTarget
+
+_log = logging.getLogger(__name__)
+
+_DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
+
+
+class DDLogger(FirewallLogger):
+    """
+    An implementation of `FirewallLogger` for sending logs to Datadog.
+    """
+    def __init__(self, logger: logging.Logger):
+        """
+        Initialize a new `DDLogger`.
+
+        Args:
+            logger: A configured log handle to which logs will be written.
+        """
+        self._logger = logger
+
+        try:
+            self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
+        except ValueError:
+            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
+            self._level = _DD_LOG_LEVEL_DEFAULT
+
+    def log(
+        self,
+        action: FirewallAction,
+        ecosystem: ECOSYSTEM,
+        command: list[str],
+        targets: list[InstallTarget]
+    ):
+        """
+        Receive and log data about a completed firewall run.
+
+        Args:
+            action: The action taken by the firewall.
+            ecosystem: The ecosystem of the inspected package manager command.
+            command: The package manager command line provided to the firewall.
+            targets: The installation targets relevant to firewall's action.
+        """
+        if not self._level or action < self._level:
+            return
+
+        match action:
+            case FirewallAction.ALLOW:
+                message = f"Command '{' '.join(command)}' was allowed"
+            case FirewallAction.ABORT:
+                message = f"Command '{' '.join(command)}' was aborted"
+            case FirewallAction.BLOCK:
+                message = f"Command '{' '.join(command)}' was blocked"
+
+        self._logger.info(
+            message,
+            extra={"action": str(action), "ecosystem": str(ecosystem), "targets": list(map(str, targets))}
+        )


### PR DESCRIPTION
This PR adds a new default logger to Supply-Chain Firewall that logs to the local Datadog Agent running on the user's system.  This logger can be enabled alongside the previous Datadog API logger, if desired, to send the same logs into different Datadog orgs.

It also updates the `scfw configure` command so that Agent logging can be configured interactively and non-interactively:
```bash
$ scfw configure --dd-agent-logging --dd-log-level ALLOW
```
Once this command is run, the user just needs to run `source ~/.bashrc` (or `.zshrc`) in their active shell to pick up the new configuration.  Otherwise, no additional action from the user is required to set up Agent logging.