### PR TITLE
Rank OSV.dev findings by severity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["scfw", "scfw.commands", "scfw.configure", "scfw.loggers", "scfw.verifiers"]
+packages = [
+    "scfw", "scfw.commands", "scfw.configure", "scfw.loggers", "scfw.verifiers", "scfw.verifiers.osv_verifier"
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "scfw.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "scfw"
 dynamic = ["version"]
 dependencies = [
+    "cvss",
     "datadog-api-client",
     "inquirer",
     "packaging",

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,6 +97,9 @@ charset-normalizer==3.4.1 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e \
     --hash=sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00 \
     --hash=sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616
+cvss==3.4 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:632353244ba3c58b53355466677edc968b9d7143c317b66271f9fd7939951ee8 \
+    --hash=sha256:d9950613758e60820f7fac37ca5f35158712f8f2ea4f6629858a60c4984fe4ef
 datadog-api-client==2.33.1 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:26e6b44fccff5d7bc9eaeaae1d3ce4fc4c0587400d869a53c81e4cc272dc63b4 \
     --hash=sha256:9b56521fa8ea7b743024759c624804cf0435dca110f111f31f08dd68d640737a
@@ -115,9 +118,9 @@ packaging==24.2 ; python_version >= "3.10" and python_version < "4" \
 python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-python-dotenv==1.0.1 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
-    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
+python-dotenv==1.1.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5 \
+    --hash=sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d
 readchar==4.2.1 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:91ce3faf07688de14d800592951e5575e9c7a3213738ed01d394dcc949b79adb \
     --hash=sha256:a769305cd3994bb5fa2764aa4073452dc105a4ec39068ffe6efd3c20c60acc77
@@ -130,9 +133,9 @@ runs==1.2.2 ; python_version >= "3.10" and python_version < "4" \
 six==1.17.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-typing-extensions==4.12.2 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
-    --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
+typing-extensions==4.13.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b \
+    --hash=sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5
 urllib3==2.3.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
     --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -38,15 +38,7 @@ class FirewallAction(Enum):
                 f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
             )
 
-        match self.name, other.name:
-            case "ALLOW", "ABORT":
-                return True
-            case "ALLOW", "BLOCK":
-                return True
-            case "ABORT", "BLOCK":
-                return True
-            case _:
-                return False
+        return (self.name, other.name) in {("ALLOW", "ABORT"), ("ALLOW", "BLOCK"), ("ABORT", "BLOCK")}
 
     def __str__(self) -> str:
         """

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -15,9 +15,9 @@ class FirewallAction(Enum):
     The various actions the firewall may take in response to inspecting a
     package manager command.
     """
-    ALLOW = "ALLOW"
-    ABORT = "ABORT"
-    BLOCK = "BLOCK"
+    ALLOW = 0
+    ABORT = 1
+    BLOCK = 2
 
     def __lt__(self, other) -> bool:
         """
@@ -38,7 +38,7 @@ class FirewallAction(Enum):
                 f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
             )
 
-        return (self.name, other.name) in {("ALLOW", "ABORT"), ("ALLOW", "BLOCK"), ("ABORT", "BLOCK")}
+        return self.value < other.value
 
     def __str__(self) -> str:
         """
@@ -47,7 +47,7 @@ class FirewallAction(Enum):
         Returns:
             A `str` representing the given `FirewallAction` suitable for printing.
         """
-        return self.value
+        return self.name
 
 
 class FirewallLogger(metaclass=ABCMeta):

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -5,6 +5,7 @@ completed run of the supply-chain firewall.
 
 from abc import (ABCMeta, abstractmethod)
 from enum import Enum
+from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.target import InstallTarget
@@ -48,6 +49,25 @@ class FirewallAction(Enum):
             A `str` representing the given `FirewallAction` suitable for printing.
         """
         return self.name
+
+    @classmethod
+    def from_string(cls, s: str) -> Self:
+        """
+        Convert a string into a `FirewallAction`.
+
+        Args:
+            s: The `str` to be converted.
+
+        Returns:
+            The `FirewallAction` referred to by the given string.
+
+        Raises:
+            ValueError: The given string does not refer to a valid `FirewallAction`.
+        """
+        mappings = {f"{action}".lower(): action for action in cls}
+        if (action := mappings.get(s.lower())):
+            return action
+        raise ValueError(f"Invalid firewall action '{s}'")
 
 
 class FirewallLogger(metaclass=ABCMeta):

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -66,12 +66,13 @@ class DDLogger(FirewallLogger):
             logger: A configured log handle to which logs will be written.
         """
         self._logger = logger
+        self._level = _DD_LOG_LEVEL_DEFAULT
 
         try:
-            self._level = FirewallAction(os.getenv(DD_LOG_LEVEL_VAR))
+            if (dd_log_level := os.getenv(DD_LOG_LEVEL_VAR)) is not None:
+                self._level = FirewallAction.from_string(dd_log_level)
         except ValueError:
             _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
-            self._level = _DD_LOG_LEVEL_DEFAULT
 
     def log(
         self,

--- a/scfw/main.py
+++ b/scfw/main.py
@@ -49,7 +49,7 @@ def _configure_logging(level: int):
     """
     handler = logging.StreamHandler()
     handler.addFilter(logging.Filter(name="scfw"))
-    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.setFormatter(logging.Formatter("[SCFW] %(levelname)s: %(message)s"))
 
     log = logging.getLogger()
     log.addHandler(handler)

--- a/scfw/verifiers/osv_verifier.py
+++ b/scfw/verifiers/osv_verifier.py
@@ -4,8 +4,11 @@ and malicious open source software packages.
 """
 
 from dataclasses import dataclass
+from enum import Enum
 import logging
+from typing import Optional
 
+from cvss import CVSS2, CVSS3, CVSS4  # type: ignore
 import requests
 
 from scfw.ecosystem import ECOSYSTEM
@@ -21,6 +24,151 @@ _OSV_DEV_VULN_URL_PREFIX = "https://osv.dev/vulnerability"
 _OSV_DEV_LIST_URL_PREFIX = "https://osv.dev/list"
 
 
+class Severity(Enum):
+    """
+    Represents the possible severities that an OSV advisory can have.
+    """
+    Non = "None"
+    Low = "Low"
+    Medium = "Medium"
+    High = "High"
+    Critical = "Critical"
+
+    def __lt__(self, other: "Severity") -> bool:
+        """
+        Compare two `Severity` instances.
+
+        Args:
+            self: The `Severity` to be compared on the left-hand side
+            other: The `Severity` to be compared on the right-hand side
+
+        Returns:
+            A `bool` indicating whether `<` holds between the two given `Severity`.
+
+        Raises:
+            TypeError: The other argument given was not a `Severity`.
+        """
+        if self.__class__ is not other.__class__:
+            raise TypeError(
+                f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
+            )
+
+        return (self.name, other.name) in {
+            ("Non", "Low"), ("Non", "Medium"), ("Non", "High"), ("Non", "Critical"),
+            ("Low", "Medium"), ("Low", "High"), ("Low", "Critical"),
+            ("Medium", "High"), ("Medium", "Critical"),
+            ("High", "Critical")
+        }
+
+    def __str__(self) -> str:
+        """
+        Format a `Severity` for printing.
+
+        Returns:
+            A `str` representing the given `Severity` suitable for printing.
+        """
+        return self.value
+
+    @classmethod
+    def from_string(cls, s: str) -> "Severity":
+        """
+        Convert a string into a `Severity`.
+
+        Args:
+            s: The `str` to be converted.
+
+        Returns:
+            The `Severity` referred to by the given string.
+
+        Raises:
+            ValueError: The given string does not refer to a valid `Severity`.
+        """
+        mappings = {severity.value: severity for severity in cls}
+        if (severity := mappings.get(s.lower().capitalize())):
+            return severity
+        else:
+            raise ValueError(f"Invalid severity '{s}'")
+
+
+class OsvSeverityType(Enum):
+    """
+    The various severity score types defined in the OSV standard.
+    """
+    CVSS_V2 = "CVSS_V2"
+    CVSS_V3 = "CVSS_V3"
+    CVSS_V4 = "CVSS_V4"
+    Ubuntu = "Ubuntu"
+
+    @classmethod
+    def from_string(cls, s: str) -> "OsvSeverityType":
+        """
+        Convert a string into a `OsvSeverityType`.
+
+        Args:
+            s: The `str` to be converted.
+
+        Returns:
+            The `OsvSeverityType` referred to by the given string.
+
+        Raises:
+            ValueError: The given string does not refer to a valid `OsvSeverityType`.
+        """
+        mappings = {type.value: type for type in cls}
+        if (type := mappings.get(s)):
+            return type
+        else:
+            raise ValueError(f"Invalid OSV severity type '{s}'")
+
+
+@dataclass(eq=True, frozen=True)
+class OsvSeverityScore:
+    """
+    A typed severity score used in assigning severities to OSV advisories.
+    """
+    type: OsvSeverityType
+    score: str
+
+    @classmethod
+    def from_json(cls, osv_json: dict) -> "OsvSeverityScore":
+        """
+        Convert a JSON-formatted OSV advisory into an `OsvSeverityScore`.
+
+        Args:
+            osv_json: The JSON-formatted OSV severity score to be converted.
+
+        Returns:
+            An `OsvSeverityScore` derived from the content of the given JSON.
+
+        Raises:
+            ValueError: The severity score was malformed or missing required information.
+        """
+        type = osv_json.get("type")
+        score = osv_json.get("score")
+        if type and score:
+            return cls(type=OsvSeverityType.from_string(type), score=score)
+        else:
+            raise ValueError("Encountered malformed OSV severity score")
+
+    def severity(self) -> Severity:
+        """
+        Return the `Severity` of the given `OsvSeverityScore`.
+
+        Returns:
+            The computed `Severity` of the given `OsvSeverityScore`.
+        """
+        match self.type:
+            case OsvSeverityType.CVSS_V2:
+                severity_str = CVSS2(self.score).severities()[0]
+            case OsvSeverityType.CVSS_V3:
+                severity_str = CVSS3(self.score).severities()[0]
+            case OsvSeverityType.CVSS_V4:
+                severity_str = CVSS4(self.score).severity
+            case OsvSeverityType.Ubuntu:
+                severity_str = "None" if self.score == "Negligible" else self.score
+
+        return Severity.from_string(severity_str)
+
+
 @dataclass(eq=True, frozen=True)
 class OsvAdvisory:
     """
@@ -28,6 +176,32 @@ class OsvAdvisory:
     to installation target verification.
     """
     id: str
+    severity: Optional[Severity]
+
+    def __lt__(self, other: "OsvAdvisory") -> bool:
+        """
+        Compare two `OsvAdvisory` instances on the basis of their severities.
+
+        Args:
+            self: The `OsvAdvisory` to be compared on the left-hand side
+            other: The `OsvAdvisory` to be compared on the right-hand side
+
+        Returns:
+            A `bool` indicating whether `<` holds between the two given `OsvAdvisory`.
+
+        Raises:
+            TypeError: The other argument given was not an `OsvAdvisory`.
+        """
+        if self.__class__ is not other.__class__:
+            raise TypeError(
+                f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
+            )
+
+        # A match statement would be more natural here but mypy is not up to it
+        return (
+            (self.severity is None and other.severity is not None)
+            or (self.severity is not None and other.severity is not None and self.severity < other.severity)
+        )
 
     @classmethod
     def from_json(cls, osv_json: dict) -> "OsvAdvisory":
@@ -44,7 +218,11 @@ class OsvAdvisory:
             ValueError: The advisory was malformed or missing required information.
         """
         if (id := osv_json.get("id")):
-            return cls(id)
+            scores = map(OsvSeverityScore.from_json, osv_json.get("severity", []))
+            return cls(
+                id=id,
+                severity=max(map(lambda score: score.severity(), scores)) if scores else None
+            )
         else:
             raise ValueError("Encountered OSV advisory with missing ID field")
 
@@ -83,15 +261,17 @@ class OsvVerifier(InstallTargetVerifier):
                 An error occurred while querying an installation target against the OSV.dev API.
         """
         def mal_finding(osv: OsvAdvisory) -> str:
+            severity_tag = f"[{osv.severity}] " if osv.severity else ""
             return (
                 f"An OSV.dev malicious package disclosure exists for package {target}:\n"
-                f"  * {_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
+                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
             )
 
         def non_mal_finding(osv: OsvAdvisory) -> str:
+            severity_tag = f"[{osv.severity}] " if osv.severity else ""
             return (
                 f"An OSV.dev disclosure exists for package {target}:\n"
-                f"  * {_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
+                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
             )
 
         def error_message(e: str) -> str:
@@ -136,8 +316,8 @@ class OsvVerifier(InstallTargetVerifier):
             non_mal_osvs = osvs - mal_osvs
 
             return (
-                [(FindingSeverity.CRITICAL, mal_finding(osv)) for osv in mal_osvs]
-                + [(FindingSeverity.WARNING, non_mal_finding(osv)) for osv in non_mal_osvs]
+                [(FindingSeverity.CRITICAL, mal_finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
+                + [(FindingSeverity.WARNING, non_mal_finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
             )
 
         except requests.exceptions.RequestException as e:

--- a/scfw/verifiers/osv_verifier.py
+++ b/scfw/verifiers/osv_verifier.py
@@ -115,8 +115,7 @@ class OsvSeverityType(Enum):
         mappings = {type.value: type for type in cls}
         if (type := mappings.get(s)):
             return type
-        else:
-            raise ValueError(f"Invalid OSV severity type '{s}'")
+        raise ValueError(f"Invalid OSV severity type '{s}'")
 
 
 @dataclass(eq=True, frozen=True)
@@ -145,8 +144,7 @@ class OsvSeverityScore:
         score = osv_json.get("score")
         if type and score:
             return cls(type=OsvSeverityType.from_string(type), score=score)
-        else:
-            raise ValueError("Encountered malformed OSV severity score")
+        raise ValueError("Encountered malformed OSV severity score")
 
     def severity(self) -> Severity:
         """
@@ -222,8 +220,7 @@ class OsvAdvisory:
                 id=id,
                 severity=max(map(lambda score: score.severity(), scores)) if scores else None
             )
-        else:
-            raise ValueError("Encountered OSV advisory with missing ID field")
+        raise ValueError("Encountered OSV advisory with missing ID field")
 
 
 class OsvVerifier(InstallTargetVerifier):

--- a/scfw/verifiers/osv_verifier.py
+++ b/scfw/verifiers/osv_verifier.py
@@ -86,8 +86,7 @@ class Severity(Enum):
         mappings = {severity.value: severity for severity in cls}
         if (severity := mappings.get(s.lower().capitalize())):
             return severity
-        else:
-            raise ValueError(f"Invalid severity '{s}'")
+        raise ValueError(f"Invalid severity '{s}'")
 
 
 class OsvSeverityType(Enum):
@@ -218,7 +217,7 @@ class OsvAdvisory:
             ValueError: The advisory was malformed or missing required information.
         """
         if (id := osv_json.get("id")):
-            scores = map(OsvSeverityScore.from_json, osv_json.get("severity", []))
+            scores = list(map(OsvSeverityScore.from_json, osv_json.get("severity", [])))
             return cls(
                 id=id,
                 severity=max(map(lambda score: score.severity(), scores)) if scores else None

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -3,6 +3,7 @@ Defines an installation target verifier that uses OSV.dev's database of vulnerab
 and malicious open source software packages.
 """
 
+import functools
 import logging
 
 import requests
@@ -103,9 +104,13 @@ class OsvVerifier(InstallTargetVerifier):
             mal_osvs = set(filter(lambda osv: osv.id.startswith("MAL"), osvs))
             non_mal_osvs = osvs - mal_osvs
 
+            osv_sort_key = functools.cmp_to_key(OsvAdvisory.compare_severities)
+            sorted_mal_osvs = sorted(mal_osvs, reverse=True, key=osv_sort_key)
+            sorted_non_mal_osvs = sorted(non_mal_osvs, reverse=True, key=osv_sort_key)
+
             return (
-                [(FindingSeverity.CRITICAL, finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
-                + [(FindingSeverity.WARNING, finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
+                [(FindingSeverity.CRITICAL, finding(osv)) for osv in sorted_mal_osvs]
+                + [(FindingSeverity.WARNING, finding(osv)) for osv in sorted_non_mal_osvs]
             )
 
         except requests.exceptions.RequestException as e:

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -1,0 +1,129 @@
+"""
+Defines an installation target verifier that uses OSV.dev's database of vulnerable
+and malicious open source software packages.
+"""
+
+import logging
+
+import requests
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.target import InstallTarget
+from scfw.verifier import FindingSeverity, InstallTargetVerifier
+from scfw.verifiers.osv_verifier.osv_advisory import OsvAdvisory
+
+_log = logging.getLogger(__name__)
+
+_OSV_ECOSYSTEMS = {ECOSYSTEM.PIP: "PyPI", ECOSYSTEM.NPM: "npm"}
+
+_OSV_DEV_QUERY_URL = "https://api.osv.dev/v1/query"
+_OSV_DEV_VULN_URL_PREFIX = "https://osv.dev/vulnerability"
+_OSV_DEV_LIST_URL_PREFIX = "https://osv.dev/list"
+
+
+class OsvVerifier(InstallTargetVerifier):
+    """
+    An `InstallTargetVerifier` for the OSV.dev open source vulnerability and
+    malicious package database.
+    """
+    def name(self) -> str:
+        """
+        Return the `OsvVerifier` name string.
+
+        Returns:
+            The class' constant name string: `"OsvVerifier"`.
+        """
+        return "OsvVerifier"
+
+    def verify(self, target: InstallTarget) -> list[tuple[FindingSeverity, str]]:
+        """
+        Query an given installation target against the OSV.dev database.
+
+        Args:
+            target: The installation target to query.
+
+        Returns:
+            A list containing any findings for the given installation target, obtained
+            by querying for it against OSV.dev.
+
+            OSV.dev disclosures with `MAL` IDs are treated as `CRITICAL` findings and all
+            others are treated as `WARNING`.  *It is very important to note that most but
+            **not all** OSV.dev malicious package disclosures have `MAL` IDs.*
+
+        Raises:
+            requests.HTTPError:
+                An error occurred while querying an installation target against the OSV.dev API.
+        """
+        def mal_finding(osv: OsvAdvisory) -> str:
+            severity_tag = f"[{osv.severity}] " if osv.severity else ""
+            return (
+                f"An OSV.dev malicious package disclosure exists for package {target}:\n"
+                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
+            )
+
+        def non_mal_finding(osv: OsvAdvisory) -> str:
+            severity_tag = f"[{osv.severity}] " if osv.severity else ""
+            return (
+                f"An OSV.dev disclosure exists for package {target}:\n"
+                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
+            )
+
+        def error_message(e: str) -> str:
+            url = f"{_OSV_DEV_LIST_URL_PREFIX}?q={target.package}&ecosystem={_OSV_ECOSYSTEMS[target.ecosystem]}"
+            return (
+                f"Failed to verify target against OSV.dev: {e if e else 'An unspecified error occurred'}.\n"
+                f"Before proceeding, please check for OSV.dev advisories related to this target.\n"
+                f"DO NOT PROCEED if it has an advisory with a MAL ID: it is very likely malicious.\n"
+                f"  * {url}"
+            )
+
+        vulns = []
+
+        query = {
+            "version": target.version,
+            "package": {
+                "name": target.package,
+                "ecosystem": _OSV_ECOSYSTEMS[target.ecosystem]
+            }
+        }
+
+        try:
+            while True:
+                # The OSV.dev API is sometimes quite slow, hence the generous timeout
+                request = requests.post(_OSV_DEV_QUERY_URL, json=query, timeout=10)
+                request.raise_for_status()
+                response = request.json()
+
+                if (response_vulns := response.get("vulns")):
+                    vulns.extend(response_vulns)
+
+                query["page_token"] = response.get("next_page_token")
+
+                if not query["page_token"]:
+                    break
+
+            if not vulns:
+                return []
+
+            osvs = set(map(OsvAdvisory.from_json, filter(lambda vuln: vuln.get("id"), vulns)))
+            mal_osvs = set(filter(lambda osv: osv.id.startswith("MAL"), osvs))
+            non_mal_osvs = osvs - mal_osvs
+
+            return (
+                [(FindingSeverity.CRITICAL, mal_finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
+                + [(FindingSeverity.WARNING, non_mal_finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
+            )
+
+        except requests.exceptions.RequestException as e:
+            _log.warning(f"Failed to query OSV.dev API: returning WARNING finding for target {target}")
+            return [(FindingSeverity.WARNING, error_message(str(e)))]
+
+
+def load_verifier() -> InstallTargetVerifier:
+    """
+    Export `OsvVerifier` for discovery by the firewall.
+
+    Returns:
+        An `OsvVerifier` for use in a run of the supply chain firewall.
+    """
+    return OsvVerifier()

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -112,6 +112,10 @@ class OsvVerifier(InstallTargetVerifier):
             _log.warning(f"Failed to query OSV.dev API: returning WARNING finding for target {target}")
             return [(FindingSeverity.WARNING, error_message(str(e)))]
 
+        except Exception as e:
+            _log.warning(f"Target verification failed: returning WARNING finding for target {target}")
+            return [(FindingSeverity.WARNING, error_message(str(e)))]
+
 
 def load_verifier() -> InstallTargetVerifier:
     """

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -54,17 +54,11 @@ class OsvVerifier(InstallTargetVerifier):
             requests.HTTPError:
                 An error occurred while querying an installation target against the OSV.dev API.
         """
-        def mal_finding(osv: OsvAdvisory) -> str:
+        def finding(osv: OsvAdvisory) -> str:
+            kind = "malicious package " if osv.id.startswith("MAL") else ""
             severity_tag = f"[{osv.severity}] " if osv.severity else ""
             return (
-                f"An OSV.dev malicious package disclosure exists for package {target}:\n"
-                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
-            )
-
-        def non_mal_finding(osv: OsvAdvisory) -> str:
-            severity_tag = f"[{osv.severity}] " if osv.severity else ""
-            return (
-                f"An OSV.dev disclosure exists for package {target}:\n"
+                f"An OSV.dev {kind}disclosure exists for package {target}:\n"
                 f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
             )
 
@@ -110,8 +104,8 @@ class OsvVerifier(InstallTargetVerifier):
             non_mal_osvs = osvs - mal_osvs
 
             return (
-                [(FindingSeverity.CRITICAL, mal_finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
-                + [(FindingSeverity.WARNING, non_mal_finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
+                [(FindingSeverity.CRITICAL, finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
+                + [(FindingSeverity.WARNING, finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
             )
 
         except requests.exceptions.RequestException as e:

--- a/scfw/verifiers/osv_verifier/osv_advisory.py
+++ b/scfw/verifiers/osv_verifier/osv_advisory.py
@@ -13,11 +13,11 @@ class Severity(Enum):
     """
     Represents the possible severities that an OSV advisory can have.
     """
-    Non = "None"
-    Low = "Low"
-    Medium = "Medium"
-    High = "High"
-    Critical = "Critical"
+    Non = 0
+    Low = 1
+    Medium = 2
+    High = 3
+    Critical = 4
 
     def __lt__(self, other: "Severity") -> bool:
         """
@@ -38,12 +38,7 @@ class Severity(Enum):
                 f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
             )
 
-        return (self.name, other.name) in {
-            ("Non", "Low"), ("Non", "Medium"), ("Non", "High"), ("Non", "Critical"),
-            ("Low", "Medium"), ("Low", "High"), ("Low", "Critical"),
-            ("Medium", "High"), ("Medium", "Critical"),
-            ("High", "Critical")
-        }
+        return self.value < other.value
 
     def __str__(self) -> str:
         """
@@ -52,7 +47,7 @@ class Severity(Enum):
         Returns:
             A `str` representing the given `Severity` suitable for printing.
         """
-        return self.value
+        return "None" if self.name == "Non" else self.name
 
     @classmethod
     def from_string(cls, s: str) -> "Severity":
@@ -68,8 +63,8 @@ class Severity(Enum):
         Raises:
             ValueError: The given string does not refer to a valid `Severity`.
         """
-        mappings = {severity.value: severity for severity in cls}
-        if (severity := mappings.get(s.lower().capitalize())):
+        mappings = {f"{severity}".lower(): severity for severity in cls}
+        if (severity := mappings.get(s.lower())):
             return severity
         raise ValueError(f"Invalid severity '{s}'")
 

--- a/scfw/verifiers/osv_verifier/osv_advisory.py
+++ b/scfw/verifiers/osv_verifier/osv_advisory.py
@@ -86,7 +86,7 @@ class OsvSeverityType(Enum):
     @classmethod
     def from_string(cls, s: str) -> "OsvSeverityType":
         """
-        Convert a string into a `OsvSeverityType`.
+        Convert a string into an `OsvSeverityType`.
 
         Args:
             s: The `str` to be converted.
@@ -162,7 +162,8 @@ class OsvAdvisory:
 
     def __lt__(self, other: "OsvAdvisory") -> bool:
         """
-        Compare two `OsvAdvisory` instances on the basis of their severities.
+        Compare two `OsvAdvisory` instances on the basis of their severities such that
+        advisories with no severities are sorted lower than those with severities.
 
         Args:
             self: The `OsvAdvisory` to be compared on the left-hand side

--- a/scfw/verifiers/osv_verifier/osv_advisory.py
+++ b/scfw/verifiers/osv_verifier/osv_advisory.py
@@ -5,6 +5,7 @@ Provides a representation of OSV advisories for use in `OsvVerifier`.
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
+from typing_extensions import Self
 
 from cvss import CVSS2, CVSS3, CVSS4  # type: ignore
 
@@ -19,7 +20,7 @@ class Severity(Enum):
     High = 3
     Critical = 4
 
-    def __lt__(self, other: "Severity") -> bool:
+    def __lt__(self, other: Self) -> bool:
         """
         Compare two `Severity` instances.
 
@@ -50,7 +51,7 @@ class Severity(Enum):
         return "None" if self.name == "Non" else self.name
 
     @classmethod
-    def from_string(cls, s: str) -> "Severity":
+    def from_string(cls, s: str) -> Self:
         """
         Convert a string into a `Severity`.
 
@@ -69,7 +70,7 @@ class Severity(Enum):
         raise ValueError(f"Invalid severity '{s}'")
 
 
-class OsvSeverityType(Enum):
+class OsvSeverityType(str, Enum):
     """
     The various severity score types defined in the OSV standard.
     """
@@ -77,25 +78,6 @@ class OsvSeverityType(Enum):
     CVSS_V3 = "CVSS_V3"
     CVSS_V4 = "CVSS_V4"
     Ubuntu = "Ubuntu"
-
-    @classmethod
-    def from_string(cls, s: str) -> "OsvSeverityType":
-        """
-        Convert a string into an `OsvSeverityType`.
-
-        Args:
-            s: The `str` to be converted.
-
-        Returns:
-            The `OsvSeverityType` referred to by the given string.
-
-        Raises:
-            ValueError: The given string does not refer to a valid `OsvSeverityType`.
-        """
-        mappings = {type.value: type for type in cls}
-        if (type := mappings.get(s)):
-            return type
-        raise ValueError(f"Invalid OSV severity type '{s}'")
 
 
 @dataclass(eq=True, frozen=True)
@@ -107,7 +89,7 @@ class OsvSeverityScore:
     score: str
 
     @classmethod
-    def from_json(cls, osv_json: dict) -> "OsvSeverityScore":
+    def from_json(cls, osv_json: dict) -> Self:
         """
         Convert a JSON-formatted OSV advisory into an `OsvSeverityScore`.
 
@@ -123,7 +105,7 @@ class OsvSeverityScore:
         type = osv_json.get("type")
         score = osv_json.get("score")
         if type and score:
-            return cls(type=OsvSeverityType.from_string(type), score=score)
+            return cls(type=OsvSeverityType(type), score=score)
         raise ValueError("Encountered malformed OSV severity score")
 
     def severity(self) -> Severity:
@@ -156,7 +138,7 @@ class OsvAdvisory:
     severity: Optional[Severity]
 
     @classmethod
-    def compare_severities(cls, lhs: "OsvAdvisory", rhs: "OsvAdvisory") -> int:
+    def compare_severities(cls, lhs: Self, rhs: Self) -> int:
         """
         Compare two `OsvAdvisory` instances on the basis of their severities such that
         advisories with no severities are sorted lower than those with severities.
@@ -190,7 +172,7 @@ class OsvAdvisory:
         return result
 
     @classmethod
-    def from_json(cls, osv_json: dict) -> "OsvAdvisory":
+    def from_json(cls, osv_json: dict) -> Self:
         """
         Convert a JSON-formatted OSV advisory into an `OsvAdvisory`.
 

--- a/scfw/verifiers/osv_verifier/osv_advisory.py
+++ b/scfw/verifiers/osv_verifier/osv_advisory.py
@@ -1,27 +1,12 @@
 """
-Defines an installation target verifier that uses OSV.dev's database of vulnerable
-and malicious open source software packages.
+Provides a representation of OSV advisories for use in `OsvVerifier`.
 """
 
 from dataclasses import dataclass
 from enum import Enum
-import logging
 from typing import Optional
 
 from cvss import CVSS2, CVSS3, CVSS4  # type: ignore
-import requests
-
-from scfw.ecosystem import ECOSYSTEM
-from scfw.target import InstallTarget
-from scfw.verifier import FindingSeverity, InstallTargetVerifier
-
-_log = logging.getLogger(__name__)
-
-_OSV_ECOSYSTEMS = {ECOSYSTEM.PIP: "PyPI", ECOSYSTEM.NPM: "npm"}
-
-_OSV_DEV_QUERY_URL = "https://api.osv.dev/v1/query"
-_OSV_DEV_VULN_URL_PREFIX = "https://osv.dev/vulnerability"
-_OSV_DEV_LIST_URL_PREFIX = "https://osv.dev/list"
 
 
 class Severity(Enum):
@@ -221,111 +206,3 @@ class OsvAdvisory:
                 severity=max(map(lambda score: score.severity(), scores)) if scores else None
             )
         raise ValueError("Encountered OSV advisory with missing ID field")
-
-
-class OsvVerifier(InstallTargetVerifier):
-    """
-    An `InstallTargetVerifier` for the OSV.dev open source vulnerability and
-    malicious package database.
-    """
-    def name(self) -> str:
-        """
-        Return the `OsvVerifier` name string.
-
-        Returns:
-            The class' constant name string: `"OsvVerifier"`.
-        """
-        return "OsvVerifier"
-
-    def verify(self, target: InstallTarget) -> list[tuple[FindingSeverity, str]]:
-        """
-        Query an given installation target against the OSV.dev database.
-
-        Args:
-            target: The installation target to query.
-
-        Returns:
-            A list containing any findings for the given installation target, obtained
-            by querying for it against OSV.dev.
-
-            OSV.dev disclosures with `MAL` IDs are treated as `CRITICAL` findings and all
-            others are treated as `WARNING`.  *It is very important to note that most but
-            **not all** OSV.dev malicious package disclosures have `MAL` IDs.*
-
-        Raises:
-            requests.HTTPError:
-                An error occurred while querying an installation target against the OSV.dev API.
-        """
-        def mal_finding(osv: OsvAdvisory) -> str:
-            severity_tag = f"[{osv.severity}] " if osv.severity else ""
-            return (
-                f"An OSV.dev malicious package disclosure exists for package {target}:\n"
-                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
-            )
-
-        def non_mal_finding(osv: OsvAdvisory) -> str:
-            severity_tag = f"[{osv.severity}] " if osv.severity else ""
-            return (
-                f"An OSV.dev disclosure exists for package {target}:\n"
-                f"  * {severity_tag}{_OSV_DEV_VULN_URL_PREFIX}/{osv.id}"
-            )
-
-        def error_message(e: str) -> str:
-            url = f"{_OSV_DEV_LIST_URL_PREFIX}?q={target.package}&ecosystem={_OSV_ECOSYSTEMS[target.ecosystem]}"
-            return (
-                f"Failed to verify target against OSV.dev: {e if e else 'An unspecified error occurred'}.\n"
-                f"Before proceeding, please check for OSV.dev advisories related to this target.\n"
-                f"DO NOT PROCEED if it has an advisory with a MAL ID: it is very likely malicious.\n"
-                f"  * {url}"
-            )
-
-        vulns = []
-
-        query = {
-            "version": target.version,
-            "package": {
-                "name": target.package,
-                "ecosystem": _OSV_ECOSYSTEMS[target.ecosystem]
-            }
-        }
-
-        try:
-            while True:
-                # The OSV.dev API is sometimes quite slow, hence the generous timeout
-                request = requests.post(_OSV_DEV_QUERY_URL, json=query, timeout=10)
-                request.raise_for_status()
-                response = request.json()
-
-                if (response_vulns := response.get("vulns")):
-                    vulns.extend(response_vulns)
-
-                query["page_token"] = response.get("next_page_token")
-
-                if not query["page_token"]:
-                    break
-
-            if not vulns:
-                return []
-
-            osvs = set(map(OsvAdvisory.from_json, filter(lambda vuln: vuln.get("id"), vulns)))
-            mal_osvs = set(filter(lambda osv: osv.id.startswith("MAL"), osvs))
-            non_mal_osvs = osvs - mal_osvs
-
-            return (
-                [(FindingSeverity.CRITICAL, mal_finding(osv)) for osv in sorted(mal_osvs, reverse=True)]
-                + [(FindingSeverity.WARNING, non_mal_finding(osv)) for osv in sorted(non_mal_osvs, reverse=True)]
-            )
-
-        except requests.exceptions.RequestException as e:
-            _log.warning(f"Failed to query OSV.dev API: returning WARNING finding for target {target}")
-            return [(FindingSeverity.WARNING, error_message(str(e)))]
-
-
-def load_verifier() -> InstallTargetVerifier:
-    """
-    Export `OsvVerifier` for discovery by the firewall.
-
-    Returns:
-        An `OsvVerifier` for use in a run of the supply chain firewall.
-    """
-    return OsvVerifier()

--- a/scfw/verifiers/osv_verifier/osv_advisory.py
+++ b/scfw/verifiers/osv_verifier/osv_advisory.py
@@ -160,7 +160,8 @@ class OsvAdvisory:
     id: str
     severity: Optional[Severity]
 
-    def __lt__(self, other: "OsvAdvisory") -> bool:
+    @classmethod
+    def compare_severities(cls, lhs: "OsvAdvisory", rhs: "OsvAdvisory") -> int:
         """
         Compare two `OsvAdvisory` instances on the basis of their severities such that
         advisories with no severities are sorted lower than those with severities.
@@ -170,21 +171,28 @@ class OsvAdvisory:
             other: The `OsvAdvisory` to be compared on the right-hand side
 
         Returns:
-            A `bool` indicating whether `<` holds between the two given `OsvAdvisory`.
+            An `int` indicating whether the first `OsvAdvisory` is less than, equal to
+            or greater than the second one.
 
         Raises:
-            TypeError: The other argument given was not an `OsvAdvisory`.
+            TypeError: One of the given arguments is not an `OsvAdvisory`.
         """
-        if self.__class__ is not other.__class__:
-            raise TypeError(
-                f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
-            )
+        if not (isinstance(lhs, cls) and isinstance(rhs, cls)):
+            raise TypeError("Received incompatible argument types while comparing OSV severities")
 
         # A match statement would be more natural here but mypy is not up to it
-        return (
-            (self.severity is None and other.severity is not None)
-            or (self.severity is not None and other.severity is not None and self.severity < other.severity)
-        )
+        if lhs.severity == rhs.severity:
+            result = 0
+        elif lhs.severity is None:
+            result = -1
+        elif rhs.severity is None:
+            result = 1
+        elif lhs.severity < rhs.severity:
+            result = -1
+        elif rhs.severity < lhs.severity:
+            result = 1
+
+        return result
 
     @classmethod
     def from_json(cls, osv_json: dict) -> "OsvAdvisory":


### PR DESCRIPTION
This PR enhances the `OsvVerifier` so that its findings are ranked by severity:

```bash
$ scfw run pip install jinja2==3.1.4
Installation target Jinja2-3.1.4:
  - An OSV.dev disclosure exists for package Jinja2-3.1.4:
      * [High] https://osv.dev/vulnerability/GHSA-gmj6-6f8f-6699
  - An OSV.dev disclosure exists for package Jinja2-3.1.4:
      * [High] https://osv.dev/vulnerability/GHSA-q2x7-8rv6-6q7h
  - An OSV.dev disclosure exists for package Jinja2-3.1.4:
      * [Medium] https://osv.dev/vulnerability/GHSA-cpwx-vrp4-4pq7
[?] Proceed with installation? (y/N):
The installation request was aborted. No changes have been made.
```

Each OSV advisory optionally has a `severities` attribute containing a list of (usually CVSS) severity scores.  For each advisory returned for an install target, if this attribute is present, we compute the highest severity among these and sort the findings on this basis.  Findings for which no severity could be computed sort lower than findings with severities.

It should be noted that individual affected ranges are permitted to have their own severity scores by the OSV standard.  In such cases, the global `severities` attribute is not set.  For advisories like this, no severity score is currently assigned to the finding.