### PR TITLE
Add an uninstall subcommand

### DIFF
--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -89,12 +89,23 @@ def _add_run_cli(parser: ArgumentParser) -> None:
     )
 
 
+def _add_uninstall_cli(parser: ArgumentParser) -> None:
+    """
+    Defines the command-line interface for the firewall's `uninstall` subcommand.
+
+    Args:
+        parser: The `ArgumentParser` to which the `run` command line will be added.
+    """
+    return
+
+
 class Subcommand(Enum):
     """
     The set of subcommands that comprise the supply-chain firewall's command line.
     """
     Configure = "configure"
     Run = "run"
+    Uninstall = "uninstall"
 
     def __str__(self) -> str:
         """
@@ -125,6 +136,11 @@ class Subcommand(Enum):
                     "exit_on_error": False,
                     "description": "Run a package manager command through Supply-Chain Firewall."
                 }
+            case Subcommand.Uninstall:
+                return {
+                    "exit_on_error": False,
+                    "description": "Uninstall Supply-Chain Firewall and remove all related configuration"
+                }
 
     def _cli_spec(self) -> Callable[[ArgumentParser], None]:
         """
@@ -141,6 +157,8 @@ class Subcommand(Enum):
                 return _add_configure_cli
             case Subcommand.Run:
                 return _add_run_cli
+            case Subcommand.Uninstall:
+                return _add_uninstall_cli
 
 
 def _cli() -> ArgumentParser:

--- a/scfw/main.py
+++ b/scfw/main.py
@@ -9,6 +9,7 @@ import scfw.cli as cli
 from scfw.cli import Subcommand
 import scfw.configure as configure
 import scfw.firewall as firewall
+import scfw.uninstall as uninstall
 
 _log = logging.getLogger(__name__)
 
@@ -36,6 +37,8 @@ def main() -> int:
             return configure.run_configure(args)
         case Subcommand.Run:
             return firewall.run_firewall(args)
+        case Subcommand.Uninstall:
+            return uninstall.run_uninstall(args)
 
     return 0
 

--- a/scfw/uninstall.py
+++ b/scfw/uninstall.py
@@ -2,6 +2,8 @@
 Implements the supply-chain firewall's `uninstall` command.
 """
 
+from argparse import Namespace
+
 
 def run_uninstall(args: Namespace) -> int:
     """

--- a/scfw/uninstall.py
+++ b/scfw/uninstall.py
@@ -1,0 +1,16 @@
+"""
+Implements the supply-chain firewall's `uninstall` command.
+"""
+
+
+def run_uninstall(args: Namespace) -> int:
+    """
+    Remove all Supply-Chain Firewall configuration and uninstall the tool.
+
+    Args:
+        args: A `Namespace` containing the parsed `uninstall` subcommand command line.
+
+    Returns:
+        An integer status code, 0 or 1.
+    """
+    return 0


### PR DESCRIPTION
This PR adds an `scfw uninstall` subcommand to remove any `scfw configure` configuration from the user's system.  This sets the user up to completely remove SCFW from their system via `pip uninstall scfw` without any dangling shell aliases, environment variables, or Datadog Agent configuration files.