### PR TITLE
Bump version number to 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To check whether the installation succeeded, run the following command and verif
 
 ```bash
 $ scfw --version
-1.3.2
+1.3.3
 ```
 
 ### Post-installation steps

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,7 +62,7 @@ coverage==7.8.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883 \
     --hash=sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f \
     --hash=sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f
-exceptiongroup==1.2.2 ; python_version >= "3.10" and python_version < "3.11" \
+exceptiongroup==1.2.2 ; python_version == "3.10" \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
 flake8==7.2.0 ; python_version >= "3.10" and python_version < "4" \
@@ -196,7 +196,7 @@ pygments==2.19.1 ; python_version >= "3.10" and python_version < "4" \
 pytest==8.3.5 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820 \
     --hash=sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845
-tomli==2.2.1 ; python_version >= "3.10" and python_version < "3.11" \
+tomli==2.2.1 ; python_version == "3.10" \
     --hash=sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6 \
     --hash=sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd \
     --hash=sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c \
@@ -229,6 +229,6 @@ tomli==2.2.1 ; python_version >= "3.10" and python_version < "3.11" \
     --hash=sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272 \
     --hash=sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a \
     --hash=sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7
-typing-extensions==4.13.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b \
-    --hash=sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5
+typing-extensions==4.13.1 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69 \
+    --hash=sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,9 +133,9 @@ runs==1.2.2 ; python_version >= "3.10" and python_version < "4" \
 six==1.17.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-typing-extensions==4.13.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b \
-    --hash=sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5
+typing-extensions==4.13.1 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69 \
+    --hash=sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff
 urllib3==2.3.0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
     --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"


### PR DESCRIPTION
This PR bumps the version number in preparation for the latest release.

It also updates all dependencies to their latest compatible versions.