### PR TITLE
Handle OSV.dev results pagination

### DIFF
--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -102,6 +102,7 @@ def get_farewell(answers: dict) -> str:
 
     return farewell
 
+
 def _describe_log_level(action: FirewallAction) -> str:
     """
     Return a description of the given `action` considered as a log level.

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -115,8 +115,8 @@ def _describe_log_level(action: FirewallAction) -> str:
     """
     match action:
         case FirewallAction.ALLOW:
-            return "Log allowed, aborted and blocked commands"
+            return "Log allowed, user-cancelled, and blocked commands"
         case FirewallAction.ABORT:
-            return "Log aborted and blocked commands"
+            return "Log user-cancelled and blocked commands"
         case FirewallAction.BLOCK:
             return "Log only blocked commands"

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -64,7 +64,7 @@ def get_answers() -> dict:
         inquirer.List(
             name="dd_log_level",
             message="Select the desired log level for Datadog logging",
-            choices=[str(action) for action in FirewallAction],
+            choices=[(_describe_log_level(action), str(action)) for action in FirewallAction],
             ignore=lambda answers: not (answers["dd_agent_logging"] or has_dd_api_key or answers["dd_api_logging"])
         )
     ]
@@ -101,3 +101,21 @@ def get_farewell(answers: dict) -> str:
     farewell += "\n\nGood luck!"
 
     return farewell
+
+def _describe_log_level(action: FirewallAction) -> str:
+    """
+    Return a description of the given `action` considered as a log level.
+
+    Args:
+        action: A `FirewallAction` considered as a log level.
+
+    Returns:
+        A `str` description of which firewall actions are logged at the given level.
+    """
+    match action:
+        case FirewallAction.ALLOW:
+            return "Log allowed, aborted and blocked commands"
+        case FirewallAction.ABORT:
+            return "Log aborted and blocked commands"
+        case FirewallAction.BLOCK:
+            return "Log only blocked commands"


### PR DESCRIPTION
This PR updates `OsvVerifier` so that it correctly handles pagination of OSV.dev API query results, querying until all pages have been read.  It also adds more informative descriptions of the Datadog log levels in the interactive configure script.