### PR TITLE
chore: disable automated dependency updater config [incident-51602]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"

--- a/.github/dependabot.yml.disabled
+++ b/.github/dependabot.yml.disabled
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
As part of #incident-51602, we are temporarily disabling all automated dependency updaters to reduce exposure to potential zero-day vulnerabilities in recent releases.

This PR disables the Dependabot/Renovate configuration not managed by ADMS by commenting out (YAML) or renaming (JSON) the config file. Please do not re-enable until further notice.