### PR TITLE
[SECRES-3057] Add support for poetry sync

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,7 +97,7 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 - --version ${{ matrix.poetry-version }}
           if [ "${{ matrix.poetry-version }}" = "1.7.0" ] || [ "${{ matrix.poetry-version }}" = "1.8.0" ]; then
             # Known issue with virtualenv 20.31.x breaking these Poetry versions
-            $POETRY_HOME/bin/python -m pip install virtualenv==20.30.0
+            $POETRY_HOME/venv/bin/python -m pip install virtualenv==20.30.0
           fi
           export PATH="$POETRY_HOME/bin:$PATH"
       - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,8 +92,14 @@ jobs:
           python-version: "3.10"
       - name: Install Poetry
         run: |
+          export POETRY_HOME="$HOME/.poetry"
+          mkdir $POETRY_HOME
           curl -sSL https://install.python-poetry.org | python3 - --version ${{ matrix.poetry-version }}
-          export PATH="$HOME/.local/bin:$PATH"
+          if [ "${{ matrix.poetry-version }}" = "1.7.0" ] || [ "${{ matrix.poetry-version }}" = "1.8.0" ]; then
+            # Known issue with virtualenv 20.31.x breaking these Poetry versions
+            $POETRY_HOME/bin/python -m pip install virtualenv==20.30.0
+          fi
+          export PATH="$POETRY_HOME/bin:$PATH"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           export POETRY_HOME="$HOME/pypoetry"
           mkdir $POETRY_HOME
-          curl -sSL https://install.python-poetry.org | python3 - --version ${{ matrix.poetry-version }}
+          curl -sSL https://install.python-poetry.org | DEB_PYTHON_INSTALL_LAYOUT=deb python3 - --version ${{ matrix.poetry-version }}
           if [ "${{ matrix.poetry-version }}" = "1.7.0" ] || [ "${{ matrix.poetry-version }}" = "1.8.0" ]; then
             # Known issue with virtualenv 20.31.x breaking these Poetry versions
             $POETRY_HOME/venv/bin/python -m pip install virtualenv==20.30.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,14 +92,11 @@ jobs:
           python-version: "3.10"
       - name: Install Poetry
         run: |
-          export POETRY_HOME="$HOME/pypoetry"
-          mkdir $POETRY_HOME
-          curl -sSL https://install.python-poetry.org | DEB_PYTHON_INSTALL_LAYOUT=deb python3 - --version ${{ matrix.poetry-version }}
+          pip install poetry==${{ matrix.poetry-version }}
           if [ "${{ matrix.poetry-version }}" = "1.7.0" ] || [ "${{ matrix.poetry-version }}" = "1.8.0" ]; then
             # Known issue with virtualenv 20.31.x breaking these Poetry versions
-            $POETRY_HOME/venv/bin/python -m pip install virtualenv==20.30.0
+            pip install virtualenv==20.30.0
           fi
-          export PATH="$POETRY_HOME/bin:$PATH"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
           python-version: "3.10"
       - name: Install Poetry
         run: |
-          export POETRY_HOME="$HOME/.poetry"
+          export POETRY_HOME="$HOME/pypoetry"
           mkdir $POETRY_HOME
           curl -sSL https://install.python-poetry.org | python3 - --version ${{ matrix.poetry-version }}
           if [ "${{ matrix.poetry-version }}" = "1.7.0" ] || [ "${{ matrix.poetry-version }}" = "1.8.0" ]; then

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs:
 	pdoc --docformat google ./scfw > /dev/null &
 
 clean:
-	rm -rf .mypy_cache .pytest_cache .coverage*
+	rm -rf .mypy_cache .pytest_cache .coverage* build scfw.egg-info
 	find . -name '__pycache__' -print0 | xargs -0 rm -rf
 
 .PHONY: checks clean coverage install install-dev test

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ scfw configure
 | :---------------: | :-------------------: | :---------------------------: |
 | npm               | >= 7.0                | `install` (including aliases) |
 | pip               | >= 22.2               | `install`                     |
-| poetry            | >= 1.7                | `add`, `install`              |
+| poetry            | >= 1.7                | `add`, `install`, `sync`      |
 
 In keeping with its goal of blocking 100% of known-malicious package installations, `scfw` will refuse to run with an incompatible version of a supported package manager.  Please upgrade to or verify that you are running a compatible version before using this tool.
 

--- a/scfw/commands/poetry_command.py
+++ b/scfw/commands/poetry_command.py
@@ -17,7 +17,7 @@ from scfw.target import InstallTarget
 
 _log = logging.getLogger(__name__)
 
-MIN_POETRY_VERSION = version_parse("1.3.0")
+MIN_POETRY_VERSION = version_parse("1.7.0")
 
 INSPECTED_SUBCOMMANDS = {"add", "install", "sync"}
 

--- a/scfw/commands/poetry_command.py
+++ b/scfw/commands/poetry_command.py
@@ -19,6 +19,8 @@ _log = logging.getLogger(__name__)
 
 MIN_POETRY_VERSION = version_parse("1.3.0")
 
+INSPECTED_SUBCOMMANDS = {"add", "install", "sync"}
+
 
 class PoetryCommand(PackageManagerCommand):
     """
@@ -112,7 +114,7 @@ class PoetryCommand(PackageManagerCommand):
                 return InstallTarget(self.ecosystem(), match.group(2), get_target_version(match.group(3)))
             return None
 
-        if not any(subcommand in self._command for subcommand in {"add", "install"}):
+        if not any(subcommand in self._command for subcommand in INSPECTED_SUBCOMMANDS):
             return []
 
         # The presence of these options prevent the add command from running

--- a/tests/commands/test_poetry.py
+++ b/tests/commands/test_poetry.py
@@ -131,6 +131,16 @@ def test_poetry_version_output():
             ["poetry", "install", "--help"],
             ["poetry", "--dry-run", "install"],
             ["poetry", "install", "--dry-run"],
+            ["poetry", "-V", "sync"],
+            ["poetry", "sync", "-V"],
+            ["poetry", "--version", "sync"],
+            ["poetry", "sync", "--version"],
+            ["poetry", "-h", "sync"],
+            ["poetry", "sync", "-h"],
+            ["poetry", "--help", "sync"],
+            ["poetry", "sync", "--help"],
+            ["poetry", "--dry-run", "sync"],
+            ["poetry", "sync", "--dry-run"],
         ]
 )
 def test_poetry_no_change(new_poetry_project, init_poetry_state, command):
@@ -172,6 +182,18 @@ def test_poetry_no_change(new_poetry_project, init_poetry_state, command):
             ["poetry", "install", "--project"],
             ["poetry", "install", "-C"],
             ["poetry", "install", "--directory"],
+            ["poetry", "sync", "unnecessary_argument"],
+            ["poetry", "sync", "--dry-run", "unnecessary_argument"],
+            ["poetry", "sync", "--nonexistent-option"],
+            ["poetry", "sync", "--without"],
+            ["poetry", "sync", "--with"],
+            ["poetry", "sync", "--only"],
+            ["poetry", "sync", "-E"],
+            ["poetry", "sync", "--extras"],
+            ["poetry", "sync", "-P"],
+            ["poetry", "sync", "--project"],
+            ["poetry", "sync", "-C"],
+            ["poetry", "sync", "--directory"],
         ]
 )
 def test_poetry_error_no_change(new_poetry_project, init_poetry_state, command):
@@ -189,6 +211,7 @@ def test_poetry_error_no_change(new_poetry_project, init_poetry_state, command):
         [
             (["poetry", "add", "--dry-run", TARGET], TARGET, "target_latest"),
             (["poetry", "install", "--dry-run"], TEST_PROJECT_NAME, "0.1.0"),
+            (["poetry", "sync", "--dry-run"], TEST_PROJECT_NAME, "0.1.0"),
         ]
 )
 def test_poetry_dry_run_output_install(new_poetry_project, target_latest, command, target, version):

--- a/tests/commands/test_poetry_command.py
+++ b/tests/commands/test_poetry_command.py
@@ -8,8 +8,9 @@ from scfw.commands.poetry_command import PoetryCommand
 from scfw.ecosystem import ECOSYSTEM
 
 from .test_poetry import (
-    TARGET, TEST_PROJECT_NAME, init_poetry_state, new_poetry_project, poetry_project_target_latest,
-    poetry_project_target_previous, poetry_show, target_latest, target_previous, target_releases
+    POETRY_V2, TARGET, TEST_PROJECT_NAME, init_poetry_state, new_poetry_project,
+    poetry_project_target_latest, poetry_project_target_previous, poetry_show,
+    poetry_version, target_latest, target_previous, target_releases
 )
 
 TARGET_REPO = f"https://github.com/{TARGET}/py-tree-sitter"
@@ -101,11 +102,14 @@ def test_poetry_command_would_install_install(new_poetry_project, init_poetry_st
     assert poetry_show(new_poetry_project) == init_poetry_state
 
 
-def test_poetry_command_would_install_sync(new_poetry_project, init_poetry_state):
+def test_poetry_command_would_install_sync(poetry_version, new_poetry_project, init_poetry_state):
     """
     Tests that `PoetryCommand.would_install()` for a `poetry sync` command
     correctly resolves installation targets without installing anything.
     """
+    if poetry_version < POETRY_V2:
+        return
+
     command = PoetryCommand(["poetry", "sync", "--directory", new_poetry_project])
     targets = command.would_install()
 

--- a/tests/commands/test_poetry_command.py
+++ b/tests/commands/test_poetry_command.py
@@ -2,15 +2,15 @@
 Tests of `PoetryCommand`.
 """
 
-import pytest
-
 from scfw.commands.poetry_command import PoetryCommand
 from scfw.ecosystem import ECOSYSTEM
 from scfw.target import InstallTarget
 
 from .test_poetry import (
     POETRY_V2, TARGET, TARGET_LATEST, TARGET_PREVIOUS, TEST_PROJECT_NAME, new_poetry_project,
-    poetry_project_target_latest, poetry_project_target_previous, poetry_show, poetry_version,
+    poetry_project_target_latest, poetry_project_target_latest_lock_previous,
+    poetry_project_target_previous, poetry_project_target_previous_lock_latest,
+    poetry_show, poetry_version,
 )
 
 TARGET_REPO = f"https://github.com/{TARGET}/py-tree-sitter"
@@ -66,7 +66,12 @@ def test_poetry_command_would_install_add(
         assert poetry_show(poetry_project) == init_state
 
 
-def test_poetry_command_would_install_install(new_poetry_project, poetry_project_target_latest):
+def test_poetry_command_would_install_install(
+    new_poetry_project,
+    poetry_project_target_latest,
+    poetry_project_target_latest_lock_previous,
+    poetry_project_target_previous_lock_latest,
+):
     """
     Tests that `PoetryCommand.would_install()` for a `poetry install` command
     correctly resolves installation targets without installing anything.
@@ -74,6 +79,8 @@ def test_poetry_command_would_install_install(new_poetry_project, poetry_project
     test_cases = [
         (new_poetry_project, [(TEST_PROJECT_NAME, "0.1.0")]),
         (poetry_project_target_latest, [(TEST_PROJECT_NAME, "0.1.0")]),
+        (poetry_project_target_latest_lock_previous, [(TARGET, TARGET_PREVIOUS), (TEST_PROJECT_NAME, "0.1.0")]),
+        (poetry_project_target_previous_lock_latest, [(TARGET, TARGET_LATEST), (TEST_PROJECT_NAME, "0.1.0")]),
     ]
 
     for poetry_project, true_targets in test_cases:
@@ -91,6 +98,8 @@ def test_poetry_command_would_install_sync(
     new_poetry_project,
     poetry_project_target_latest,
     poetry_project_target_previous,
+    poetry_project_target_latest_lock_previous,
+    poetry_project_target_previous_lock_latest,
 ):
     """
     Tests that `PoetryCommand.would_install()` for a `poetry sync` command
@@ -103,6 +112,8 @@ def test_poetry_command_would_install_sync(
         (new_poetry_project, [(TEST_PROJECT_NAME, "0.1.0")]),
         (poetry_project_target_latest, [(TEST_PROJECT_NAME, "0.1.0")]),
         (poetry_project_target_previous, [(TEST_PROJECT_NAME, "0.1.0")]),
+        (poetry_project_target_latest_lock_previous, [(TARGET, TARGET_PREVIOUS), (TEST_PROJECT_NAME, "0.1.0")]),
+        (poetry_project_target_previous_lock_latest, [(TARGET, TARGET_LATEST), (TEST_PROJECT_NAME, "0.1.0")]),
     ]
 
     for poetry_project, true_targets in test_cases:

--- a/tests/commands/test_poetry_command.py
+++ b/tests/commands/test_poetry_command.py
@@ -99,3 +99,20 @@ def test_poetry_command_would_install_install(new_poetry_project, init_poetry_st
         and targets[0].version == "0.1.0"
     )
     assert poetry_show(new_poetry_project) == init_poetry_state
+
+
+def test_poetry_command_would_install_sync(new_poetry_project, init_poetry_state):
+    """
+    Tests that `PoetryCommand.would_install()` for a `poetry sync` command
+    correctly resolves installation targets without installing anything.
+    """
+    command = PoetryCommand(["poetry", "sync", "--directory", new_poetry_project])
+    targets = command.would_install()
+
+    assert (
+        len(targets) == 1
+        and targets[0].ecosystem == ECOSYSTEM.PyPI
+        and targets[0].package == TEST_PROJECT_NAME
+        and targets[0].version == "0.1.0"
+    )
+    assert poetry_show(new_poetry_project) == init_poetry_state


### PR DESCRIPTION
This PR adds support for `poetry sync` as well as related tests.

It also significantly refactors the Poetry tests, as each per-version Poetry test was taking nearly 20 minutes to complete in CI runs.  Use of `pytest.fixture` is reduced, in part by no longer relying on `pytest.mark.parametrize`.

Additional tests for `poetry install` output are also added.