### PR TITLE
Hotfix: Add missing subpackage to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["scfw", "scfw.commands", "scfw.loggers", "scfw.verifiers"]
+packages = ["scfw", "scfw.commands", "scfw.configure", "scfw.loggers", "scfw.verifiers"]
 
 [tool.setuptools.dynamic]
 version = {attr = "scfw.__version__"}

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -5,7 +5,7 @@ Implements Supply-Chain Firewall's `configure` subcommand.
 from argparse import Namespace
 import logging
 
-from scfw.configure.constants import *
+from scfw.configure.constants import *  # noqa
 import scfw.configure.dd_agent as dd_agent
 import scfw.configure.env as env
 import scfw.configure.interactive as interactive

--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -5,43 +5,13 @@ Implements Supply-Chain Firewall's `configure` subcommand.
 from argparse import Namespace
 import logging
 
+from scfw.configure.constants import *
 import scfw.configure.dd_agent as dd_agent
 import scfw.configure.env as env
 import scfw.configure.interactive as interactive
 from scfw.configure.interactive import GREETING
 
 _log = logging.getLogger(__name__)
-
-DD_SOURCE = "scfw"
-"""
-Source value for Datadog logging.
-"""
-
-DD_SERVICE = "scfw"
-"""
-Service value for Datadog logging.
-"""
-
-DD_ENV = "dev"
-"""
-Default environment value for Datadog logging.
-"""
-
-DD_API_KEY_VAR = "DD_API_KEY"
-"""
-The environment variable under which the firewall looks for a Datadog API key.
-"""
-
-DD_LOG_LEVEL_VAR = "SCFW_DD_LOG_LEVEL"
-"""
-The environment variable under which the firewall looks for a Datadog log level setting.
-"""
-
-DD_AGENT_PORT_VAR = "SCFW_DD_AGENT_LOG_PORT"
-"""
-The environment variable under which the firewall looks for a port number on which to
-forward firewall logs to the local Datadog Agent.
-"""
 
 
 def run_configure(args: Namespace) -> int:

--- a/scfw/configure/constants.py
+++ b/scfw/configure/constants.py
@@ -1,0 +1,34 @@
+"""
+Provides various configuration-related constants.
+"""
+
+DD_SOURCE = "scfw"
+"""
+Source value for Datadog logging.
+"""
+
+DD_SERVICE = "scfw"
+"""
+Service value for Datadog logging.
+"""
+
+DD_ENV = "dev"
+"""
+Default environment value for Datadog logging.
+"""
+
+DD_API_KEY_VAR = "DD_API_KEY"
+"""
+The environment variable under which the firewall looks for a Datadog API key.
+"""
+
+DD_LOG_LEVEL_VAR = "SCFW_DD_LOG_LEVEL"
+"""
+The environment variable under which the firewall looks for a Datadog log level setting.
+"""
+
+DD_AGENT_PORT_VAR = "SCFW_DD_AGENT_LOG_PORT"
+"""
+The environment variable under which the firewall looks for a port number on which to
+forward firewall logs to the local Datadog Agent.
+"""

--- a/scfw/configure/dd_agent.py
+++ b/scfw/configure/dd_agent.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import shutil
 import subprocess
 
-from scfw.configure import DD_SERVICE, DD_SOURCE
+from scfw.configure.constants import DD_SERVICE, DD_SOURCE
 
 
 def configure_agent_logging(port: str):

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -7,7 +7,7 @@ import re
 import os
 import tempfile
 
-from scfw.configure import DD_AGENT_PORT_VAR, DD_API_KEY_VAR, DD_LOG_LEVEL_VAR
+from scfw.configure.constants import DD_AGENT_PORT_VAR, DD_API_KEY_VAR, DD_LOG_LEVEL_VAR
 
 _CONFIG_FILES = [".bashrc", ".zshrc"]
 

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -6,7 +6,7 @@ import os
 
 import inquirer  # type: ignore
 
-from scfw.configure import DD_API_KEY_VAR
+from scfw.configure.constants import DD_API_KEY_VAR
 from scfw.logger import FirewallAction
 
 GREETING = (


### PR DESCRIPTION
This PR fixes a bug introduced in eaea17003cf8007b64fd7602b03bcf3918568395 that caused Setuptools not to be able to find the new `scfw/configure/` submodule when building Supply-Chain Firewall.  This broke the `configure` subcommand.