### PR TITLE
[SECRES-3222] [SECRES-3272] Add Datadog logging for local audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To check whether the installation succeeded, run the following command and verif
 
 ```bash
 $ scfw --version
-2.0.0
+2.1.0
 ```
 
 ### Post-installation steps

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,9 +100,9 @@ charset-normalizer==3.4.2 ; python_version >= "3.10" and python_version < "4" \
 cvss==3.4 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:632353244ba3c58b53355466677edc968b9d7143c317b66271f9fd7939951ee8 \
     --hash=sha256:d9950613758e60820f7fac37ca5f35158712f8f2ea4f6629858a60c4984fe4ef
-datadog-api-client==2.36.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:a7535e5c48c7109c564cd77c4a17191f4d80152b6aa59569b96a81c039b37d02 \
-    --hash=sha256:e3d93497c394d03d2c3e75545ae994ca13799e7fc9d1fd1e6a49e32952192d36
+datadog-api-client==2.39.0 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:011633adff7441b76d2f0a69f580760e0c0c0348e2ce74fe7efb5094aab68cf8 \
+    --hash=sha256:581da02d426c001e915a13d317481c819aa9ed61e08132e34376e7b549a15e02
 editor==1.6.6 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:bb6989e872638cd119db9a4fce284cd8e13c553886a1c044c6b8d8a160c871f8 \
     --hash=sha256:e818e6913f26c2a81eadef503a2741d7cca7f235d20e217274a009ecd5a74abf
@@ -118,9 +118,9 @@ packaging==25.0 ; python_version >= "3.10" and python_version < "4" \
 python-dateutil==2.9.0.post0 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-python-dotenv==1.1.0 ; python_version >= "3.10" and python_version < "4" \
-    --hash=sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5 \
-    --hash=sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d
+python-dotenv==1.1.1 ; python_version >= "3.10" and python_version < "4" \
+    --hash=sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc \
+    --hash=sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab
 readchar==4.2.1 ; python_version >= "3.10" and python_version < "4" \
     --hash=sha256:91ce3faf07688de14d800592951e5575e9c7a3213738ed01d394dcc949b79adb \
     --hash=sha256:a769305cd3994bb5fa2764aa4073452dc105a4ec39068ffe6efd3c20c60acc77

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -36,7 +36,12 @@ def run_audit(args: Namespace) -> int:
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
             reports = verifiers.verify_packages(packages)
-            FirewallLoggers().log_audit(package_manager.ecosystem(), package_manager.executable(), reports)
+            FirewallLoggers().log_audit(
+                package_manager.ecosystem(),
+                package_manager.name(),
+                package_manager.executable(),
+                reports
+            )
 
             for severity in FindingSeverity:
                 if (severity_report := reports.get(severity)):

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -5,6 +5,7 @@ Implements Supply-Chain Firewall's `audit` subcommand.
 from argparse import Namespace
 import logging
 
+from scfw.loggers import FirewallLoggers
 import scfw.package_managers as package_managers
 from scfw.report import VerificationReport
 from scfw.verifier import FindingSeverity
@@ -35,6 +36,7 @@ def run_audit(args: Namespace) -> int:
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
             reports = verifiers.verify_packages(packages)
+            FirewallLoggers().log_audit(package_manager.ecosystem(), package_manager.executable(), reports)
 
             for severity in FindingSeverity:
                 if (severity_report := reports.get(severity)):

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -48,7 +48,7 @@ def run_firewall(args: Namespace) -> int:
             reports = verifiers.verify_packages(targets)
 
             if (critical_report := reports.get(FindingSeverity.CRITICAL)):
-                loggers.log(
+                loggers.log_firewall_action(
                     package_manager.ecosystem(),
                     package_manager.executable(),
                     args.command,
@@ -65,7 +65,7 @@ def run_firewall(args: Namespace) -> int:
                 warned = True
 
                 if not args.dry_run and not inquirer.confirm("Proceed with installation?", default=False):
-                    loggers.log(
+                    loggers.log_firewall_action(
                         package_manager.ecosystem(),
                         package_manager.executable(),
                         args.command,
@@ -80,7 +80,7 @@ def run_firewall(args: Namespace) -> int:
             _log.info("Firewall dry-run mode enabled: command will not be run")
             print("Dry-run: exiting without running command.")
         else:
-            loggers.log(
+            loggers.log_firewall_action(
                 package_manager.ecosystem(),
                 package_manager.executable(),
                 args.command,

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -50,6 +50,7 @@ def run_firewall(args: Namespace) -> int:
             if (critical_report := reports.get(FindingSeverity.CRITICAL)):
                 loggers.log_firewall_action(
                     package_manager.ecosystem(),
+                    package_manager.name(),
                     package_manager.executable(),
                     args.command,
                     list(critical_report.packages()),
@@ -67,6 +68,7 @@ def run_firewall(args: Namespace) -> int:
                 if not args.dry_run and not inquirer.confirm("Proceed with installation?", default=False):
                     loggers.log_firewall_action(
                         package_manager.ecosystem(),
+                        package_manager.name(),
                         package_manager.executable(),
                         args.command,
                         list(warning_report.packages()),
@@ -82,6 +84,7 @@ def run_firewall(args: Namespace) -> int:
         else:
             loggers.log_firewall_action(
                 package_manager.ecosystem(),
+                package_manager.name(),
                 package_manager.executable(),
                 args.command,
                 targets,

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -118,6 +118,17 @@ class FirewallLogger(metaclass=ABCMeta):
         reports: dict[FindingSeverity, VerificationReport],
     ):
         """
-        Lorem ipsum dolor sit amet.
+        Log the results of an audit for the given ecosystem and package manager.
+
+        Args:
+            ecosystem: The ecosystem of the audited packages.
+            package_manager: The package manager that manages the audited packages.
+            executable: The package manager executable used to enumerate audited packages.
+            reports:
+                The severity-ranked reports resulting from auditing the installed packages.
+
+                These reports contain only those packages for which at least one verifier had
+                a finding (at the severity level associated with the entire report).  That is,
+                packages with no findings are not included in the audit results.
         """
         pass

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -129,6 +129,6 @@ class FirewallLogger(metaclass=ABCMeta):
 
                 These reports contain only those packages for which at least one verifier had
                 a finding (at the severity level associated with the entire report).  That is,
-                packages with no findings are not included in the audit results.
+                packages with no findings are excluded from the audit results.
         """
         pass

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -71,11 +71,11 @@ class FirewallAction(Enum):
 
 class FirewallLogger(metaclass=ABCMeta):
     """
-    An interface for passing information about a completed firewall run to
+    An interface for passing information about runs of Supply-Chain Firewall to
     client loggers.
     """
     @abstractmethod
-    def log(
+    def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
         executable: str,
@@ -85,7 +85,7 @@ class FirewallLogger(metaclass=ABCMeta):
         warned: bool
     ):
         """
-        Pass data from a completed run of the firewall to a logger.
+        Log the data and action taken in a completed run of Supply-Chain Firewall.
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -111,6 +111,7 @@ class FirewallLogger(metaclass=ABCMeta):
     def log_audit(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         reports: dict[FindingSeverity, VerificationReport],
     ):

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -80,6 +80,7 @@ class FirewallLogger(metaclass=ABCMeta):
     def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         command: list[str],
         targets: list[Package],
@@ -91,6 +92,7 @@ class FirewallLogger(metaclass=ABCMeta):
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.
+            package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
             command: The package manager command line provided to the firewall.
             targets:

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -9,6 +9,8 @@ from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
+from scfw.report import VerificationReport
+from scfw.verifier import FindingSeverity
 
 
 class FirewallAction(Enum):
@@ -102,5 +104,17 @@ class FirewallLogger(metaclass=ABCMeta):
             warned:
                 Indicates whether the user was warned about findings for any installation
                 targets and prompted for approval to proceed with `command`.
+        """
+        pass
+
+    @abstractmethod
+    def log_audit(
+        self,
+        ecosystem: ECOSYSTEM,
+        executable: str,
+        reports: dict[FindingSeverity, VerificationReport],
+    ):
+        """
+        Lorem ipsum dolor sit amet.
         """
         pass

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -79,7 +79,7 @@ class FirewallLoggers(FirewallLogger):
         reports: dict[FindingSeverity, VerificationReport]
     ):
         """
-        Lorem ipsum dolor sit amet.
+        Log the results of an audit to all client loggers.
         """
         for logger in self._loggers:
             logger.log_audit(ecosystem, package_manager, executable, reports)

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -57,6 +57,7 @@ class FirewallLoggers(FirewallLogger):
     def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         command: list[str],
         targets: list[Package],
@@ -68,7 +69,7 @@ class FirewallLoggers(FirewallLogger):
         all client loggers.
         """
         for logger in self._loggers:
-            logger.log_firewall_action(ecosystem, executable, command, targets, action, warned)
+            logger.log_firewall_action(ecosystem, package_manager, executable, command, targets, action, warned)
 
     def log_audit(
         self,

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -52,7 +52,7 @@ class FirewallLoggers(FirewallLogger):
             except AttributeError:
                 _log.info(f"Module {module} does not export a logger")
 
-    def log(
+    def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
         executable: str,
@@ -62,7 +62,8 @@ class FirewallLoggers(FirewallLogger):
         warned: bool
     ):
         """
-        Log a completed run of the supply-chain firewall to all discovered loggers.
+        Log the data and action taken in a completed run of Supply-Chain Firewall to
+        all client loggers.
         """
         for logger in self._loggers:
             logger.log(ecosystem, executable, command, targets, action, warned)

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -73,6 +73,7 @@ class FirewallLoggers(FirewallLogger):
     def log_audit(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         reports: dict[FindingSeverity, VerificationReport]
     ):
@@ -80,4 +81,4 @@ class FirewallLoggers(FirewallLogger):
         Lorem ipsum dolor sit amet.
         """
         for logger in self._loggers:
-            logger.log_audit(ecosystem, executable, reports)
+            logger.log_audit(ecosystem, package_manager, executable, reports)

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -29,6 +29,8 @@ import pkgutil
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.package import Package
+from scfw.report import VerificationReport
+from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
@@ -66,4 +68,16 @@ class FirewallLoggers(FirewallLogger):
         all client loggers.
         """
         for logger in self._loggers:
-            logger.log(ecosystem, executable, command, targets, action, warned)
+            logger.log_firewall_action(ecosystem, executable, command, targets, action, warned)
+
+    def log_audit(
+        self,
+        ecosystem: ECOSYSTEM,
+        executable: str,
+        reports: dict[FindingSeverity, VerificationReport]
+    ):
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        for logger in self._loggers:
+            logger.log_audit(ecosystem, executable, reports)

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -142,9 +142,14 @@ class DDLogger(FirewallLogger):
         reports: dict[FindingSeverity, VerificationReport]
     ):
         """
-        Lorem ipsum dolor sit amet.
+        Log the results of an audit for the given ecosystem and package manager.
+
+        Args:
+            ecosystem: The ecosystem of the audited packages.
+            package_manager: The package manager that manages the audited packages.
+            executable: The package manager executable used to enumerate audited packages.
+            reports: The severity-ranked reports resulting from auditing the installed packages.
         """
-        # TODO(ikretz): Add some log level check
         self._logger.info(
             f"Successfully audited {ecosystem} packages managed by {package_manager}",
             extra={

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -23,8 +23,24 @@ _log = logging.getLogger(__name__)
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
 
 # The `created` and `msg` attributes are provided by `logging.LogRecord`
-_AUDIT_ATTRIBUTES = {"created", "ecosystem", "executable", "msg", "package_manager", "reports"}
-_FIREWALL_ACTION_ATTRIBUTES = {"action", "created", "ecosystem", "executable", "msg", "targets", "warned"}
+_AUDIT_ATTRIBUTES = {
+    "created",
+    "ecosystem",
+    "executable",
+    "msg",
+    "package_manager",
+    "reports"
+}
+_FIREWALL_ACTION_ATTRIBUTES = {
+    "action",
+    "created",
+    "ecosystem",
+    "executable",
+    "msg",
+    "package_manager",
+    "targets",
+    "warned"
+}
 
 
 dotenv.load_dotenv()
@@ -84,6 +100,7 @@ class DDLogger(FirewallLogger):
     def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         command: list[str],
         targets: list[Package],
@@ -95,6 +112,7 @@ class DDLogger(FirewallLogger):
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.
+            package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
             command: The package manager command line provided to the firewall.
             targets: The installation targets relevant to firewall's action.
@@ -108,6 +126,7 @@ class DDLogger(FirewallLogger):
             f"Command '{' '.join(command)}' was {str(action).lower()}ed",
             extra={
                 "ecosystem": str(ecosystem),
+                "package_manager": package_manager,
                 "executable": executable,
                 "targets": list(map(str, targets)),
                 "action": str(action),

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -15,6 +15,8 @@ from scfw.configure import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.package import Package
+from scfw.report import VerificationReport
+from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
@@ -108,3 +110,14 @@ class DDLogger(FirewallLogger):
                 "warned": warned,
             }
         )
+
+    def log_audit(
+        self,
+        ecosystem: ECOSYSTEM,
+        executable: str,
+        reports: dict[FindingSeverity, VerificationReport]
+    ):
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        pass

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -75,7 +75,7 @@ class DDLogger(FirewallLogger):
         except ValueError:
             _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
 
-    def log(
+    def log_firewall_action(
         self,
         ecosystem: ECOSYSTEM,
         executable: str,
@@ -85,7 +85,7 @@ class DDLogger(FirewallLogger):
         warned: bool
     ):
         """
-        Receive and log data about a completed firewall run.
+        Log the data and action taken in a completed run of Supply-Chain Firewall.
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -23,7 +23,7 @@ _log = logging.getLogger(__name__)
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
 
 # The `created` and `msg` attributes are provided by `logging.LogRecord`
-_AUDIT_ATTRIBUTES = {"created", "ecosystem", "executable", "reports"}
+_AUDIT_ATTRIBUTES = {"created", "ecosystem", "executable", "msg", "package_manager", "reports"}
 _FIREWALL_ACTION_ATTRIBUTES = {"action", "created", "ecosystem", "executable", "msg", "targets", "warned"}
 
 
@@ -118,6 +118,7 @@ class DDLogger(FirewallLogger):
     def log_audit(
         self,
         ecosystem: ECOSYSTEM,
+        package_manager: str,
         executable: str,
         reports: dict[FindingSeverity, VerificationReport]
     ):
@@ -126,9 +127,10 @@ class DDLogger(FirewallLogger):
         """
         # TODO(ikretz): Add some log level check
         self._logger.info(
-            None,
+            f"Successfully audited {ecosystem} packages managed by {package_manager}",
             extra={
                 "ecosystem": str(ecosystem),
+                "package_manager": package_manager,
                 "executable": executable,
                 "reports": {
                     str(severity): list(map(str, report.packages())) for severity, report in reports.items()

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -22,6 +22,15 @@ class FindingSeverity(Enum):
     CRITICAL = "CRITICAL"
     WARNING = "WARNING"
 
+    def __str__(self) -> str:
+        """
+        Format a `FindingSeverity` for printing.
+
+        Returns:
+            A `str` representing the given `FindingSeverity` suitable for printing.
+        """
+        return self.name
+
 
 class PackageVerifier(metaclass=ABCMeta):
     """

--- a/scfw/verifiers/dd_verifier/dataset.py
+++ b/scfw/verifiers/dd_verifier/dataset.py
@@ -63,7 +63,7 @@ def get_latest_manifest(cache_dir: Path, ecosystem: ECOSYSTEM) -> Manifest:
         else:
             latest_etag, latest_manifest = download_manifest(ecosystem)
 
-    except requests.HTTPError:
+    except Exception:
         _log.warning(f"Failed to obtain malicious {ecosystem} packages metadata or dataset from GitHub")
 
         if cached_manifest_file:

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -1,14 +1,20 @@
 """
-Tests of `DatadogMaliciousPackagesVerifier.
+Tests of `DatadogMaliciousPackagesVerifier`.
 """
 
+import glob
+import json
+from pathlib import Path
 import pytest
+from tempfile import TemporaryDirectory
 
+from scfw.configure import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 from scfw.verifiers.dd_verifier import DatadogMaliciousPackagesVerifier
+import scfw.verifiers.dd_verifier.dataset as dataset
 
 # Create a single Datadog malicious packages verifier to use for testing
 DD_VERIFIER = DatadogMaliciousPackagesVerifier()
@@ -39,3 +45,107 @@ def test_dd_verifier_malicious(ecosystem: ECOSYSTEM):
 
     for package in test_set:
         assert critical_report.get(package)
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_update_manifest_no_change(ecosystem: ECOSYSTEM):
+    """
+    Test that no update occurs when we attempt to update the manifest file using
+    the current ETag.
+    """
+    last_etag, _ = dataset.download_manifest(ecosystem)
+    latest_etag, latest_manifest = dataset._update_manifest(ecosystem, last_etag)
+
+    assert latest_etag is not None and latest_etag == last_etag
+    assert latest_manifest is None
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_update_manifest_change(ecosystem: ECOSYSTEM):
+    """
+    Tests that an update occurs with the latest ETag and manifest when we perform
+    a manifest update operation using an outdated ETag value.
+    """
+    last_etag, last_manifest = dataset.download_manifest(ecosystem)
+    latest_etag, latest_manifest = dataset._update_manifest(ecosystem, "foo")
+
+    assert latest_etag is not None and latest_etag == last_etag
+    assert latest_manifest is not None and latest_manifest == last_manifest
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_get_latest_manifest_no_cache(ecosystem: ECOSYSTEM):
+    """
+    Test that dataset caching occurs when caching is enabled but the directories
+    or cache files do not yet exist.
+    """
+    with TemporaryDirectory() as tmp:
+        cache_dir = Path(tmp)
+        latest_etag, latest_manifest = dataset.download_manifest(ecosystem)
+
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}*.json"))) == 0
+
+        test_manifest = dataset.get_latest_manifest(cache_dir, ecosystem)
+
+        assert  test_manifest == latest_manifest
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}{latest_etag}.json"))) == 1
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_get_latest_manifest_cache_no_update(ecosystem: ECOSYSTEM):
+    """
+    Tests that no change in the cache filename or contents occurs when the cached
+    manifest file is already up to date with the remote copy.
+    """
+    with TemporaryDirectory() as tmp:
+        cache_dir = Path(tmp)
+
+        latest_etag, latest_manifest = dataset.download_manifest(ecosystem)
+        with open(cache_dir / f"{ecosystem}{latest_etag}.json", 'w') as f:
+            json.dump(latest_manifest, f)
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}{latest_etag}.json"))) == 1
+
+        test_manifest = dataset.get_latest_manifest(cache_dir, ecosystem)
+
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}{latest_etag}.json"))) == 1
+        with open(cache_dir / f"{ecosystem}{latest_etag}.json") as f:
+            assert json.load(f) == test_manifest
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_get_latest_manifest_cache_update_invalid_etag(ecosystem: ECOSYSTEM):
+    """
+    Tests the cached manifest file is updated when the ETag portion of the
+    file name is invalid (including outdated) with respect to the current one.
+    """
+    with TemporaryDirectory() as tmp:
+        cache_dir = Path(tmp)
+
+        with open(cache_dir / f"{ecosystem}foo.json", 'w') as f:
+            json.dump({}, f)
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}*.json"))) == 1
+
+        dataset.get_latest_manifest(cache_dir, ecosystem)
+
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}*.json"))) == 1
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}foo.json"))) == 0
+
+
+@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
+def test_get_latest_manifest_cache_update_no_etag(ecosystem: ECOSYSTEM):
+    """
+     Tests the cached manifest file is updated when the file name is missing
+     the ETag portion, showing that the caching logic is capable of tolerating
+     and indeed repairing a missing ETag.
+    """
+    with TemporaryDirectory() as tmp:
+        cache_dir = Path(tmp)
+
+        with open(cache_dir / f"{ecosystem}.json", 'w') as f:
+            json.dump({}, f)
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}*.json"))) == 1
+
+        dataset.get_latest_manifest(cache_dir, ecosystem)
+
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}*.json"))) == 1
+        assert len(glob.glob(str(cache_dir / f"{ecosystem}.json"))) == 0

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -87,7 +87,7 @@ def test_get_latest_manifest_no_cache(ecosystem: ECOSYSTEM):
 
         test_manifest = dataset.get_latest_manifest(cache_dir, ecosystem)
 
-        assert  test_manifest == latest_manifest
+        assert test_manifest == latest_manifest
         assert len(glob.glob(str(cache_dir / f"{ecosystem}{latest_etag}.json"))) == 1
 
 


### PR DESCRIPTION
This PR adds Datadog logging for the `scfw audit` command.

Unlike package manager operations, which occur in the course of normal development workflows, an audit is a special-purpose operation, one that the user can only trigger by invoking `scfw` directly (as opposed to indirectly via shell aliases) and usually occurring in an incident response-like context.  As such, we consider that there is always in interest in logging the results of an audit, and so **the configured `SCFW_LOG_LEVEL` settings are ignored when it comes to logging audits**.  More precisely, we consider that these settings pertain only to the firewall operations of inspecting package manager commands.

Other changes include:
* Log the command-line name of the package manager in firewall action logs
* Add unit tests for the malicious packages verifier's caching logic
* Fallback on cached manifests on any error, not just `requests.HTTPError` (not general enough)
* Reduce error message verbosity when the OSV.dev API fails
* Update dependencies to their latest compatible versions
* Version number bump in preparation for next release