### PR TITLE
Add a configuration removal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ In keeping with its goal of blocking 100% of known-malicious package installatio
 
 Currently, Supply-Chain Firewall is only fully supported on macOS systems, though it should run as intended on common Linux distributions.  It is currently not supported on Windows.
 
+### Uninstalling Supply-Chain Firewall
+
+Supply-Chain Firewall may be uninstalled via `pip uninstall scfw`.  Before doing so, be sure to run `scfw configure --remove` to remove any Supply-Chain Firewall-related configuration you may have previously added to your environment.
+
 ## Usage
 
 To use Supply-Chain Firewall, prepend `scfw run` to the `pip install` or `npm install` command you want to run.

--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -30,6 +30,13 @@ def _add_configure_cli(parser: ArgumentParser) -> None:
         parser: The `ArgumentParser` to which the `configure` command line will be added.
     """
     parser.add_argument(
+        "-r",
+        "--remove",
+        action="store_true",
+        help="Remove all configuration associated with Supply-Chain Firewall"
+    )
+
+    parser.add_argument(
         "--alias-pip",
         action="store_true",
         help="Add shell aliases to always run pip commands through Supply-Chain Firewall"


### PR DESCRIPTION
This PR adds a `--remove` option to the `scfw configure` subcommand that can be used to remove all SCFW-related configuration added to the environment via `scfw configure`, typically in preparation for uninstalling the tool.

This option unsets all shell aliases, removes SCFW-related environment variables, and deletes any Datadog Agent configuration added for log forwarding purposes.