### PR TITLE
[SECRES-3298] Allow for automatically allowing or blocking on warning

### DIFF
--- a/scfw/cli.py
+++ b/scfw/cli.py
@@ -131,6 +131,20 @@ def _add_run_cli(parser: ArgumentParser):
         help="Verify any installation targets but do not run the package manager command"
     )
 
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument(
+        "--allow-on-warning",
+        action="store_true",
+        help="Non-interactively allow commands with only warning-level findings"
+    )
+
+    group.add_argument(
+        "--block-on-warning",
+        action="store_true",
+        help="Non-interactively block commands with only warning-level findings"
+    )
+
     parser.add_argument(
         "--error-on-block",
         action="store_true",

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -65,7 +65,11 @@ def run_firewall(args: Namespace) -> int:
                 print(warning_report)
                 warned = True
 
-                if not args.dry_run and not inquirer.confirm("Proceed with installation?", default=False):
+                if (
+                    not args.dry_run
+                    and not args.allow_on_warning
+                    and (args.block_on_warning or not inquirer.confirm("Proceed with installation?", default=False))
+                ):
                     loggers.log_firewall_action(
                         package_manager.ecosystem(),
                         package_manager.name(),


### PR DESCRIPTION
This PR adds two new options, `--allow-on-warning` and `--block-on-warning` to allow the user to non-interactively decide how to handle a command with only warning-level findings.  This is in an effort to make it easier to write scripts using SCFW.

```bash
$ scfw run --help
usage: scfw run [options] COMMAND

Run a package manager command through Supply-Chain Firewall.

options:
  -h, --help          show this help message and exit
  --dry-run           Verify any installation targets but do not run the package manager command
  --allow-on-warning  Non-interactively allow commands with only warning-level findings
  --block-on-warning  Non-interactively block commands with only warning-level findings
  --error-on-block    Treat blocked commands as errors (useful for scripting)
  --executable PATH   Package manager executable to use for running commands (default: environmentally determined)
```