### PR TITLE
[SECRES-3536] Make dry-run exit code reflect findings status

### DIFF
--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -44,8 +44,10 @@ def run_firewall(args: Namespace) -> int:
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
             reports = verifiers.verify_packages(targets)
+            critical_report = reports.get(FindingSeverity.CRITICAL)
+            warning_report = reports.get(FindingSeverity.WARNING)
 
-            if (critical_report := reports.get(FindingSeverity.CRITICAL)) and not args.dry_run:
+            if not args.dry_run and critical_report:
                 loggers.log_firewall_action(
                     package_manager.ecosystem(),
                     package_manager.name(),
@@ -59,7 +61,7 @@ def run_firewall(args: Namespace) -> int:
                 print("\nThe installation request was blocked. No changes have been made.")
                 return 1 if args.error_on_block else 0
 
-            if (warning_report := reports.get(FindingSeverity.WARNING)) and not args.dry_run:
+            if not args.dry_run and warning_report:
                 print(warning_report)
                 if (
                     not args.allow_on_warning


### PR DESCRIPTION
This PR makes it so SCFW's exit code when the `--dry-run` option is given reflects whether or not there were findings of any severity, with 0 indicating no findings.  Previously, the exit code for dry-runs was always 0.

This PR also fixes a bug with respect to `--dry-run` and `CRITICAL` findings: if `--dry-run` is given, SCFW no longer sends a `BLOCK` log, as it was previously doing.  The new behavior is correct because dry-runs are not `BLOCK` actions.

In order to achieve these two goals, the PR refactors `run_firewall()` slightly so that it no longer uses a separate boolean variable to track whether it warned the user.

Closes #139 