### PR TITLE
[SECRES-3537] Account for verbose option in pip commands

### DIFF
--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -135,7 +135,7 @@ class Pip(PackageManager):
         # Otherwise, this is probably a live `pip install` command
         # To be certain, we would need to write a full parser for pip
         try:
-            dry_run_command = command + ["--dry-run", "--quiet", "--report", "-"]
+            dry_run_command = command + ["--dry-run", "-qqqqq", "--report", "-"]
             dry_run = subprocess.run(dry_run_command, check=True, text=True, capture_output=True)
             install_reports = json.loads(dry_run.stdout).get("install", [])
             return list(map(report_to_install_target, install_reports))

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -41,7 +41,15 @@ def test_executable():
             (["pip", "install" "--dry-run", TEST_TARGET], False),
             (["pip", "--dry-run", "install", TEST_TARGET], False),
             (["pip", "install", "--report", "report.json", TEST_TARGET], True),
-            (["pip", "install", "--non-existent-option", TEST_TARGET], False)
+            (["pip", "install", "--non-existent-option", TEST_TARGET], False),
+            (["pip", "install", "-v", TEST_TARGET], True),
+            (["pip", "install", "-vv", TEST_TARGET], True),
+            (["pip", "install", "-vvv", TEST_TARGET], True),
+            (["pip", "install", "-vvvv", TEST_TARGET], True),
+            (["pip", "install", "--verbose", TEST_TARGET], True),
+            (["pip", "install", "--verbose", "--verbose", TEST_TARGET], True),
+            (["pip", "install", "--verbose", "--verbose", "--verbose", TEST_TARGET], True),
+            (["pip", "install", "--verbose", "--verbose", "--verbose", "--verbose", TEST_TARGET], True),
         ]
 )
 def test_pip_command_resolve_install_targets(command_line: list[str], has_targets: bool):


### PR DESCRIPTION
This PR fixes a bug in which `pip` commands with the `-v/--verbose` option included were causing SCFW's internal interactions with pip to fail (specifically the JSON parsing step).  We fix this by adding a bunch of `-q` (quiet) options to counter any `-v` present in the given command.

New tests have been added to confirm that the fix works across all supported pip versions.