### PR TITLE
Update documentation for direct pip invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Supply-Chain Firewall can also use its verifiers to audit installed packages:
 $ scfw audit npm
 No issues found.
 
-$ scfw audit --executable venv/bin/python pip
+$ scfw audit --executable venv/bin/pip pip
 Package pip-23.0.1:
   - An OSV.dev advisory exists for package pip-23.0.1:
       * [Medium] https://osv.dev/vulnerability/GHSA-mq26-g339-26xf


### PR DESCRIPTION
This PR updates the README to match the change introduced in [042fea4](https://github.com/DataDog/supply-chain-firewall/commit/042fea4be957c59ae5c2c1555993406cba274af6) in which the `Pip` package manager now directly invokes the backing `pip` executable instead of proxying through `python -m` module invocation.