### PR TITLE
[SECRES-4141] Bump version number for v2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To check whether the installation succeeded, run the following command and verif
 
 ```bash
 $ scfw --version
-2.4.0
+2.5.0
 ```
 
 ### Post-installation steps

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -2,4 +2,4 @@
 A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"


### PR DESCRIPTION
This PR bumps SCFW's version number for the upcoming release of v2.5.0.