### PR TITLE
[SECRES-3533] Update .rc files in-place while configuring

### DIFF
--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -61,10 +61,10 @@ def run_configure(args: Namespace) -> int:
     if not answers:
         return 0
 
+    env.update_config_files(answers)
+
     if (port := answers.get("dd_agent_port")):
         dd_agent.configure_agent_logging(port)
-
-    env.update_config_files(answers)
 
     if is_interactive:
         print(interactive.get_farewell(answers))

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -38,14 +38,10 @@ def _update_config_file(config_file: Path, answers: dict):
     scfw_config = _format_answers(answers)
     scfw_block = f"{_BLOCK_START}{scfw_config}\n{_BLOCK_END}" if scfw_config else ""
 
-    pattern = f"{_BLOCK_START}(.*?){_BLOCK_END}"
-    if not scfw_config:
-        pattern = f"\n{pattern}\n"
-
     with open(config_file) as f:
         original_config = f.read()
 
-    updated_config = re.sub(pattern, scfw_block, original_config, flags=re.DOTALL)
+    updated_config = re.sub(f"{_BLOCK_START}(.*?){_BLOCK_END}", scfw_block, original_config, flags=re.DOTALL)
     if updated_config == original_config and scfw_config not in original_config:
         updated_config = f"{original_config}\n{scfw_block}\n"
 

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -4,8 +4,6 @@ Provides utilities for configuring the environment (via `.rc` files) for using S
 
 from pathlib import Path
 import re
-import os
-import tempfile
 
 from scfw.configure.constants import DD_AGENT_PORT_VAR, DD_API_KEY_VAR, DD_LOG_LEVEL_VAR, SCFW_HOME_VAR
 
@@ -38,19 +36,16 @@ def _update_config_file(config_file: Path, answers: dict):
     scfw_config = _format_answers(answers)
     scfw_block = f"{_BLOCK_START}{scfw_config}\n{_BLOCK_END}" if scfw_config else ""
 
-    with open(config_file) as f:
+    with open(config_file, "r+") as f:
         original_config = f.read()
 
-    updated_config = re.sub(f"{_BLOCK_START}(.*?){_BLOCK_END}", scfw_block, original_config, flags=re.DOTALL)
-    if updated_config == original_config and scfw_config not in original_config:
-        updated_config = f"{original_config}\n{scfw_block}\n"
+        updated_config = re.sub(f"{_BLOCK_START}(.*?){_BLOCK_END}", scfw_block, original_config, flags=re.DOTALL)
+        if updated_config == original_config and scfw_config not in original_config:
+            updated_config = f"{original_config}\n{scfw_block}\n"
 
-    temp_fd, temp_file = tempfile.mkstemp(text=True)
-    temp_handle = os.fdopen(temp_fd, 'w')
-    temp_handle.write(updated_config)
-    temp_handle.close()
-
-    os.rename(temp_file, config_file)
+        f.seek(0)
+        f.write(updated_config)
+        f.truncate()
 
 
 def _format_answers(answers: dict) -> str:

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -35,25 +35,23 @@ def _update_config_file(config_file: Path, answers: dict):
         config_file: A `Path` to the configuration file to update.
         answers: The `dict` of configuration options to write.
     """
-    def enclose(config: str) -> str:
-        return f"{_BLOCK_START}{config}\n{_BLOCK_END}"
-
-    with open(config_file) as f:
-        contents = f.read()
-
-    config = _format_answers(answers)
+    scfw_config = _format_answers(answers)
+    scfw_block = f"{_BLOCK_START}{scfw_config}\n{_BLOCK_END}" if scfw_config else ""
 
     pattern = f"{_BLOCK_START}(.*?){_BLOCK_END}"
-    if not config:
+    if not scfw_config:
         pattern = f"\n{pattern}\n"
 
-    updated = re.sub(pattern, enclose(config) if config else '', contents, flags=re.DOTALL)
-    if updated == contents and config not in contents:
-        updated = f"{contents}\n{enclose(config)}\n"
+    with open(config_file) as f:
+        original_config = f.read()
+
+    updated_config = re.sub(pattern, scfw_block, original_config, flags=re.DOTALL)
+    if updated_config == original_config and scfw_config not in original_config:
+        updated_config = f"{original_config}\n{scfw_block}\n"
 
     temp_fd, temp_file = tempfile.mkstemp(text=True)
     temp_handle = os.fdopen(temp_fd, 'w')
-    temp_handle.write(updated)
+    temp_handle.write(updated_config)
     temp_handle.close()
 
     os.rename(temp_file, config_file)


### PR DESCRIPTION
This PR changes the behavior of SCFW while adding configuration to the user's `.bashrc` and `.zshrc` files to edit these in-place.

Previously, SCFW made the updates in a copy of these files and moved the updated files into the existing ones, which caused issues with symlinked files and, on Linux, with file permissions.