### PR TITLE
[SECRES-4876] Add optional package artifact source attribute

### DIFF
--- a/scfw/package.py
+++ b/scfw/package.py
@@ -3,8 +3,32 @@ A representation of software packages in supported ecosystems.
 """
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
+
+
+@dataclass(eq=True, frozen=True)
+class LocalPackageSource:
+    """
+    Specifies a local source for a software package.
+
+    Attributes:
+        local_source: A `Path` to the local source for the package.
+    """
+    local_source: Path
+
+
+@dataclass(eq=True, frozen=True)
+class RemotePackageSource:
+    """
+    Specifies a remote source for a software package.
+
+    Attributes:
+        remote_source: A `str` specifying the remote source for the package (e.g., download URL).
+    """
+    remote_source: str
 
 
 @dataclass(eq=True, frozen=True)
@@ -16,10 +40,12 @@ class Package:
         ecosystem: The package's ecosystem.
         name: The package's name.
         version: The package's version string.
+        source: Optional data specifying the package source (local or remote).
     """
     ecosystem: ECOSYSTEM
     name: str
     version: str
+    source: Optional[LocalPackageSource | RemotePackageSource] = None
 
     def __str__(self) -> str:
         """
@@ -36,3 +62,25 @@ class Package:
                 return f"{self.name}@{self.version}"
             case ECOSYSTEM.PyPI:
                 return f"{self.name}-{self.version}"
+
+    def get_local_source(self) -> Optional[LocalPackageSource]:
+        """
+        Return the package's `source` if it is local.
+
+        Returns:
+            The package's `LocalPackageSource` attribute or `None` if the source
+            is undefined or remote.
+        """
+        if isinstance(self.source, LocalPackageSource):
+            return self.source
+
+    def get_remote_source(self) -> Optional[RemotePackageSource]:
+        """
+        Return the package's `source` if it is remote.
+
+        Returns:
+            The package's `RemotePackageSource` attribute or `None` if the source
+            is undefined or remote.
+        """
+        if isinstance(self.source, RemotePackageSource):
+            return self.source

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -74,6 +74,8 @@ class Package:
         if isinstance(self.source, LocalPackageSource):
             return self.source
 
+        return None
+
     def get_remote_source(self) -> Optional[RemotePackageSource]:
         """
         Return the package's `source` if it is remote.
@@ -84,3 +86,5 @@ class Package:
         """
         if isinstance(self.source, RemotePackageSource):
             return self.source
+
+        return None

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -119,7 +119,7 @@ class Pip(PackageManager):
             if not (version := metadata.get("version")):
                 raise ValueError("Missing version for pip installation target")
 
-            if not (download_info := metadata.get("download_info")) or not (url := download_info.get("url")):
+            if not (download_info := install_report.get("download_info")) or not (url := download_info.get("url")):
                 return Package(ECOSYSTEM.PyPI, name, version)
 
             source: Optional[LocalPackageSource | RemotePackageSource] = None

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -5,6 +5,7 @@ Provides a `PackageManager` representation of `pip`.
 import json
 import logging
 import os
+from pathlib import Path
 import shutil
 import subprocess
 from typing import Optional
@@ -12,7 +13,7 @@ from typing import Optional
 from packaging.version import InvalidVersion, Version, parse as version_parse
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package
+from scfw.package import LocalPackageSource, Package, RemotePackageSource
 from scfw.package_manager import PackageManager, UnsupportedVersionError
 
 _log = logging.getLogger(__name__)
@@ -117,7 +118,17 @@ class Pip(PackageManager):
                 raise ValueError("Missing name for pip installation target")
             if not (version := metadata.get("version")):
                 raise ValueError("Missing version for pip installation target")
-            return Package(ECOSYSTEM.PyPI, name, version)
+
+            if not (download_info := metadata.get("download_info")) or not (url := download_info.get("url")):
+                return Package(ECOSYSTEM.PyPI, name, version)
+
+            source: Optional[LocalPackageSource | RemotePackageSource] = None
+            if url.startswith("http"):
+                source = RemotePackageSource(url)
+            if url.startswith("file://"):
+                source = LocalPackageSource(Path(url[len("file://"):]))
+
+            return Package(ECOSYSTEM.PyPI, name, version, source=source)
 
         command = self._normalize_command(command)
 

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -18,6 +18,8 @@ from scfw.package_manager import PackageManager, UnsupportedVersionError
 
 _log = logging.getLogger(__name__)
 
+_LOCAL_PACKAGE_SOURCE_PREFIX = "file://"
+
 MIN_PIP_VERSION = version_parse("22.2")
 
 
@@ -125,8 +127,8 @@ class Pip(PackageManager):
             source: Optional[LocalPackageSource | RemotePackageSource] = None
             if url.startswith("http"):
                 source = RemotePackageSource(url)
-            if url.startswith("file://"):
-                source = LocalPackageSource(Path(url[len("file://"):]))
+            if url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
+                source = LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
 
             return Package(ECOSYSTEM.PyPI, name, version, source=source)
 

--- a/tests/package_managers/pip_fixtures.py
+++ b/tests/package_managers/pip_fixtures.py
@@ -1,0 +1,44 @@
+"""
+Provides a collection of common fixtures for the pip tests.
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+LOCAL_PACKAGE_NAME = "foo"
+LOCAL_PACKAGE_VERSION = "0.1.0"
+
+LOCAL_PACKAGE_SETUP_FILE = f"""\
+from setuptools import setup, find_packages
+
+setup(
+    name='{LOCAL_PACKAGE_NAME}',
+    version='{LOCAL_PACKAGE_VERSION}',
+    packages=find_packages(),
+)
+"""
+
+
+@pytest.fixture
+def local_python_package():
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    # Create a minimally installable local Python package
+    local_package_dir = tempdir_path / LOCAL_PACKAGE_NAME
+    local_package_dir.mkdir()
+
+    source_dir = local_package_dir / LOCAL_PACKAGE_NAME
+    source_dir.mkdir()
+    init_file_path = source_dir / "__init__.py"
+    init_file_path.touch()
+
+    setup_file = local_package_dir / "setup.py"
+    with open(setup_file, 'w') as f:
+        f.write(LOCAL_PACKAGE_SETUP_FILE)
+
+    yield local_package_dir
+
+    tempdir.cleanup()

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -7,9 +7,12 @@ import os
 import subprocess
 import sys
 import tempfile
+from typing import Optional
 
 import packaging.version as version
 import pytest
+
+from .pip_fixtures import *
 
 PIP_COMMAND_PREFIX = [sys.executable, "-m", "pip"]
 
@@ -150,3 +153,66 @@ def test_pip_install_report_override():
         assert report.get("install")
         # Nothing was written to the temporary file
         assert tmpfile.read() == b''
+
+
+def test_pip_install_report_format_local(local_python_package):
+    """
+    Test that the dry-run report has the expected format for a local package target.
+    """
+    _test_pip_install_report_format(
+        str(local_python_package),
+        LOCAL_PACKAGE_NAME,
+        LOCAL_PACKAGE_VERSION,
+        local_python_package
+    )
+
+
+def test_pip_install_report_format_remote():
+    """
+    Test that the dry-run report has the expected format for a remote package target.
+    """
+    package_name = "tree-sitter"
+    package_version = "0.24.0"
+
+    _test_pip_install_report_format(
+        f"{package_name}=={package_version}",
+        package_name,
+        package_version,
+        None,
+    )
+
+
+def _test_pip_install_report_format(
+    target_spec: str,
+    package_name: str,
+    package_version: str,
+    local_package_source: Optional[Path],
+):
+    """
+    Backend function for testing that the dry-run report has the expected format.
+    """
+    command_line = (
+        PIP_COMMAND_PREFIX +
+        ["install", target_spec, "--dry-run", "-qqqqq", "--report", "-"]
+    )
+    p = subprocess.run(command_line, check=True, text=True, capture_output=True)
+    install_reports = json.loads(p.stdout).get("install", [])
+
+    assert len(install_reports) == 1
+    install_report = install_reports[0]
+
+    metadata = install_report.get("metadata")
+    assert metadata
+    name = metadata.get("name")
+    assert name == package_name
+    version = metadata.get("version")
+    assert version == package_version
+
+    download_info = install_report.get("download_info")
+    assert download_info
+    url = download_info.get("url")
+
+    if local_package_source:
+        assert url == f"file://{local_package_source}"
+    else:
+        assert url.startswith("https://files.pythonhosted.org")

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package
+from scfw.package import Package, RemotePackageSource
 from scfw.package_managers.pip import Pip
 
 from .test_pip import INIT_PIP_STATE, TEST_TARGET, pip_list
@@ -73,14 +73,38 @@ def test_pip_command_resolve_install_targets_exact():
     """
     true_targets = list(
         map(
-            lambda p: Package(ECOSYSTEM.PyPI, p[0], p[1]),
+            lambda p: Package(ECOSYSTEM.PyPI, p[0], p[1], RemotePackageSource(p[2])),
             [
-                ("botocore", "1.15.0"),
-                ("docutils", "0.15.2"),
-                ("jmespath", "0.10.0"),
-                ("python-dateutil", "2.9.0.post0"),
-                ("six", "1.17.0"),
-                ("urllib3", "1.25.11")
+                (
+                    "botocore",
+                    "1.15.0",
+                    "https://files.pythonhosted.org/packages/a4/ba/236f25b9200f0cda4842585205b566979484d38927a8a302cc5c1beea10c/botocore-1.15.0-py2.py3-none-any.whl",
+                ),
+                (
+                    "docutils",
+                    "0.15.2",
+                    "https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl",
+                ),
+                (
+                    "jmespath",
+                    "0.10.0",
+                    "https://files.pythonhosted.org/packages/07/cb/5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/jmespath-0.10.0-py2.py3-none-any.whl",
+                ),
+                (
+                    "python-dateutil",
+                    "2.9.0.post0",
+                    "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+                ),
+                (
+                    "six",
+                    "1.17.0",
+                    "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+                ),
+                (
+                    "urllib3",
+                    "1.25.11",
+                    "https://files.pythonhosted.org/packages/56/aa/4ef5aa67a9a62505db124a5cb5262332d1d4153462eb8fd89c9fa41e5d92/urllib3-1.25.11-py2.py3-none-any.whl",
+                )
             ]
         )
     )


### PR DESCRIPTION
This PR updates the `Package` class to be able to optionally attach package artifact source data to the standard ecosystem-name-version triple that defines a software package.  A distinction is made between local sources, defined by local file paths, and remote sources, defined by URLs.

This change is being made as part of an ongoing effort to cut down on cases of dependency confusion.  By making artifact source data available to SCFW's verifiers, they can determine whether a given package falls within the purview of their data sources.

The `PackageManager` implementation for `pip` is updated to start using this new artifact source attribute.  Similar changes for `npm` and `poetry`, along with the updates to the verifiers themselves, will be made across subsequent PRs.

Other changes include:

* Adding tests for the new `Pip` behaviors