### PR TITLE
Bump version number to 1.2.0

### DIFF
--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
This PR bumps the version number to 1.2.0 in preparation for the latest release.