### PR TITLE
Handle missing Datadog agent when removing config

### DIFF
--- a/scfw/configure/dd_agent.py
+++ b/scfw/configure/dd_agent.py
@@ -53,7 +53,11 @@ def remove_agent_logging():
     Raises:
         RuntimeError: An error occurred while attempting to remove the configuration directory.
     """
-    scfw_config_dir = _dd_agent_scfw_config_dir()
+    try:
+        scfw_config_dir = _dd_agent_scfw_config_dir()
+    except FileNotFoundError:
+        _log.info("Datadog Agent binary is not available; no configuration to remove")
+        return
 
     if not scfw_config_dir.is_dir():
         _log.info("No Datadog Agent configuration directory to remove")


### PR DESCRIPTION
scfw configure --remove would crash with FileNotFoundError when run on hosts without the `datadog-agent` binary. Catch the missing-binary case and skip the Datadog cleanup so we still remove the shell configuration while logging that there's nothing to do.