### PR TITLE
[SECRES-3533] Modify .rc files in-place

### DIFF
--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -42,8 +42,9 @@ def _update_config_file(config_file: Path, answers: dict):
         return f"{_BLOCK_START}{config}\n{_BLOCK_END}"
 
     def overwrite_file(f, contents: str):
-        f.truncate(0)
+        f.seek(0)
         f.write(contents)
+        f.truncate()
 
     config = _format_answers(answers)
 


### PR DESCRIPTION
This PR changes the behavior of SCFW to modify `.bashrc` and `.zshrc` files in-place during configuration instead of writing the changes to a new file and moving the new file into the old one.