### PR TITLE
[SECRES-5193] Use package artifact source in default verifiers

### DIFF
--- a/docs/verifiers.md
+++ b/docs/verifiers.md
@@ -2,13 +2,15 @@
 
 ## Package minimum age verifier
 
-The minimum package age verifier checks whether a given package (specified by an ecosystem-name-version triple) has a certain minimum age, defined to be the number of hours elapsed since the time of its publication to the ecosystem's package registry.  If a given package does not have the required minimum age, a single `WARNING`-level finding is returned.
+The minimum package age verifier checks whether a given package (specified by an ecosystem-name-version triple) has a certain minimum age, defined to be the number of hours elapsed since the time of its publication to the ecosystem's main package registry.  If a given package does not have the required minimum age, a single `WARNING`-level finding is returned.
 
 ```bash
 scfw run pip install foo
 Package foo-1.0.1:
   - Package foo was published less than 24 hours ago: treat new releases with caution
 ```
+
+Packages with a known artifact source other than the ecosystem's main registry are out of scope for this verifier.  Packages with unknown artifact source are treated as if they were sourced from the main registry.
 
 This verifier provides an additional level of protection to SCFW users against supply-chain attacks via package takeover or library compromise.  All things being equal, very recent releases have less vetting than older ones and should be treated with a greater deal of initial skepticism before being installed.
 
@@ -26,6 +28,8 @@ $ scfw run npm install basementio
 Package basementio@0.0.1-security:
   - Datadog Security Research has determined that package basementio@0.0.1-security is malicious
 ```
+
+Packages with a known artifact source other than the ecosystem's main registry are out of scope for this verifier.  Packages with unknown artifact source are treated as if they were sourced from the main registry.
 
 Users may configure the behavior of this verifier via the following environment variables:
 
@@ -46,6 +50,8 @@ Package pynamodb-6.1.0:
 The installation request was blocked. No changes have been made.
 ```
 
+This verifier assumes that all findings pertain to packages from the ecosystem's main package registry.  As such, packages with a known artifact source other than the ecosystem's main registry are out of scope for this verifier.  Packages with unknown artifact source are treated as if they were sourced from the main registry.
+
 Findings lists are expressed in YAML.  A simple example of the expected format may be found [here](https://github.com/DataDog/supply-chain-firewall/blob/main/examples/findings_list.yaml).
 
 Users may configure the behavior of this verifier via the following environment variables:
@@ -65,6 +71,8 @@ Package basementio@0.0.1-security:
   - An OSV.dev malicious package advisory exists for package basementio@0.0.1-security:
       * https://osv.dev/vulnerability/MAL-2024-7874
 ```
+
+Packages with a known artifact source other than the ecosystem's main registry are out of scope for this verifier.  Packages with unknown artifact source are treated as if they were sourced from the main registry.
 
 Users may configure the behavior of this verifier via the following environment variables:
 

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -20,7 +20,6 @@ from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.package import Package
 from scfw.report import VerificationReport
-from scfw.verifier import FindingSeverity
 
 
 class CustomFirewallLogger(FirewallLogger):
@@ -42,7 +41,7 @@ class CustomFirewallLogger(FirewallLogger):
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        reports: dict[FindingSeverity, VerificationReport],
+        report: VerificationReport,
     ):
         return
 

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -46,6 +46,8 @@ def run_audit(args: Namespace) -> int:
             if (severity_report := report.get_findings_report(severity)):
                 merged_report.extend(severity_report)
 
+        merged_report.extend(report.unverified_packages)
+
     if merged_report:
         print(merged_report)
     else:

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -7,7 +7,7 @@ import logging
 
 from scfw.loggers import FirewallLoggers
 import scfw.package_managers as package_managers
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 
@@ -24,7 +24,7 @@ def run_audit(args: Namespace) -> int:
     Returns:
         An integer status code indicating normal exit.
     """
-    merged_report = VerificationReport()
+    merged_report = FindingsReport()
 
     package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
@@ -34,16 +34,16 @@ def run_audit(args: Namespace) -> int:
         verifiers = FirewallVerifiers(package_manager.ecosystem())
         _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-        reports = verifiers.verify_packages(packages)
+        report = verifiers.verify_packages(packages)
         FirewallLoggers().log_audit(
             package_manager.ecosystem(),
             package_manager.name(),
             package_manager.executable(),
-            reports,
+            report,
         )
 
         for severity in FindingSeverity:
-            if (severity_report := reports.get(severity)):
+            if (severity_report := report.get_findings_report(severity)):
                 merged_report.extend(severity_report)
 
     if merged_report:

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -46,7 +46,7 @@ def run_audit(args: Namespace) -> int:
             if (severity_report := report.get_findings_report(severity)):
                 merged_report.extend(severity_report)
 
-        merged_report.extend(report.unverified_packages)
+        merged_report.extend(report.unverifiable)
 
     if merged_report:
         print(merged_report)

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -42,3 +42,22 @@ class ECOSYSTEM(Enum):
             return mappings[s.lower()]
         except KeyError:
             raise ValueError(f"Invalid package ecosystem: '{s}'")
+
+    def registry_domains(self) -> set[str]:
+        """
+        Return the URL domains associated with the main package registry for
+        a given `ECOSYSTEM`.
+
+        Returns:
+            A `set[str]` containing the URL domains for the given package ecosystem,
+            those from which package artifacts are known to be sourced.
+        """
+        match self:
+            case ECOSYSTEM.Npm:
+                return {
+                    "registry.npmjs.org",
+                }
+            case ECOSYSTEM.PyPI:
+                return {
+                    "files.pythonhosted.org",
+                }

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -53,11 +53,11 @@ def run_firewall(args: Namespace) -> int:
             critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
             warning_report = report.get_findings_report(FindingSeverity.WARNING)
 
-            # Treat unverified packages as warning-level findings
+            # Treat unverifiable packages as warning-level findings
             if warning_report is not None:
-                warning_report.extend(report.unverified_packages)
+                warning_report.extend(report.unverifiable)
             else:
-                warning_report = report.unverified_packages
+                warning_report = report.unverifiable
 
             if not args.dry_run and critical_report:
                 loggers.log_firewall_action(

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -49,9 +49,9 @@ def run_firewall(args: Namespace) -> int:
             verifiers = FirewallVerifiers(package_manager.ecosystem())
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-            reports = verifiers.verify_packages(targets)
-            critical_report = reports.get(FindingSeverity.CRITICAL)
-            warning_report = reports.get(FindingSeverity.WARNING)
+            report = verifiers.verify_packages(targets)
+            critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
+            warning_report = report.get_findings_report(FindingSeverity.WARNING)
 
             if not args.dry_run and critical_report:
                 loggers.log_firewall_action(

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -53,6 +53,12 @@ def run_firewall(args: Namespace) -> int:
             critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
             warning_report = report.get_findings_report(FindingSeverity.WARNING)
 
+            # Treat unverified packages as warning-level findings
+            if warning_report is not None:
+                warning_report.extend(report.unverified_packages)
+            else:
+                warning_report = report.unverified_packages
+
             if not args.dry_run and critical_report:
                 loggers.log_firewall_action(
                     package_manager.ecosystem(),

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
 from scfw.report import VerificationReport
-from scfw.verifier import FindingSeverity
 
 
 class FirewallAction(Enum):
@@ -119,7 +118,7 @@ class FirewallLogger(metaclass=ABCMeta):
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        reports: dict[FindingSeverity, VerificationReport],
+        report: VerificationReport,
     ):
         """
         Log the results of an audit for the given ecosystem and package manager.
@@ -128,11 +127,10 @@ class FirewallLogger(metaclass=ABCMeta):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            reports:
-                The severity-ranked reports resulting from auditing the installed packages.
+            report:
+                The `VerificationReport` resulting from auditing the installed packages.
 
-                These reports contain only those packages for which at least one verifier had
-                a finding (at the severity level associated with the entire report).  That is,
-                packages with no findings are excluded from the audit results.
+                This report contains only those packages for which at least one verifier had
+                a finding. Packages with no findings are excluded from the audit results.
         """
         pass

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -30,7 +30,6 @@ from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.package import Package
 from scfw.report import VerificationReport
-from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
@@ -94,13 +93,13 @@ class FirewallLoggers(FirewallLogger):
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        reports: dict[FindingSeverity, VerificationReport],
+        report: VerificationReport,
     ):
         """
         Log the results of an audit to all client loggers.
         """
         for logger in self._loggers:
             try:
-                logger.log_audit(ecosystem, package_manager, executable, reports)
+                logger.log_audit(ecosystem, package_manager, executable, report)
             except Exception as e:
                 _log.warning(f"Failed to log audit: {e}")

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -29,6 +29,7 @@ _AUDIT_ATTRIBUTES = {
     "msg",
     "package_manager",
     "reports",
+    "unverified",
 }
 _FIREWALL_ACTION_ATTRIBUTES = {
     "action",
@@ -241,5 +242,6 @@ class DDLogger(FirewallLogger):
                     str(severity): list(map(str, report.packages()))
                     for severity, report in report.findings_reports.items()
                 },
+                "unverified": list(map(str, report.unverified_packages.packages())),
             }
         )

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -18,7 +18,6 @@ from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.package import Package
 from scfw.report import VerificationReport
-from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
@@ -221,7 +220,7 @@ class DDLogger(FirewallLogger):
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        reports: dict[FindingSeverity, VerificationReport],
+        report: VerificationReport,
     ):
         """
         Log the results of an audit for the given ecosystem and package manager.
@@ -230,7 +229,7 @@ class DDLogger(FirewallLogger):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            reports: The severity-ranked reports resulting from auditing the installed packages.
+            reports: The `VerificationReport` resulting from auditing the installed packages.
         """
         self._logger.info(
             f"Successfully audited {ecosystem} packages managed by {package_manager}",
@@ -239,7 +238,8 @@ class DDLogger(FirewallLogger):
                 "package_manager": package_manager,
                 "executable": executable,
                 "reports": {
-                    str(severity): list(map(str, report.packages())) for severity, report in reports.items()
+                    str(severity): list(map(str, report.packages()))
+                    for severity, report in report.findings_reports.items()
                 },
             }
         )

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -239,8 +239,8 @@ class DDLogger(FirewallLogger):
                 "package_manager": package_manager,
                 "executable": executable,
                 "reports": {
-                    str(severity): list(map(str, report.packages()))
-                    for severity, report in report.findings_reports.items()
+                    str(severity): list(map(str, findings_report.packages()))
+                    for severity, findings_report in report.findings_reports.items()
                 },
                 "unverifiable": list(map(str, report.unverifiable.packages())),
             }

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -29,7 +29,7 @@ _AUDIT_ATTRIBUTES = {
     "msg",
     "package_manager",
     "reports",
-    "unverified",
+    "unverifiable",
 }
 _FIREWALL_ACTION_ATTRIBUTES = {
     "action",
@@ -242,6 +242,6 @@ class DDLogger(FirewallLogger):
                     str(severity): list(map(str, report.packages()))
                     for severity, report in report.findings_reports.items()
                 },
-                "unverified": list(map(str, report.unverified_packages.packages())),
+                "unverifiable": list(map(str, report.unverifiable.packages())),
             }
         )

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -230,7 +230,7 @@ class DDLogger(FirewallLogger):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            reports: The `VerificationReport` resulting from auditing the installed packages.
+            report: The `VerificationReport` resulting from auditing the installed packages.
         """
         self._logger.info(
             f"Successfully audited {ecosystem} packages managed by {package_manager}",

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -102,7 +102,7 @@ class Package:
             return False
 
         patterns = {
-            r'^https?://' + re.escape(domain) for domain in self.ecosystem.registry_domains()
+            r'^https?://' + re.escape(domain) + r'(?:/|$)' for domain in self.ecosystem.registry_domains()
         }
 
         return any(re.match(pattern, remote_source.remote_source) is not None for pattern in patterns)

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -4,6 +4,7 @@ A representation of software packages in supported ecosystems.
 
 from dataclasses import dataclass
 from pathlib import Path
+import re
 from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
@@ -88,3 +89,20 @@ class Package:
             return self.source
 
         return None
+
+    def has_registry_source(self) -> bool:
+        """
+        Check whether a `Package` is sourced from its ecosystem's main registry.
+
+        Returns:
+            A `bool` indicating whether the `Package` is known to be sourced from its
+            ecosystem's main package registry, based on its `source` attribute.
+        """
+        if not (remote_source := self.get_remote_source()):
+            return False
+
+        patterns = {
+            r'^https?://' + re.escape(domain) for domain in self.ecosystem.registry_domains()
+        }
+
+        return any(re.match(pattern, remote_source.remote_source) is not None for pattern in patterns)

--- a/scfw/package_manager.py
+++ b/scfw/package_manager.py
@@ -23,11 +23,6 @@ class PackageManager(metaclass=ABCMeta):
                 An optional local filesystem path to the underlying package manager executable
                 that should be used for running commands. If none is provided, the executable
                 is determined by the current environment.
-
-        Raises:
-            UnsupportedVersionError:
-                Implementors should raise this error when the underlying executable has an
-                unsupported version.
         """
         pass
 
@@ -97,9 +92,9 @@ class PackageManager(metaclass=ABCMeta):
 class UnsupportedVersionError(Exception):
     """
     An exception that occurs when an attempt is made to initialize a `PackageManager`
-    with an unsupported version of the underlying executable. Supply-Chain Firewall
-    handles this exception gracefully by alerting the user to the issue. In firewall
-    mode, the user can optionally disable verification and run commands with
-    unsupported versions of supported package managers.
+    or execute one of its key methods with an unsupported version of the underlying
+    executable. Supply-Chain Firewall handles this exception gracefully by alerting
+    the user to the issue. In firewall mode, the user can optionally disable verification
+    and run commands with unsupported versions of supported package managers.
     """
     pass

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -100,7 +100,7 @@ class VerificationReport:
     A structured report containing the results of verifying a set of `Package`.
     """
     findings_reports: dict[FindingSeverity, FindingsReport]
-    unverified_packages: FindingsReport
+    unverifiable: FindingsReport
 
     def get_findings_report(self, severity: FindingSeverity) -> Optional[FindingsReport]:
         """

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -100,6 +100,7 @@ class VerificationReport:
     A structured report containing the results of verifying a set of `Package`.
     """
     findings_reports: dict[FindingSeverity, FindingsReport]
+    unverified_packages: FindingsReport
 
     def get_findings_report(self, severity: FindingSeverity) -> Optional[FindingsReport]:
         """

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -1,21 +1,23 @@
 """
-A class for structuring and displaying the results of package verification.
+Classes for structuring and displaying the results of package verification.
 """
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Optional
 from typing_extensions import Self
 
 from scfw.package import Package
+from scfw.verifier import FindingSeverity
 
 
-class VerificationReport:
+class FindingsReport:
     """
-    A structured report containing findings resulting from package verification.
+    A structured report containing verification findings for a set of `Package`.
     """
     def __init__(self) -> None:
         """
-        Initialize a new, empty `VerificationReport`.
+        Initialize a new, empty `FindingsReport`.
         """
         self._report: dict[Package, list[str]] = {}
 
@@ -27,10 +29,10 @@ class VerificationReport:
 
     def __str__(self) -> str:
         """
-        Return a human-readable version of a verification report.
+        Return a human-readable version of a findings report.
 
         Returns:
-            A `str` containing the formatted verification report.
+            A `str` containing the formatted findings report.
         """
         def show_line(linenum: int, line: str) -> str:
             return (f"  - {line}" if linenum == 0 else f"    {line}")
@@ -74,10 +76,10 @@ class VerificationReport:
 
     def extend(self, other: Self) -> None:
         """
-        Extend a `VerificationReport` with additional findings from another.
+        Extend a `FindingsReport` with additional findings from another.
 
         Args:
-            other: The `VerificationReport` whose findings will be extended into `self`.
+            other: The `FindingsReport` whose findings will be extended into `self`.
         """
         for package, findings in other._report.items():
             if package in self._report:
@@ -90,3 +92,21 @@ class VerificationReport:
         Return an iterator over `Package` mentioned in the report.
         """
         return (package for package in self._report)
+
+
+@dataclass(eq=True, frozen=True)
+class VerificationReport:
+    """
+    A structured report containing the results of verifying a set of `Package`.
+    """
+    findings_reports: dict[FindingSeverity, FindingsReport]
+
+    def get_findings_report(self, severity: FindingSeverity) -> Optional[FindingsReport]:
+        """
+        Return the reported `FindingsReport` of the given severity level if one exists.
+
+        Returns:
+            The `FindingsReport` of the given `FindingSeverity` contained in the given
+            verification report's set of severity-ranked finding reports.
+        """
+        return self.findings_reports.get(severity)

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -103,3 +103,20 @@ class PackageVerifier(metaclass=ABCMeta):
             for the benefit of the user.
         """
         pass
+
+
+class UnverifiedPackage(Exception):
+    """
+    An exception that occurs when a verifier is unable to verify a given package.
+    This is to be distinguished from a verification failure, i.e., when errors occur
+    in the course of verifying a package.
+
+    The canonical use-case for this exception occurs when a package is not within the
+    purview of a verifier's backing data source. For instance, a package sourced from
+    a private package registry would not be within the purview of a verifier that only
+    covers packages sourced from an ecosystem's main public registry.
+
+    Supply-Chain Firewall handles this exception gracefully by separately collecting,
+    logging and reporting any packages that were unable to be verified.
+    """
+    pass

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -105,7 +105,7 @@ class PackageVerifier(metaclass=ABCMeta):
         pass
 
 
-class UnverifiedPackage(Exception):
+class UnverifiablePackage(Exception):
     """
     An exception that occurs when a verifier is unable to verify a given package.
     This is to be distinguished from a verification failure, i.e., when errors occur

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -29,7 +29,7 @@ import pkgutil
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport, VerificationReport
 from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ class FirewallVerifiers:
         """
         return [verifier.name() for verifier in self._verifiers]
 
-    def verify_packages(self, packages: list[Package]) -> dict[FindingSeverity, VerificationReport]:
+    def verify_packages(self, packages: list[Package]) -> VerificationReport:
         """
         Verify a set of packages against all discovered verifiers.
 
@@ -77,10 +77,10 @@ class FirewallVerifiers:
             packages: The set of `Package` to verify.
 
         Returns:
-            A set of severity-ranked verification reports resulting from verifying
-            `packages` against all discovered verifiers.
+            A `VerificationReport` resulting from verifying `packages` against all
+            discovered verifiers.
         """
-        reports: dict[FindingSeverity, VerificationReport] = {}
+        findings_reports: dict[FindingSeverity, FindingsReport] = {}
 
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
@@ -92,11 +92,11 @@ class FirewallVerifiers:
                 if (findings := future.result()):
                     _log.info(f"Verifier {verifier} had findings for package {package}")
                     for severity, finding in findings:
-                        if severity not in reports:
-                            reports[severity] = VerificationReport()
-                        reports[severity].insert(package, finding)
+                        if severity not in findings_reports:
+                            findings_reports[severity] = FindingsReport()
+                        findings_reports[severity].insert(package, finding)
                 else:
                     _log.info(f"Verifier {verifier} had no findings for package {package}")
 
         _log.info("Verification of packages complete")
-        return reports
+        return VerificationReport(findings_reports)

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -30,7 +30,7 @@ import pkgutil
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
 from scfw.report import FindingsReport, VerificationReport
-from scfw.verifier import FindingSeverity, UnverifiedPackage
+from scfw.verifier import FindingSeverity, UnverifiablePackage
 
 _log = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class FirewallVerifiers:
             discovered verifiers.
         """
         findings_reports: dict[FindingSeverity, FindingsReport] = {}
-        unverified_packages = FindingsReport()
+        unverifiable = FindingsReport()
 
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
@@ -100,11 +100,11 @@ class FirewallVerifiers:
                     else:
                         _log.info(f"Verifier {verifier} had no findings for package {package}")
 
-                except UnverifiedPackage as e:
-                    unverified_packages.insert(
+                except UnverifiablePackage as e:
+                    unverifiable.insert(
                         package,
                         f"Verifier {verifier} was unable to verify package {package}: {e}",
                     )
 
         _log.info("Verification of packages complete")
-        return VerificationReport(findings_reports, unverified_packages)
+        return VerificationReport(findings_reports, unverifiable)

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -30,7 +30,7 @@ import pkgutil
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
 from scfw.report import FindingsReport, VerificationReport
-from scfw.verifier import FindingSeverity
+from scfw.verifier import FindingSeverity, UnverifiedPackage
 
 _log = logging.getLogger(__name__)
 
@@ -81,6 +81,7 @@ class FirewallVerifiers:
             discovered verifiers.
         """
         findings_reports: dict[FindingSeverity, FindingsReport] = {}
+        unverified_packages = FindingsReport()
 
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
@@ -89,14 +90,21 @@ class FirewallVerifiers:
             }
             for future in cf.as_completed(task_results):
                 verifier, package = task_results[future]
-                if (findings := future.result()):
-                    _log.info(f"Verifier {verifier} had findings for package {package}")
-                    for severity, finding in findings:
-                        if severity not in findings_reports:
-                            findings_reports[severity] = FindingsReport()
-                        findings_reports[severity].insert(package, finding)
-                else:
-                    _log.info(f"Verifier {verifier} had no findings for package {package}")
+                try:
+                    if (findings := future.result()):
+                        _log.info(f"Verifier {verifier} had findings for package {package}")
+                        for severity, finding in findings:
+                            if severity not in findings_reports:
+                                findings_reports[severity] = FindingsReport()
+                            findings_reports[severity].insert(package, finding)
+                    else:
+                        _log.info(f"Verifier {verifier} had no findings for package {package}")
+
+                except UnverifiedPackage as e:
+                    unverified_packages.insert(
+                        package,
+                        f"Verifier {verifier} was unable to verify package {package}: {e}",
+                    )
 
         _log.info("Verification of packages complete")
-        return VerificationReport(findings_reports)
+        return VerificationReport(findings_reports, unverified_packages)

--- a/scfw/verifiers/age_verifier/__init__.py
+++ b/scfw/verifiers/age_verifier/__init__.py
@@ -9,7 +9,7 @@ import os
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
 import scfw.verifiers.age_verifier.npm as npm
 import scfw.verifiers.age_verifier.pypi as pypi
 
@@ -86,15 +86,15 @@ class PackageAgeVerifier(PackageVerifier):
             been published too recently, otherwise an empty list.
 
         Raises:
-            UnverifiedPackage:
+            UnverifiablePackage:
                 The given package is from an unsupported ecosystem or has a known artifact
                 source other than the ecosystem's main registry.
         """
         if package.ecosystem not in self.supported_ecosystems():
-            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+            raise UnverifiablePackage(f"Package ecosystem {package.ecosystem} is not supported")
 
         if package.source is not None and not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+            raise UnverifiablePackage(f"Cannot verify package with non-{package.ecosystem} registry source")
         if package.source is None:
             _log.warning(
                 f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"

--- a/scfw/verifiers/age_verifier/__init__.py
+++ b/scfw/verifiers/age_verifier/__init__.py
@@ -87,13 +87,18 @@ class PackageAgeVerifier(PackageVerifier):
 
         Raises:
             UnverifiedPackage:
-                The given package is from an unsupported ecosystem or has an artifact source
-                other than the ecosystem's main registry.
+                The given package is from an unsupported ecosystem or has a known artifact
+                source other than the ecosystem's main registry.
         """
         if package.ecosystem not in self.supported_ecosystems():
             raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
-        if not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
+
+        if package.source is not None and not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+        if package.source is None:
+            _log.warning(
+                f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"
+            )
 
         if self.minimum_age == timedelta(0):
             return []

--- a/scfw/verifiers/age_verifier/__init__.py
+++ b/scfw/verifiers/age_verifier/__init__.py
@@ -9,7 +9,7 @@ import os
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
 import scfw.verifiers.age_verifier.npm as npm
 import scfw.verifiers.age_verifier.pypi as pypi
 
@@ -84,7 +84,17 @@ class PackageAgeVerifier(PackageVerifier):
         Returns:
             A list containing a single `WARNING` finding if `package` is deemed to have
             been published too recently, otherwise an empty list.
+
+        Raises:
+            UnverifiedPackage:
+                The given package is from an unsupported ecosystem or has an artifact source
+                other than the ecosystem's main registry.
         """
+        if package.ecosystem not in self.supported_ecosystems():
+            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+        if not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
+
         if self.minimum_age == timedelta(0):
             return []
 

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier,  UnverifiedPackage
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
 import scfw.verifiers.dd_verifier.dataset as dataset
 
 _log = logging.getLogger(__name__)
@@ -82,15 +82,19 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
 
         Raises:
             UnverifiedPackage:
-                The given package is from an unsupported ecosystem or has an artifact source
-                other than the ecosystem's main registry.
+                The given package is from an unsupported ecosystem or has a known artifact
+                source other than the ecosystem's main registry.
         """
         manifest = self._manifests.get(package.ecosystem)
         if not manifest:
             raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
 
-        if not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
+        if package.source is not None and not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+        if package.source is None:
+            _log.warning(
+                f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"
+            )
 
         if (
             package.name in manifest

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
 import scfw.verifiers.dd_verifier.dataset as dataset
 
 _log = logging.getLogger(__name__)
@@ -81,16 +81,16 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
             is present in this case.
 
         Raises:
-            UnverifiedPackage:
+            UnverifiablePackage:
                 The given package is from an unsupported ecosystem or has a known artifact
                 source other than the ecosystem's main registry.
         """
         manifest = self._manifests.get(package.ecosystem)
         if not manifest:
-            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+            raise UnverifiablePackage(f"Package ecosystem {package.ecosystem} is not supported")
 
         if package.source is not None and not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+            raise UnverifiablePackage(f"Cannot verify package with non-{package.ecosystem} registry source")
         if package.source is None:
             _log.warning(
                 f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier
+from scfw.verifier import FindingSeverity, PackageVerifier,  UnverifiedPackage
 import scfw.verifiers.dd_verifier.dataset as dataset
 
 _log = logging.getLogger(__name__)
@@ -79,10 +79,18 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
             A list containing any findings for the given package, obtained by checking for its
             presence in the dataset's manifests.  Only a single `CRITICAL` finding to this effect
             is present in this case.
+
+        Raises:
+            UnverifiedPackage:
+                The given package is from an unsupported ecosystem or has an artifact source
+                other than the ecosystem's main registry.
         """
         manifest = self._manifests.get(package.ecosystem)
         if not manifest:
-            return [(FindingSeverity.WARNING, f"Package ecosystem {package.ecosystem} is not supported")]
+            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+
+        if not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
 
         if (
             package.name in manifest

--- a/scfw/verifiers/list_verifier/__init__.py
+++ b/scfw/verifiers/list_verifier/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
 from scfw.verifiers.list_verifier.findings_map import FindingsMap
 
 _log = logging.getLogger(__name__)
@@ -80,7 +80,22 @@ class FindingsListVerifier(PackageVerifier):
         Returns:
             A list containing all findings for the given package present in the user-provided
             findings list with which the `FindingsListVerifier` was initialized.
+
+        Raises:
+            UnverifiablePackage:
+                The given package is from an unsupported ecosystem or has a known artifact
+                source other than the ecosystem's main registry.
         """
+        if package.ecosystem not in self.supported_ecosystems():
+            raise UnverifiablePackage(f"Package ecosystem {package.ecosystem} is not supported")
+
+        if package.source is not None and not package.has_registry_source():
+            raise UnverifiablePackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+        if package.source is None:
+            _log.warning(
+                f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"
+            )
+
         return self._findings_map.get_findings(package)
 
 

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -113,8 +113,8 @@ class OsvVerifier(PackageVerifier):
 
         Raises:
             UnverifiedPackage:
-                The given package is from an unsupported ecosystem or has an artifact source
-                other than the ecosystem's main registry.
+                The given package is from an unsupported ecosystem or has a known artifact
+                source other than the ecosystem's main registry.
             requests.HTTPError:
                 An error occurred while querying a package against the OSV.dev API.
         """
@@ -136,8 +136,13 @@ class OsvVerifier(PackageVerifier):
 
         if package.ecosystem not in self.supported_ecosystems():
             raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
-        if not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
+
+        if package.source is not None and not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+        if package.source is None:
+            _log.warning(
+                f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"
+            )
 
         vulns = []
         query: dict[str, str | dict[str, str] | None] = {

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -13,7 +13,7 @@ import requests
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
 from scfw.verifiers.osv_verifier.osv_advisory import OsvAdvisory
 
 _log = logging.getLogger(__name__)
@@ -112,7 +112,7 @@ class OsvVerifier(PackageVerifier):
             **not all** OSV.dev malicious package advisories have `MAL` IDs.*
 
         Raises:
-            UnverifiedPackage:
+            UnverifiablePackage:
                 The given package is from an unsupported ecosystem or has a known artifact
                 source other than the ecosystem's main registry.
             requests.HTTPError:
@@ -135,10 +135,10 @@ class OsvVerifier(PackageVerifier):
             )
 
         if package.ecosystem not in self.supported_ecosystems():
-            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+            raise UnverifiablePackage(f"Package ecosystem {package.ecosystem} is not supported")
 
         if package.source is not None and not package.has_registry_source():
-            raise UnverifiedPackage(f"Cannot verify package with non-{package.ecosystem} registry source")
+            raise UnverifiablePackage(f"Cannot verify package with non-{package.ecosystem} registry source")
         if package.source is None:
             _log.warning(
                 f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -13,7 +13,7 @@ import requests
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier
+from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiedPackage
 from scfw.verifiers.osv_verifier.osv_advisory import OsvAdvisory
 
 _log = logging.getLogger(__name__)
@@ -112,6 +112,9 @@ class OsvVerifier(PackageVerifier):
             **not all** OSV.dev malicious package advisories have `MAL` IDs.*
 
         Raises:
+            UnverifiedPackage:
+                The given package is from an unsupported ecosystem or has an artifact source
+                other than the ecosystem's main registry.
             requests.HTTPError:
                 An error occurred while querying a package against the OSV.dev API.
         """
@@ -132,7 +135,9 @@ class OsvVerifier(PackageVerifier):
             )
 
         if package.ecosystem not in self.supported_ecosystems():
-            return [(FindingSeverity.WARNING, f"Package ecosystem {package.ecosystem} is not supported")]
+            raise UnverifiedPackage(f"Package ecosystem {package.ecosystem} is not supported")
+        if not package.has_registry_source():
+            raise UnverifiedPackage(f"Cannot verify package {package} with non-{package.ecosystem} artifact source")
 
         vulns = []
         query: dict[str, str | dict[str, str] | None] = {

--- a/tests/package_managers/npm_fixtures.py
+++ b/tests/package_managers/npm_fixtures.py
@@ -295,11 +295,3 @@ def init_npm_project(
 
     if not with_lockfile:
         os.remove(path / "package-lock.json")
-
-
-def build_npm_tarball_url(package_name: str, package_version: str) -> str:
-    """
-    Return the npm URL for the package tarball specified by the given name and version.
-    """
-    unscoped_name = package_name.split("/")[-1]
-    return f"https://registry.npmjs.org/{package_name}/-/{unscoped_name}-{package_version}.tgz"

--- a/tests/package_managers/test_npm_class.py
+++ b/tests/package_managers/test_npm_class.py
@@ -15,6 +15,7 @@ from scfw.package_managers.npm import Npm
 import scfw.package_managers.npm as npm
 
 from .npm_fixtures import *
+from .. import utils
 
 PACKAGE_MANAGER = Npm()
 """
@@ -22,12 +23,7 @@ Fixed `PackageManager` to use across all tests.
 """
 
 TEST_PACKAGE_LATEST_INSTALL_TARGETS = {
-    Package(
-        ECOSYSTEM.Npm,
-        name,
-        version,
-        RemotePackageSource(build_npm_tarball_url(name, version)),
-    )
+    utils.build_registry_package(ECOSYSTEM.Npm, name, version)
     for name, version in TEST_PACKAGE_LATEST_DEPENDENCIES
 }
 """
@@ -35,12 +31,7 @@ TEST_PACKAGE_LATEST_INSTALL_TARGETS = {
 """
 
 TEST_PACKAGE_PREVIOUS_INSTALL_TARGETS = {
-    Package(
-        ECOSYSTEM.Npm,
-        name,
-        version,
-        RemotePackageSource(build_npm_tarball_url(name, version)),
-    )
+    utils.build_registry_package(ECOSYSTEM.Npm, name, version)
     for name, version in TEST_PACKAGE_PREVIOUS_DEPENDENCIES
 }
 """
@@ -158,14 +149,7 @@ def test_resolve_install_targets_dependency_latest_lockfile(
         (["npm", "install", TEST_PACKAGE_LATEST_SPEC], None),
         (
             ["npm", "install", TEST_PACKAGE_PREVIOUS_SPEC],
-            {
-                Package(
-                    ECOSYSTEM.Npm,
-                    TEST_PACKAGE,
-                    TEST_PACKAGE_PREVIOUS,
-                    RemotePackageSource(build_npm_tarball_url(TEST_PACKAGE, TEST_PACKAGE_PREVIOUS)),
-                ),
-            },
+            {utils.build_registry_package(ECOSYSTEM.Npm, TEST_PACKAGE, TEST_PACKAGE_PREVIOUS)},
         ),
     ]
 )
@@ -227,14 +211,7 @@ def test_resolve_install_targets_dependency_previous_lockfile(
         (["npm", "install", TEST_PACKAGE_PREVIOUS_SPEC], None),
         (
             ["npm", "install", TEST_PACKAGE_LATEST_SPEC],
-            {
-                Package(
-                    ECOSYSTEM.Npm,
-                    TEST_PACKAGE,
-                    TEST_PACKAGE_LATEST,
-                    RemotePackageSource(build_npm_tarball_url(TEST_PACKAGE, TEST_PACKAGE_LATEST)),
-                ),
-            },
+            {utils.build_registry_package(ECOSYSTEM.Npm, TEST_PACKAGE, TEST_PACKAGE_LATEST)},
         ),
     ]
 )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,14 +29,15 @@ def build_registry_package(ecosystem: ECOSYSTEM, package_name: str, package_vers
 
 def build_remote_non_registry_package(ecosystem: ECOSYSTEM, package_name: str, package_version: str) -> Package:
     """
-    Lorem ipsum dolor sit amet.
+    Return a `Package` with the given parameters and a `RemotePackageSource` different
+    from the ecosystems' main registry.
     """
     return Package(ecosystem, package_name, package_version, RemotePackageSource("https://example.com"))
 
 
 def build_local_package(ecosystem: ECOSYSTEM, package_name: str, package_version: str) -> Package:
     """
-    Lorem ipsum dolor sit amet.
+    Return a `Package` with the given parameters and a local package artifact source.
     """
     return Package(
         ecosystem,
@@ -56,6 +57,6 @@ def _build_npm_tarball_url(package_name: str, package_version: str) -> str:
 
 def _build_pypi_whl_url(package_name: str, package_version: str) -> str:
     """
-    Return the PyPI URL for the package wheel file specified by the given name and version.
+    Return a URL resembling that of the PyPI wheel file for the given package and version.
     """
     return f"https://files.pythonhosted.org/packages/00/00/000000000000000000000000000000000000000000000000000000000000/{package_name}-{package_version}-py3-none-any.whl"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,4 +58,4 @@ def _build_pypi_whl_url(package_name: str, package_version: str) -> str:
     """
     Return the PyPI URL for the package wheel file specified by the given name and version.
     """
-    return f"https://files.pythonhosted.org/packages/c3/20/748e38b466e0819491f0ce6e90ebe4184966ee304fe483e2c414b0f4ef07/{package_name}-{package_version}-py3-none-any.whl"
+    return f"https://files.pythonhosted.org/packages/00/00/000000000000000000000000000000000000000000000000000000000000/{package_name}-{package_version}-py3-none-any.whl"

--- a/tests/verifiers/test_age_verifier.py
+++ b/tests/verifiers/test_age_verifier.py
@@ -11,7 +11,7 @@ from scfw.package import Package
 from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.age_verifier import PackageAgeVerifier
 
-from . import utils
+from .. import utils
 
 NPM_TEST_PACKAGE = ("axios", "1.14.0")
 PYPI_TEST_PACKAGE = ("requests", "2.32.2")
@@ -23,8 +23,8 @@ TEST_CASES = [
     (utils.build_remote_non_registry_package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1]), True),
     (utils.build_local_package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1]), True),
     (utils.build_local_package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1]), True),
-    (Package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1], source=None), True),
-    (Package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1], source=None), True),
+    (Package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1], source=None), False),
+    (Package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1], source=None), False),
 ]
 
 

--- a/tests/verifiers/test_age_verifier.py
+++ b/tests/verifiers/test_age_verifier.py
@@ -8,7 +8,7 @@ import pytest
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, UnverifiedPackage
+from scfw.verifier import FindingSeverity, UnverifiablePackage
 from scfw.verifiers.age_verifier import PackageAgeVerifier
 
 from .. import utils
@@ -39,7 +39,7 @@ def test_warn_on_recent_package(test_package: Package, unverifiable: bool):
     recency_verifier.minimum_age = timedelta(days=365*1000000)
 
     if unverifiable:
-        with pytest.raises(UnverifiedPackage):
+        with pytest.raises(UnverifiablePackage):
             recency_verifier.verify(test_package)
         return
 
@@ -58,7 +58,7 @@ def test_no_warn_on_non_recent_package(test_package: Package, unverifiable: bool
     recency_verifier = PackageAgeVerifier()
 
     if unverifiable:
-        with pytest.raises(UnverifiedPackage):
+        with pytest.raises(UnverifiablePackage):
             recency_verifier.verify(test_package)
         return
 

--- a/tests/verifiers/test_age_verifier.py
+++ b/tests/verifiers/test_age_verifier.py
@@ -8,19 +8,28 @@ import pytest
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity
+from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.age_verifier import PackageAgeVerifier
 
 from . import utils
 
-TEST_PACKAGES = [
-    utils.build_registry_sourced_package(ECOSYSTEM.Npm, "axios", "1.14.0"),
-    utils.build_registry_sourced_package(ECOSYSTEM.PyPI, "requests", "2.32.3"),
+NPM_TEST_PACKAGE = ("axios", "1.14.0")
+PYPI_TEST_PACKAGE = ("requests", "2.32.2")
+
+TEST_CASES = [
+    (utils.build_registry_package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1]), False),
+    (utils.build_registry_package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1]), False),
+    (utils.build_remote_non_registry_package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1]), True),
+    (utils.build_remote_non_registry_package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1]), True),
+    (utils.build_local_package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1]), True),
+    (utils.build_local_package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1]), True),
+    (Package(ECOSYSTEM.Npm, NPM_TEST_PACKAGE[0], NPM_TEST_PACKAGE[1], source=None), True),
+    (Package(ECOSYSTEM.PyPI, PYPI_TEST_PACKAGE[0], PYPI_TEST_PACKAGE[1], source=None), True),
 ]
 
 
-@pytest.mark.parametrize("test_package", TEST_PACKAGES)
-def test_warn_on_recent_package(test_package: Package):
+@pytest.mark.parametrize("test_package,unverifiable", TEST_CASES)
+def test_warn_on_recent_package(test_package: Package, unverifiable: bool):
     """
     Test that `PackageAgeVerifier` has findings for a package that does not have
     the required minimum age.
@@ -29,18 +38,28 @@ def test_warn_on_recent_package(test_package: Package):
     recency_verifier = PackageAgeVerifier()
     recency_verifier.minimum_age = timedelta(days=365*1000000)
 
+    if unverifiable:
+        with pytest.raises(UnverifiedPackage):
+            recency_verifier.verify(test_package)
+        return
+
     results = recency_verifier.verify(test_package)
     assert len(results) == 1
     assert results[0][0] == FindingSeverity.WARNING
 
 
 
-@pytest.mark.parametrize("test_package", TEST_PACKAGES)
-def test_no_warn_on_non_recent_package(test_package: Package):
+@pytest.mark.parametrize("test_package,unverifiable", TEST_CASES)
+def test_no_warn_on_non_recent_package(test_package: Package, unverifiable: bool):
     """
     Test that `PackageAgeVerifier` does not have findings for a package that has
     the required minimum age.
     """
     recency_verifier = PackageAgeVerifier()
+
+    if unverifiable:
+        with pytest.raises(UnverifiedPackage):
+            recency_verifier.verify(test_package)
+        return
 
     assert not recency_verifier.verify(test_package)

--- a/tests/verifiers/test_age_verifier.py
+++ b/tests/verifiers/test_age_verifier.py
@@ -11,9 +11,11 @@ from scfw.package import Package
 from scfw.verifier import FindingSeverity
 from scfw.verifiers.age_verifier import PackageAgeVerifier
 
+from . import utils
+
 TEST_PACKAGES = [
-    Package(ECOSYSTEM.Npm, "axios", "1.14.0"),
-    Package(ECOSYSTEM.PyPI, "requests", "2.32.3"),
+    utils.build_registry_sourced_package(ECOSYSTEM.Npm, "axios", "1.14.0"),
+    utils.build_registry_sourced_package(ECOSYSTEM.PyPI, "requests", "2.32.3"),
 ]
 
 

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -11,7 +11,7 @@ from typing import Callable
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, UnverifiedPackage
+from scfw.verifier import FindingSeverity, UnverifiablePackage
 from scfw.verifiers.dd_verifier import DatadogMaliciousPackagesVerifier
 import scfw.verifiers.dd_verifier.dataset as dataset
 
@@ -64,7 +64,7 @@ def test_dd_verifier_malicious(
 
     if unverifiable:
         for package in test_set:
-            with pytest.raises(UnverifiedPackage):
+            with pytest.raises(UnverifiablePackage):
                 _ = dd_verifier.verify(package)
         return
 

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -15,6 +15,8 @@ from scfw.verifiers import FirewallVerifiers
 from scfw.verifiers.dd_verifier import DatadogMaliciousPackagesVerifier
 import scfw.verifiers.dd_verifier.dataset as dataset
 
+from . import utils
+
 # Create a single Datadog malicious packages verifier to use for testing
 DD_VERIFIER = DatadogMaliciousPackagesVerifier()
 
@@ -39,9 +41,11 @@ def test_dd_verifier_malicious(ecosystem: ECOSYSTEM, kind: str):
     for name, versions in manifest.items():
         if kind == "malicious_intent" and not versions:
             # Version is not checked in this case, so use a dummy version string
-            test_set.append(Package(ecosystem, name, "dummy_version"))
+            test_set.append(utils.build_registry_sourced_package(ecosystem, name, "dummy_version"))
         elif kind == "compromised_lib" and versions:
-            test_set.extend([Package(ecosystem, name, version) for version in versions])
+            test_set.extend(
+                [utils.build_registry_sourced_package(ecosystem, name, version) for version in versions]
+            )
     assert test_set
 
     # Create a modified `FirewallVerifiers` only containing the Datadog verifier

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -7,57 +7,74 @@ import json
 from pathlib import Path
 import pytest
 from tempfile import TemporaryDirectory
+from typing import Callable
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity
-from scfw.verifiers import FirewallVerifiers
+from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.dd_verifier import DatadogMaliciousPackagesVerifier
 import scfw.verifiers.dd_verifier.dataset as dataset
 
 from . import utils
 
-# Create a single Datadog malicious packages verifier to use for testing
-DD_VERIFIER = DatadogMaliciousPackagesVerifier()
-
 
 @pytest.mark.parametrize(
-    "ecosystem,kind",
+    "ecosystem,kind,package_builder,unverifiable",
     [
-        (ECOSYSTEM.Npm, "malicious_intent"),
-        (ECOSYSTEM.Npm, "compromised_lib"),
-        (ECOSYSTEM.PyPI, "malicious_intent"),
-        (ECOSYSTEM.PyPI, "compromised_lib"),
+        (ECOSYSTEM.Npm, "malicious_intent", utils.build_registry_package, False),
+        (ECOSYSTEM.Npm, "compromised_lib", utils.build_registry_package, False),
+        (ECOSYSTEM.PyPI, "malicious_intent", utils.build_registry_package, False),
+        (ECOSYSTEM.PyPI, "compromised_lib", utils.build_registry_package, False),
+        (ECOSYSTEM.Npm, "malicious_intent", utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.Npm, "compromised_lib", utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.PyPI, "malicious_intent", utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.PyPI, "compromised_lib", utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.Npm, "malicious_intent", utils.build_local_package, True),
+        (ECOSYSTEM.Npm, "compromised_lib", utils.build_local_package, True),
+        (ECOSYSTEM.PyPI, "malicious_intent", utils.build_local_package, True),
+        (ECOSYSTEM.PyPI, "compromised_lib", utils.build_local_package, True),
+        (ECOSYSTEM.Npm, "malicious_intent", Package, True),
+        (ECOSYSTEM.Npm, "compromised_lib", Package, True),
+        (ECOSYSTEM.PyPI, "malicious_intent", Package, True),
+        (ECOSYSTEM.PyPI, "compromised_lib", Package, True),
     ]
 )
-def test_dd_verifier_malicious(ecosystem: ECOSYSTEM, kind: str):
+def test_dd_verifier_malicious(
+    ecosystem: ECOSYSTEM,
+    kind: str,
+    package_builder: Callable[[ECOSYSTEM, str, str], Package],
+    unverifiable: bool,
+):
     """
     Run a test of the `DatadogMaliciousPackagesVerifier` against all samples
     of the given ecosystem and kind.
     """
-    manifest = DD_VERIFIER._manifests[ecosystem]
+    dd_verifier = DatadogMaliciousPackagesVerifier()
 
     test_set = []
-    for name, versions in manifest.items():
+    for name, versions in dd_verifier._manifests[ecosystem].items():
         if kind == "malicious_intent" and not versions:
             # Version is not checked in this case, so use a dummy version string
-            test_set.append(utils.build_registry_sourced_package(ecosystem, name, "dummy_version"))
+            test_set.append(package_builder(ecosystem, name, "dummy_version"))
         elif kind == "compromised_lib" and versions:
             test_set.extend(
-                [utils.build_registry_sourced_package(ecosystem, name, version) for version in versions]
+                [package_builder(ecosystem, name, version) for version in versions]
             )
     assert test_set
 
-    # Create a modified `FirewallVerifiers` only containing the Datadog verifier
-    verifier = FirewallVerifiers(ecosystem)
-    verifier._verifiers = [DD_VERIFIER]
-
-    report = verifier.verify_packages(test_set)
-    assert (critical_report := report.get_findings_report(FindingSeverity.CRITICAL))
-    assert not report.get_findings_report(FindingSeverity.WARNING)
+    if unverifiable:
+        for package in test_set:
+            with pytest.raises(UnverifiedPackage):
+                _ = dd_verifier.verify(package)
+        return
 
     for package in test_set:
-        assert critical_report.get(package)
+        findings = dd_verifier.verify(package)
+        assert len(findings) == 1
+
+        severity, finding = findings[0]
+        assert severity == FindingSeverity.CRITICAL
+        assert finding
 
 
 @pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -15,7 +15,7 @@ from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.dd_verifier import DatadogMaliciousPackagesVerifier
 import scfw.verifiers.dd_verifier.dataset as dataset
 
-from . import utils
+from .. import utils
 
 
 @pytest.mark.parametrize(
@@ -33,10 +33,10 @@ from . import utils
         (ECOSYSTEM.Npm, "compromised_lib", utils.build_local_package, True),
         (ECOSYSTEM.PyPI, "malicious_intent", utils.build_local_package, True),
         (ECOSYSTEM.PyPI, "compromised_lib", utils.build_local_package, True),
-        (ECOSYSTEM.Npm, "malicious_intent", Package, True),
-        (ECOSYSTEM.Npm, "compromised_lib", Package, True),
-        (ECOSYSTEM.PyPI, "malicious_intent", Package, True),
-        (ECOSYSTEM.PyPI, "compromised_lib", Package, True),
+        (ECOSYSTEM.Npm, "malicious_intent", Package, False),
+        (ECOSYSTEM.Npm, "compromised_lib", Package, False),
+        (ECOSYSTEM.PyPI, "malicious_intent", Package, False),
+        (ECOSYSTEM.PyPI, "compromised_lib", Package, False),
     ]
 )
 def test_dd_verifier_malicious(

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -48,9 +48,9 @@ def test_dd_verifier_malicious(ecosystem: ECOSYSTEM, kind: str):
     verifier = FirewallVerifiers(ecosystem)
     verifier._verifiers = [DD_VERIFIER]
 
-    reports = verifier.verify_packages(test_set)
-    assert (critical_report := reports.get(FindingSeverity.CRITICAL))
-    assert not reports.get(FindingSeverity.WARNING)
+    report = verifier.verify_packages(test_set)
+    assert (critical_report := report.get_findings_report(FindingSeverity.CRITICAL))
+    assert not report.get_findings_report(FindingSeverity.WARNING)
 
     for package in test_set:
         assert critical_report.get(package)

--- a/tests/verifiers/test_list_verifier.py
+++ b/tests/verifiers/test_list_verifier.py
@@ -3,11 +3,14 @@ Tests of `FindingsListVerifier`.
 """
 
 import pytest
+from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity
+from scfw.verifier import FindingSeverity, UnverifiablePackage
 from scfw.verifiers.list_verifier import FindingsListVerifier, FindingsMap
+
+from .. import utils
 
 # Test findings list YAML
 FINDINGS_LIST_1 = """\
@@ -160,30 +163,26 @@ def test_findings_map_merge():
 
 
 @pytest.mark.parametrize(
-    "ecosystem, name, version, findings",
+    "package,unverifiable,findings",
     [
         (
-            ECOSYSTEM.Npm,
-            "react",
-            "18.2.0",
+            utils.build_registry_package(ECOSYSTEM.Npm, "react", "18.2.0"),
+            False,
             [(FindingSeverity.CRITICAL, "This is a critical finding in the second test findings list")],
         ),
         (
-            ECOSYSTEM.Npm,
-            "react",
-            "18.3.0",
+            utils.build_registry_package(ECOSYSTEM.Npm, "react", "18.3.0"),
+            False,
             [(FindingSeverity.CRITICAL, "This is a critical finding in the first test findings list")],
         ),
         (
-            ECOSYSTEM.PyPI,
-            "numpy",
-            "foo",
+            utils.build_registry_package(ECOSYSTEM.PyPI, "numpy", "foo"),
+            False,
             [(FindingSeverity.WARNING, "This is a warning finding in the first test findings list")],
         ),
         (
-            ECOSYSTEM.PyPI,
-            "numpy",
-            "2.3.5",
+            utils.build_registry_package(ECOSYSTEM.PyPI, "numpy", "2.3.5"),
+            False,
             [
                 (FindingSeverity.WARNING, "This is a warning finding in the first test findings list"),
                 (FindingSeverity.CRITICAL, "This is another critical finding in the second test findings list"),
@@ -191,46 +190,83 @@ def test_findings_map_merge():
             ],
         ),
         (
-            ECOSYSTEM.PyPI,
-            "pynamodb",
-            "foo",
+            utils.build_registry_package(ECOSYSTEM.PyPI, "pynamodb", "foo"),
+            False,
             [(FindingSeverity.CRITICAL, "This is a critical finding in the first test findings list")],
         ),
+        (
+            Package(ECOSYSTEM.Npm, "react", "18.2.0"),
+            False,
+            [(FindingSeverity.CRITICAL, "This is a critical finding in the second test findings list")],
+        ),
+        (
+            Package(ECOSYSTEM.Npm, "react", "18.3.0"),
+            False,
+            [(FindingSeverity.CRITICAL, "This is a critical finding in the first test findings list")],
+        ),
+        (
+            Package(ECOSYSTEM.PyPI, "numpy", "foo"),
+            False,
+            [(FindingSeverity.WARNING, "This is a warning finding in the first test findings list")],
+        ),
+        (
+            Package(ECOSYSTEM.PyPI, "numpy", "2.3.5"),
+            False,
+            [
+                (FindingSeverity.WARNING, "This is a warning finding in the first test findings list"),
+                (FindingSeverity.CRITICAL, "This is another critical finding in the second test findings list"),
+                (FindingSeverity.WARNING, "This is a warning finding in the second test findings list"),
+            ],
+        ),
+        (
+            Package(ECOSYSTEM.PyPI, "pynamodb", "foo"),
+            False,
+            [(FindingSeverity.CRITICAL, "This is a critical finding in the first test findings list")],
+        ),
+        (utils.build_remote_non_registry_package(ECOSYSTEM.Npm, "react", "18.2.0"), True, None),
+        (utils.build_remote_non_registry_package(ECOSYSTEM.Npm, "react", "18.3.0"), True, None),
+        (utils.build_remote_non_registry_package(ECOSYSTEM.PyPI, "numpy", "foo"), True, None),
+        (utils.build_remote_non_registry_package(ECOSYSTEM.PyPI, "numpy", "2.3.5"), True, None),
+        (utils.build_remote_non_registry_package(ECOSYSTEM.PyPI, "pynamodb", "foo"), True, None),
+        (utils.build_local_package(ECOSYSTEM.Npm, "react", "18.2.0"), True, None),
+        (utils.build_local_package(ECOSYSTEM.Npm, "react", "18.3.0"), True, None),
+        (utils.build_local_package(ECOSYSTEM.PyPI, "numpy", "foo"), True, None),
+        (utils.build_local_package(ECOSYSTEM.PyPI, "numpy", "2.3.5"), True, None),
+        (utils.build_local_package(ECOSYSTEM.PyPI, "pynamodb", "foo"), True, None),
+
     ]
 )
 def test_verify_positive_result(
-    ecosystem: ECOSYSTEM,
-    name: str,
-    version: str,
-    findings: list[tuple[FindingSeverity, str]],
+    package: Package,
+    unverifiable: bool,
+    findings: Optional[list[tuple[FindingSeverity, str]]],
 ):
     """
     Test that `FindingsListVerifier.verify()` returns the expected findings.
     """
-    backend_test_verify(ecosystem, name, version, findings)
+    backend_test_verify(package, unverifiable, findings)
 
 
 @pytest.mark.parametrize(
-    "ecosystem, name, version",
+    "package",
     [
-        (ECOSYSTEM.Npm, "react", "18.0.0"),
-        (ECOSYSTEM.Npm, "axios", "foo"),
-        (ECOSYSTEM.PyPI, "packaging", "foo"),
+        Package(ECOSYSTEM.Npm, "react", "18.0.0"),
+        Package(ECOSYSTEM.Npm, "axios", "foo"),
+        Package(ECOSYSTEM.PyPI, "packaging", "foo"),
     ]
 )
-def test_verify_negative_result(ecosystem: ECOSYSTEM, name: str, version: str):
+def test_verify_negative_result(package: Package):
     """
     Test that `FindingsListVerifier.verify()` does not return any findings
     when there are none that match.
     """
-    backend_test_verify(ecosystem, name, version)
+    backend_test_verify(package, False, [])
 
 
 def backend_test_verify(
-    ecosystem: ECOSYSTEM,
-    name: str,
-    version: str,
-    findings: list[tuple[FindingSeverity, str]] = [],
+    package: Package,
+    unverifiable: bool,
+    findings: Optional[list[tuple[FindingSeverity, str]]] = None,
 ):
     """
     Backend testing function for `FindingsListVerifier.verify()`.
@@ -242,4 +278,11 @@ def backend_test_verify(
     list_verifier = FindingsListVerifier()
     list_verifier._findings_map = findings_map
 
-    assert list_verifier.verify(Package(ecosystem, name, version)) == findings
+    if unverifiable:
+        assert findings is None
+        with pytest.raises(UnverifiablePackage):
+            _ = list_verifier.verify(package)
+        return
+
+    assert findings is not None
+    assert list_verifier.verify(package) == findings

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -10,6 +10,8 @@ from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 from scfw.verifiers.osv_verifier import OsvVerifier
 
+from . import utils
+
 # Package name and version pairs from 100 randomly selected PyPI OSV.dev disclosures
 # In constructing this list, we excluded the `tensorflow` package from consideration
 # because it has many OSV.dev disclosures, which cause the test to run very slowly
@@ -230,7 +232,7 @@ def test_osv_verifier_malicious(ecosystem: ECOSYSTEM):
             test_set = PYPI_TEST_SET
 
     test_set = [
-        (Package(ecosystem, name, version), has_critical, has_warning)
+        (utils.build_registry_sourced_package(ecosystem, name, version), has_critical, has_warning)
         for name, version, has_critical, has_warning in test_set
     ]
 

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -3,11 +3,11 @@ Tests of `OsvVerifier`.
 """
 
 import pytest
+from typing import Callable
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity
-from scfw.verifiers import FirewallVerifiers
+from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.osv_verifier import OsvVerifier
 
 from . import utils
@@ -219,12 +219,30 @@ NPM_TEST_SET = [
 ]
 
 
-@pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])
-def test_osv_verifier_malicious(ecosystem: ECOSYSTEM):
+@pytest.mark.parametrize(
+    "ecosystem,package_builder,unverifiable",
+    [
+        (ECOSYSTEM.Npm, utils.build_registry_package, False),
+        (ECOSYSTEM.Npm, utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.Npm, utils.build_local_package, True),
+        (ECOSYSTEM.Npm, Package, True),
+        (ECOSYSTEM.PyPI, utils.build_registry_package, False),
+        (ECOSYSTEM.PyPI, utils.build_remote_non_registry_package, True),
+        (ECOSYSTEM.PyPI, utils.build_local_package, True),
+        (ECOSYSTEM.PyPI, Package, True),
+    ]
+)
+def test_osv_verifier_malicious(
+    ecosystem: ECOSYSTEM,
+    package_builder: Callable[[ECOSYSTEM, str, str], Package],
+    unverifiable: bool
+):
     """
     Run a test of the `OsvVerifier` against the list of selected packages
     corresponding to the given ecosystem.
     """
+    osv_verifier = OsvVerifier()
+
     match ecosystem:
         case ECOSYSTEM.Npm:
             test_set = NPM_TEST_SET
@@ -232,29 +250,29 @@ def test_osv_verifier_malicious(ecosystem: ECOSYSTEM):
             test_set = PYPI_TEST_SET
 
     test_set = [
-        (utils.build_registry_sourced_package(ecosystem, name, version), has_critical, has_warning)
+        (package_builder(ecosystem, name, version), has_critical, has_warning)
         for name, version, has_critical, has_warning in test_set
     ]
 
-    # Create a modified `FirewallVerifiers` only containing the OSV.dev verifier
-    verifier = FirewallVerifiers(ecosystem)
-    verifier._verifiers = [OsvVerifier()]
-
-    report = verifier.verify_packages([test[0] for test in test_set])
-    critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
-    warning_report = report.get_findings_report(FindingSeverity.WARNING)
+    if unverifiable:
+        for package, _, _ in test_set:
+            with pytest.raises(UnverifiedPackage):
+                _ = osv_verifier.verify(package)
+        return
 
     for package, has_critical, has_warning in test_set:
+        findings = osv_verifier.verify(package)
+        assert findings
+
+        any_critical = any(finding[0] == FindingSeverity.CRITICAL for finding in findings)
+        any_warning = any(finding[0] == FindingSeverity.WARNING for finding in findings)
+
         if has_critical:
-            assert (critical_report and critical_report.get(package))
+            assert any_critical
         else:
-            assert (
-                not (critical_report and critical_report.get(package))
-            )
+            assert not any_critical
 
         if has_warning:
-            assert (warning_report and warning_report.get(package))
+            assert any_warning
         else:
-            assert (
-                not (warning_report and warning_report.get(package))
-            )
+            assert not any_warning

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, UnverifiedPackage
+from scfw.verifier import FindingSeverity, UnverifiablePackage
 from scfw.verifiers.osv_verifier import OsvVerifier
 
 from .. import utils
@@ -256,7 +256,7 @@ def test_osv_verifier_malicious(
 
     if unverifiable:
         for package, _, _ in test_set:
-            with pytest.raises(UnverifiedPackage):
+            with pytest.raises(UnverifiablePackage):
                 _ = osv_verifier.verify(package)
         return
 

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -238,9 +238,9 @@ def test_osv_verifier_malicious(ecosystem: ECOSYSTEM):
     verifier = FirewallVerifiers(ecosystem)
     verifier._verifiers = [OsvVerifier()]
 
-    reports = verifier.verify_packages([test[0] for test in test_set])
-    critical_report = reports.get(FindingSeverity.CRITICAL)
-    warning_report = reports.get(FindingSeverity.WARNING)
+    report = verifier.verify_packages([test[0] for test in test_set])
+    critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
+    warning_report = report.get_findings_report(FindingSeverity.WARNING)
 
     for package, has_critical, has_warning in test_set:
         if has_critical:

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -10,7 +10,7 @@ from scfw.package import Package
 from scfw.verifier import FindingSeverity, UnverifiedPackage
 from scfw.verifiers.osv_verifier import OsvVerifier
 
-from . import utils
+from .. import utils
 
 # Package name and version pairs from 100 randomly selected PyPI OSV.dev disclosures
 # In constructing this list, we excluded the `tensorflow` package from consideration
@@ -225,11 +225,11 @@ NPM_TEST_SET = [
         (ECOSYSTEM.Npm, utils.build_registry_package, False),
         (ECOSYSTEM.Npm, utils.build_remote_non_registry_package, True),
         (ECOSYSTEM.Npm, utils.build_local_package, True),
-        (ECOSYSTEM.Npm, Package, True),
+        (ECOSYSTEM.Npm, Package, False),
         (ECOSYSTEM.PyPI, utils.build_registry_package, False),
         (ECOSYSTEM.PyPI, utils.build_remote_non_registry_package, True),
         (ECOSYSTEM.PyPI, utils.build_local_package, True),
-        (ECOSYSTEM.PyPI, Package, True),
+        (ECOSYSTEM.PyPI, Package, False),
     ]
 )
 def test_osv_verifier_malicious(

--- a/tests/verifiers/utils.py
+++ b/tests/verifiers/utils.py
@@ -1,0 +1,44 @@
+"""
+Common verifier testing utilities.
+"""
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.package import Package, RemotePackageSource
+
+
+def build_registry_sourced_package(
+    ecosystem: ECOSYSTEM,
+    package_name: str,
+    package_version: str
+) -> Package:
+    """
+    Return a `Package` with the given parameters and the ecosystem's main registry as
+    its artifact source.
+    """
+    match ecosystem:
+        case ECOSYSTEM.Npm:
+            source_url = _build_npm_tarball_url(package_name, package_version)
+        case ECOSYSTEM.PyPI:
+            source_url = _build_pypi_whl_url(package_name, package_version)
+
+    return Package(
+        ecosystem,
+        package_name,
+        package_version,
+        RemotePackageSource(source_url),
+    )
+
+
+def _build_npm_tarball_url(package_name: str, package_version: str) -> str:
+    """
+    Return the npm URL for the package tarball specified by the given name and version.
+    """
+    unscoped_name = package_name.split("/")[-1]
+    return f"https://registry.npmjs.org/{package_name}/-/{unscoped_name}-{package_version}.tgz"
+
+
+def _build_pypi_whl_url(package_name: str, package_version: str) -> str:
+    """
+    Return the PyPI URL for the package wheel file specified by the given name and version.
+    """
+    return f"https://files.pythonhosted.org/packages/c3/20/748e38b466e0819491f0ce6e90ebe4184966ee304fe483e2c414b0f4ef07/{package_name}-{package_version}-py3-none-any.whl"

--- a/tests/verifiers/utils.py
+++ b/tests/verifiers/utils.py
@@ -2,15 +2,13 @@
 Common verifier testing utilities.
 """
 
+from pathlib import Path
+
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package, RemotePackageSource
+from scfw.package import Package, LocalPackageSource, RemotePackageSource
 
 
-def build_registry_sourced_package(
-    ecosystem: ECOSYSTEM,
-    package_name: str,
-    package_version: str
-) -> Package:
+def build_registry_package(ecosystem: ECOSYSTEM, package_name: str, package_version: str) -> Package:
     """
     Return a `Package` with the given parameters and the ecosystem's main registry as
     its artifact source.
@@ -26,6 +24,25 @@ def build_registry_sourced_package(
         package_name,
         package_version,
         RemotePackageSource(source_url),
+    )
+
+
+def build_remote_non_registry_package(ecosystem: ECOSYSTEM, package_name: str, package_version: str) -> Package:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    return Package(ecosystem, package_name, package_version, RemotePackageSource("https://example.com"))
+
+
+def build_local_package(ecosystem: ECOSYSTEM, package_name: str, package_version: str) -> Package:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    return Package(
+        ecosystem,
+        package_name,
+        package_version,
+        LocalPackageSource(Path(f"/tmp/{package_name}_v{package_version}")),
     )
 
 


### PR DESCRIPTION
This PR updates SCFW's set of default verifiers to make use of the new package artifact source attribute of `Package`.  Built-in verifiers now explicitly exclude from verification any `Package` targets that are known to fall outside of their purview, generally the npm and PyPI registries, based on package artifact source.  When a `Package`'s artifact source is unknown, the verifiers assume it is sourced from the main registry (consistent with previous behavior).

The `VerificationReport` class is also refactored to separately report on unverifiable packages.  The `scfw audit` logging protocol is updated to receive the refactored `VerificationReport`.  In a subsequent PR, we will update the `scfw run` logging protocol to also receive this information.