### PR TITLE
[SECRES-5212] Bugfix: npm audit not reporting package sources for transitive dependencies

### DIFF
--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -5,7 +5,6 @@ Provides a `PackageManager` representation of `npm`.
 import json
 import logging
 import os
-from pathlib import Path
 import shutil
 import subprocess
 from typing import Optional
@@ -13,9 +12,10 @@ from typing import Optional
 from packaging.version import InvalidVersion, parse as version_parse
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import LocalPackageSource, Package, RemotePackageSource
+from scfw.package import Package
 from scfw.package_manager import PackageManager, UnsupportedVersionError
-from scfw.package_managers.npm.temp_project import FILE_URI_PREFIX, NODE_MODULES_PREFIX, TemporaryNpmProject
+from scfw.package_managers.npm import installed
+from scfw.package_managers.npm.temp_project import TemporaryNpmProject
 
 _log = logging.getLogger(__name__)
 
@@ -136,106 +136,10 @@ class Npm(PackageManager):
             RuntimeError: Failed to list installed packages or decode report JSON.
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
-        def load_lock_file_resolved_map(lock_file: Path) -> dict[tuple[str, str], str]:
-            """
-            Build a (name, version) -> resolved-URL map from a package-lock.json.
-
-            Only entries under node_modules/ that carry both resolved and version
-            fields are included. Keying by (name, version) keeps multiple versions
-            of the same package distinct (e.g., a hoisted and a non-hoisted copy).
-            Returns an empty dict if the file is missing or malformed.
-            """
-            try:
-                data = json.loads(lock_file.read_text())
-            except (OSError, json.JSONDecodeError) as e:
-                _log.debug(f"Could not read lock file {lock_file}: {e}")
-                return {}
-
-            result = {}
-            for key, pkg_data in data.get("packages", {}).items():
-                if key.startswith(NODE_MODULES_PREFIX):
-                    resolved = pkg_data.get("resolved", "")
-                    version = pkg_data.get("version", "")
-                    if resolved and version:
-                        # Nested (non-hoisted) entries look like
-                        # `node_modules/<parent>/node_modules/<child>` — take
-                        # the segment after the last `node_modules/` boundary.
-                        name = key.rpartition(NODE_MODULES_PREFIX)[2]
-                        result[(name, version)] = resolved
-            return result
-
-        def dependencies_to_packages(
-            dependencies: dict[str, dict],
-            resolved_fallback: dict[tuple[str, str], str],
-        ) -> set[Package]:
-            packages = set()
-
-            node_modules_path = Path.cwd() / "node_modules"
-
-            for name, package_data in dependencies.items():
-                try:
-                    if not (version := package_data.get("version")):
-                        # Skip the whole entry, including any `dependencies` subtree:
-                        # npm list does not report children under an uninstalled parent.
-                        _log.debug(f"Skipping dependency {name}: not installed")
-                        continue
-
-                    resolved = package_data.get("resolved", "") or resolved_fallback.get((name, version), "")
-
-                    # `file:` dependencies reported by `npm list` are relative to `node_modules/`
-                    local_path = (
-                        (node_modules_path / resolved[len(FILE_URI_PREFIX):]).resolve()
-                        if resolved.startswith(FILE_URI_PREFIX) else None
-                    )
-
-                    if (nested := package_data.get("dependencies")):
-                        nested_fallback = resolved_fallback
-                        if local_path is not None:
-                            lock_file = local_path / "package-lock.json"
-                            if lock_file.is_file():
-                                nested_fallback = {
-                                    **resolved_fallback,
-                                    **load_lock_file_resolved_map(lock_file),
-                                }
-                        packages |= dependencies_to_packages(nested, nested_fallback)
-
-                    if not resolved:
-                        _log.info(f"No artifact source data found for installed dependency {name}")
-
-                    source: Optional[LocalPackageSource | RemotePackageSource] = None
-                    if resolved.startswith("http"):
-                        source = RemotePackageSource(resolved)
-                    elif local_path is not None:
-                        if local_path.exists():
-                            source = LocalPackageSource(local_path)
-                        else:
-                            _log.warning(
-                                f"Could not resolve local source path for installed dependency {name}: "
-                                f"{local_path} does not exist"
-                            )
-
-                    packages.add(Package(ECOSYSTEM.Npm, name, version, source=source))
-
-                except (AttributeError, TypeError, ValueError) as e:
-                    _log.warning(f"Failed to resolve installed dependency {name}: {e}")
-
-            return packages
-
         self._check_version()
 
         try:
-            npm_list = subprocess.run(
-                [self.executable(), "list", "--all", "--json"],
-                check=True, text=True, capture_output=True,
-            )
-
-            dependencies = json.loads(npm_list.stdout.strip()).get("dependencies", {})
-            if not isinstance(dependencies, dict):
-                raise RuntimeError("Received malformed dependencies data from npm")
-
-            resolved_fallback = load_lock_file_resolved_map(Path.cwd() / "package-lock.json")
-
-            return list(dependencies_to_packages(dependencies, resolved_fallback))
+            return installed.list_installed_packages(self.executable())
 
         except subprocess.CalledProcessError:
             raise RuntimeError("Failed to list npm installed packages")

--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -21,6 +21,8 @@ _log = logging.getLogger(__name__)
 
 MIN_NPM_VERSION = version_parse("7.0.0")
 
+_LOCK_FILE_NODE_MODULES_PREFIX = "node_modules/"
+
 
 class Npm(PackageManager):
     """
@@ -138,34 +140,80 @@ class Npm(PackageManager):
             RuntimeError: Failed to list installed packages or decode report JSON.
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
-        def dependencies_to_packages(dependencies: dict[str, dict]) -> set[Package]:
+        def load_lock_file_resolved_map(lock_file: Path) -> dict[tuple[str, str], str]:
+            """
+            Build a (name, version) -> resolved-URL map from a package-lock.json.
+
+            Only entries under node_modules/ that carry both resolved and version
+            fields are included. Keying by (name, version) keeps multiple versions
+            of the same package distinct (e.g., a hoisted and a non-hoisted copy).
+            Returns an empty dict if the file is missing or malformed.
+            """
+            try:
+                data = json.loads(lock_file.read_text())
+            except (OSError, json.JSONDecodeError) as e:
+                _log.debug(f"Could not read lock file {lock_file}: {e}")
+                return {}
+
+            result = {}
+            for key, pkg_data in data.get("packages", {}).items():
+                if key.startswith(_LOCK_FILE_NODE_MODULES_PREFIX):
+                    resolved = pkg_data.get("resolved", "")
+                    version = pkg_data.get("version", "")
+                    if resolved and version:
+                        # Nested (non-hoisted) entries look like
+                        # `node_modules/<parent>/node_modules/<child>` — take
+                        # the segment after the last `node_modules/` boundary.
+                        name = key.rpartition(_LOCK_FILE_NODE_MODULES_PREFIX)[2]
+                        result[(name, version)] = resolved
+            return result
+
+        def dependencies_to_packages(
+            dependencies: dict[str, dict],
+            resolved_fallback: dict[tuple[str, str], str],
+        ) -> set[Package]:
             packages = set()
 
             for name, package_data in dependencies.items():
                 try:
-                    if (nested := package_data.get("dependencies")):
-                        packages |= dependencies_to_packages(nested)
-
                     if not (version := package_data.get("version")):
-                        raise ValueError("Missing version data")
+                        # Skip the whole entry, including any `dependencies` subtree:
+                        # npm list does not report children under an uninstalled parent.
+                        _log.debug(f"Skipping dependency {name}: not installed")
+                        continue
 
-                    resolved = package_data.get("resolved", "")
+                    resolved = package_data.get("resolved", "") or resolved_fallback.get((name, version), "")
+
+                    # `file:` dependencies reported by `npm list` are relative to `node_modules/`
+                    local_path = (
+                        (Path.cwd() / "node_modules" / resolved[len(FILE_URI_PREFIX):]).resolve()
+                        if resolved.startswith(FILE_URI_PREFIX) else None
+                    )
+
+                    if (nested := package_data.get("dependencies")):
+                        nested_fallback = resolved_fallback
+                        if local_path is not None:
+                            lock_file = local_path / "package-lock.json"
+                            if lock_file.is_file():
+                                nested_fallback = {
+                                    **resolved_fallback,
+                                    **load_lock_file_resolved_map(lock_file),
+                                }
+                        packages |= dependencies_to_packages(nested, nested_fallback)
+
                     if not resolved:
                         _log.info(f"No artifact source data found for installed dependency {name}")
 
                     source: Optional[LocalPackageSource | RemotePackageSource] = None
                     if resolved.startswith("http"):
                         source = RemotePackageSource(resolved)
-                    elif resolved.startswith(FILE_URI_PREFIX):
-                        try:
-                            # `file:` dependencies reported by `npm list` are relative to `node_modules/`
-                            node_modules_dir = Path.cwd() / "node_modules"
-                            source = LocalPackageSource(
-                                (node_modules_dir / resolved[len(FILE_URI_PREFIX):]).resolve(strict=True)
-                            )
-                        except (OSError, RuntimeError) as e:
+                    elif local_path is not None:
+                        if local_path.exists():
+                            source = LocalPackageSource(local_path)
+                        else:
                             _log.warning(
-                                f"Could not resolve local source path for installed dependency {name}: {e}"
+                                f"Could not resolve local source path for installed dependency {name}: "
+                                f"{local_path} does not exist"
                             )
 
                     packages.add(Package(ECOSYSTEM.Npm, name, version, source=source))
@@ -187,7 +235,9 @@ class Npm(PackageManager):
             if not isinstance(dependencies, dict):
                 raise RuntimeError("Received malformed dependencies data from npm")
 
-            return list(dependencies_to_packages(dependencies))
+            resolved_fallback = load_lock_file_resolved_map(Path.cwd() / "package-lock.json")
+
+            return list(dependencies_to_packages(dependencies, resolved_fallback))
 
         except subprocess.CalledProcessError:
             raise RuntimeError("Failed to list npm installed packages")

--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -149,16 +149,20 @@ class Npm(PackageManager):
         Check whether the underlying `npm` executable is of a supported version.
 
         Raises:
+            RuntimeError: Failed to determine or parse `npm` version.
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
         try:
             # All supported versions adhere to this format
             p = subprocess.run([self._executable, "--version"], check=True, text=True, capture_output=True)
             if version_parse(p.stdout.strip()) < MIN_NPM_VERSION:
-                raise InvalidVersion
+                raise UnsupportedVersionError(f"npm before v{MIN_NPM_VERSION} is not supported")
+
+        except subprocess.CalledProcessError:
+            raise RuntimeError("Failed to determine npm version")
 
         except InvalidVersion:
-            raise UnsupportedVersionError(f"npm before v{MIN_NPM_VERSION} is not supported")
+            raise RuntimeError("Failed to parse npm version")
 
     def _normalize_command(self, command: list[str]) -> list[str]:
         """

--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -141,11 +141,8 @@ class Npm(PackageManager):
         try:
             return installed.list_installed_packages(self.executable())
 
-        except subprocess.CalledProcessError:
-            raise RuntimeError("Failed to list npm installed packages")
-
-        except json.JSONDecodeError:
-            raise RuntimeError("Failed to decode installed package report JSON")
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Failed to decode installed package report JSON: {e}")
 
     def _check_version(self):
         """

--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -10,18 +10,21 @@ import shutil
 import subprocess
 from typing import Optional
 
-from packaging.version import InvalidVersion, Version, parse as version_parse
+from packaging.version import InvalidVersion, parse as version_parse
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import LocalPackageSource, Package, RemotePackageSource
 from scfw.package_manager import PackageManager, UnsupportedVersionError
-from scfw.package_managers.npm.temp_project import FILE_URI_PREFIX, TemporaryNpmProject
+from scfw.package_managers.npm.temp_project import FILE_URI_PREFIX, NODE_MODULES_PREFIX, TemporaryNpmProject
 
 _log = logging.getLogger(__name__)
 
 MIN_NPM_VERSION = version_parse("7.0.0")
 
-_LOCK_FILE_NODE_MODULES_PREFIX = "node_modules/"
+# https://docs.npmjs.com/cli/v10/commands/npm-install
+_INSTALL_COMMAND_ALIASES = {
+    "install", "add", "i", "in", "ins", "inst", "insta", "instal", "isnt", "isnta", "isntal", "isntall"
+}
 
 
 class Npm(PackageManager):
@@ -101,18 +104,11 @@ class Npm(PackageManager):
             RuntimeError: Failed to resolve npm installation targets (with error detail)
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
-        def is_install_command(command: list[str]) -> bool:
-            # https://docs.npmjs.com/cli/v10/commands/npm-install
-            install_aliases = {
-                "install", "add", "i", "in", "ins", "inst", "insta", "instal", "isnt", "isnta", "isntal", "isntall"
-            }
-            return any(alias in command for alias in install_aliases)
-
         if not command or command[0] != self.name():
             raise ValueError("Received empty or invalid npm command line")
 
         # For now, allow all non-`install` commands
-        if not is_install_command(command):
+        if not any(alias in command for alias in _INSTALL_COMMAND_ALIASES):
             return []
 
         self._check_version()
@@ -157,14 +153,14 @@ class Npm(PackageManager):
 
             result = {}
             for key, pkg_data in data.get("packages", {}).items():
-                if key.startswith(_LOCK_FILE_NODE_MODULES_PREFIX):
+                if key.startswith(NODE_MODULES_PREFIX):
                     resolved = pkg_data.get("resolved", "")
                     version = pkg_data.get("version", "")
                     if resolved and version:
                         # Nested (non-hoisted) entries look like
                         # `node_modules/<parent>/node_modules/<child>` — take
                         # the segment after the last `node_modules/` boundary.
-                        name = key.rpartition(_LOCK_FILE_NODE_MODULES_PREFIX)[2]
+                        name = key.rpartition(NODE_MODULES_PREFIX)[2]
                         result[(name, version)] = resolved
             return result
 
@@ -173,6 +169,8 @@ class Npm(PackageManager):
             resolved_fallback: dict[tuple[str, str], str],
         ) -> set[Package]:
             packages = set()
+
+            node_modules_path = Path.cwd() / "node_modules"
 
             for name, package_data in dependencies.items():
                 try:
@@ -186,7 +184,7 @@ class Npm(PackageManager):
 
                     # `file:` dependencies reported by `npm list` are relative to `node_modules/`
                     local_path = (
-                        (Path.cwd() / "node_modules" / resolved[len(FILE_URI_PREFIX):]).resolve()
+                        (node_modules_path / resolved[len(FILE_URI_PREFIX):]).resolve()
                         if resolved.startswith(FILE_URI_PREFIX) else None
                     )
 
@@ -227,7 +225,7 @@ class Npm(PackageManager):
 
         try:
             npm_list = subprocess.run(
-                [self.executable() or "npm", "list", "--all", "--json"],
+                [self.executable(), "list", "--all", "--json"],
                 check=True, text=True, capture_output=True,
             )
 
@@ -252,16 +250,13 @@ class Npm(PackageManager):
         Raises:
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
-        def get_npm_version(executable: str) -> Optional[Version]:
-            try:
-                # All supported versions adhere to this format
-                npm_version = subprocess.run([executable, "--version"], check=True, text=True, capture_output=True)
-                return version_parse(npm_version.stdout.strip())
-            except InvalidVersion:
-                return None
+        try:
+            # All supported versions adhere to this format
+            p = subprocess.run([self._executable, "--version"], check=True, text=True, capture_output=True)
+            if version_parse(p.stdout.strip()) < MIN_NPM_VERSION:
+                raise InvalidVersion
 
-        npm_version = get_npm_version(self._executable)
-        if not npm_version or npm_version < MIN_NPM_VERSION:
+        except InvalidVersion:
             raise UnsupportedVersionError(f"npm before v{MIN_NPM_VERSION} is not supported")
 
     def _normalize_command(self, command: list[str]) -> list[str]:

--- a/scfw/package_managers/npm/common.py
+++ b/scfw/package_managers/npm/common.py
@@ -1,0 +1,9 @@
+"""
+Provides common definitions related to npm.
+"""
+
+# URI scheme for npm local package dependencies
+FILE_URI_PREFIX = "file:"
+
+# Prefix for all installed-package entries in package-lock.json
+NODE_MODULES_PREFIX = "node_modules/"

--- a/scfw/package_managers/npm/installed.py
+++ b/scfw/package_managers/npm/installed.py
@@ -26,16 +26,24 @@ def list_installed_packages(executable: str) -> list[Package]:
         A `list[Package]` representing all npm packages installed in the active environment.
 
     Raises:
-        RuntimeError: Received malformed dependencies data from npm.
-        subprocess.CalledProcessError: Failed to run `npm list`.
+        RuntimeError:
+            npm produced no parseable output or its output contained malformed data.
         json.JSONDecodeError: Failed to decode the package report JSON.
     """
-    npm_list = subprocess.run(
-        [executable, "list", "--all", "--json"],
-        check=True, text=True, capture_output=True,
-    )
+    # `npm list` exits non-zero for non-fatal conditions like `ELSPROBLEMS`, e.g.,
+    # a dependency declared in `package.json` is not present in `node_modules/`.
+    # In these cases, however, a JSON report is still produced, and we attempt to
+    # use it in spite of non-zero exit codes.
+    p = subprocess.run([executable, "list", "--all", "--json"], check=False, text=True, capture_output=True)
+    output = p.stdout.strip()
 
-    dependencies = json.loads(npm_list.stdout.strip()).get("dependencies", {})
+    # Raise only when `npm list` produces no usable output
+    if not output:
+        raise RuntimeError("npm returned no output during installed package discovery")
+    if p.returncode != 0:
+        _log.info("npm returned non-zero exit code during installed package discovery")
+
+    dependencies = json.loads(output).get("dependencies", {})
     if not isinstance(dependencies, dict):
         raise RuntimeError("Received malformed dependencies data from npm")
 

--- a/scfw/package_managers/npm/installed.py
+++ b/scfw/package_managers/npm/installed.py
@@ -43,7 +43,7 @@ def list_installed_packages(executable: str) -> list[Package]:
     if p.returncode != 0:
         _log.info("npm returned non-zero exit code during installed package discovery")
 
-    dependencies = json.loads(output).get("dependencies", {})
+    dependencies = json.loads(output).get("dependencies") or {}
     if not isinstance(dependencies, dict):
         raise RuntimeError("Received malformed dependencies data from npm")
 
@@ -91,7 +91,7 @@ def _dependencies_to_packages(
                 _log.info(f"No artifact source data found for installed dependency {name}")
 
             source: Optional[LocalPackageSource | RemotePackageSource] = None
-            if resolved.startswith("http"):
+            if resolved.startswith(("http", "git")):
                 source = RemotePackageSource(resolved)
             elif local_path is not None:
                 if local_path.exists():
@@ -128,6 +128,10 @@ def _load_lock_file_resolved_map(lock_file: Path) -> dict[tuple[str, str], str]:
             # Take the segment after the last `node_modules/` boundary
             if resolved and version:
                 name = key.rpartition(NODE_MODULES_PREFIX)[2]
+                # If the same (name, version) appears at multiple nesting depths with different
+                # resolved URLs (e.g. the same version on two registries), last write wins.
+                # This is unlikely in practice and not reliably fixable without physical path
+                # information that npm list --json does not expose.
                 result[(name, version)] = resolved
 
     return result

--- a/scfw/package_managers/npm/installed.py
+++ b/scfw/package_managers/npm/installed.py
@@ -76,7 +76,7 @@ def _dependencies_to_packages(
                 if resolved.startswith(FILE_URI_PREFIX) else None
             )
 
-            if (nested := package_data.get("dependencies")):
+            if (nested := package_data.get("dependencies", {})) and isinstance(nested, dict):
                 nested_fallback = resolved_fallback
                 if local_path is not None:
                     lock_file = local_path / "package-lock.json"
@@ -86,6 +86,9 @@ def _dependencies_to_packages(
                             **_load_lock_file_resolved_map(lock_file),
                         }
                 packages |= _dependencies_to_packages(nested, nested_fallback)
+
+            elif not isinstance(nested, dict):
+                _log.warning(f"Skipping malformed dependencies data for installed dependency {name}")
 
             if not resolved:
                 _log.info(f"No artifact source data found for installed dependency {name}")
@@ -117,9 +120,17 @@ def _load_lock_file_resolved_map(lock_file: Path) -> dict[tuple[str, str], str]:
         _log.debug(f"Could not read lock file {lock_file}: {e}")
         return {}
 
+    packages = data.get("packages", {})
+    if not isinstance(packages, dict):
+        _log.warning(f"Malformed packages data in lock file {lock_file}")
+        return {}
+
     result = {}
 
-    for key, pkg_data in data.get("packages", {}).items():
+    for key, pkg_data in packages.items():
+        if not isinstance(pkg_data, dict):
+            _log.warning(f"Malformed entry for {key!r} in lock file {lock_file}")
+            continue
         if key.startswith(NODE_MODULES_PREFIX):
             resolved = pkg_data.get("resolved", "")
             version = pkg_data.get("version", "")

--- a/scfw/package_managers/npm/installed.py
+++ b/scfw/package_managers/npm/installed.py
@@ -1,0 +1,125 @@
+"""
+Provides logic for listing installed npm packages in the active environment.
+"""
+
+import json
+import logging
+from pathlib import Path
+import subprocess
+from typing import Optional
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.package import LocalPackageSource, Package, RemotePackageSource
+from scfw.package_managers.npm.common import FILE_URI_PREFIX, NODE_MODULES_PREFIX
+
+_log = logging.getLogger(__name__)
+
+
+def list_installed_packages(executable: str) -> list[Package]:
+    """
+    List all npm packages installed in the active npm environment.
+
+    Args:
+        executable: Path to the npm executable.
+
+    Returns:
+        A `list[Package]` representing all npm packages installed in the active environment.
+
+    Raises:
+        RuntimeError: Received malformed dependencies data from npm.
+        subprocess.CalledProcessError: Failed to run `npm list`.
+        json.JSONDecodeError: Failed to decode the package report JSON.
+    """
+    npm_list = subprocess.run(
+        [executable, "list", "--all", "--json"],
+        check=True, text=True, capture_output=True,
+    )
+
+    dependencies = json.loads(npm_list.stdout.strip()).get("dependencies", {})
+    if not isinstance(dependencies, dict):
+        raise RuntimeError("Received malformed dependencies data from npm")
+
+    resolved_fallback = _load_lock_file_resolved_map(Path.cwd() / "package-lock.json")
+
+    return list(_dependencies_to_packages(dependencies, resolved_fallback))
+
+
+def _dependencies_to_packages(
+    dependencies: dict[str, dict],
+    resolved_fallback: dict[tuple[str, str], str],
+) -> set[Package]:
+    packages = set()
+
+    node_modules_path = Path.cwd() / "node_modules"
+
+    for name, package_data in dependencies.items():
+        try:
+            if not (version := package_data.get("version")):
+                # Skip the whole entry, including any `dependencies` subtree:
+                # npm list does not report children under an uninstalled parent
+                _log.debug(f"Skipping dependency {name}: not installed")
+                continue
+
+            resolved = package_data.get("resolved", "") or resolved_fallback.get((name, version), "")
+
+            # `file:` dependencies reported by `npm list` are relative to `node_modules/`
+            local_path = (
+                (node_modules_path / resolved[len(FILE_URI_PREFIX):]).resolve()
+                if resolved.startswith(FILE_URI_PREFIX) else None
+            )
+
+            if (nested := package_data.get("dependencies")):
+                nested_fallback = resolved_fallback
+                if local_path is not None:
+                    lock_file = local_path / "package-lock.json"
+                    if lock_file.is_file():
+                        nested_fallback = {
+                            **resolved_fallback,
+                            **_load_lock_file_resolved_map(lock_file),
+                        }
+                packages |= _dependencies_to_packages(nested, nested_fallback)
+
+            if not resolved:
+                _log.info(f"No artifact source data found for installed dependency {name}")
+
+            source: Optional[LocalPackageSource | RemotePackageSource] = None
+            if resolved.startswith("http"):
+                source = RemotePackageSource(resolved)
+            elif local_path is not None:
+                if local_path.exists():
+                    source = LocalPackageSource(local_path)
+                else:
+                    _log.warning(
+                        f"Could not resolve local source path for installed dependency {name}: "
+                        f"{local_path} does not exist"
+                    )
+
+            packages.add(Package(ECOSYSTEM.Npm, name, version, source=source))
+
+        except (AttributeError, TypeError, ValueError) as e:
+            _log.warning(f"Failed to resolve installed dependency {name}: {e}")
+
+    return packages
+
+
+def _load_lock_file_resolved_map(lock_file: Path) -> dict[tuple[str, str], str]:
+    try:
+        data = json.loads(lock_file.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        _log.debug(f"Could not read lock file {lock_file}: {e}")
+        return {}
+
+    result = {}
+
+    for key, pkg_data in data.get("packages", {}).items():
+        if key.startswith(NODE_MODULES_PREFIX):
+            resolved = pkg_data.get("resolved", "")
+            version = pkg_data.get("version", "")
+
+            # Nested (non-hoisted) entries look like `node_modules/<parent>/node_modules/<child>`
+            # Take the segment after the last `node_modules/` boundary
+            if resolved and version:
+                name = key.rpartition(NODE_MODULES_PREFIX)[2]
+                result[(name, version)] = resolved
+
+    return result

--- a/scfw/package_managers/npm/temp_project.py
+++ b/scfw/package_managers/npm/temp_project.py
@@ -21,6 +21,9 @@ _log = logging.getLogger(__name__)
 # URI scheme for npm local package dependencies
 FILE_URI_PREFIX = "file:"
 
+# Prefix for all installed-package entries in package-lock.json
+NODE_MODULES_PREFIX = "node_modules/"
+
 # Dependency sections present in npm package.json and package-lock.json files
 _DEPENDENCY_SECTIONS = {"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"}
 
@@ -70,6 +73,9 @@ class TemporaryNpmProject:
             absolute_path = (project_root / relative_path).resolve()
             return os.path.relpath(absolute_path, temp_dir_path.resolve())
 
+        def rewrite_file_uri(uri: str, project_root: Path, temp_dir_path: Path) -> str:
+            return f"{FILE_URI_PREFIX}{rewrite_relative_path(uri[len(FILE_URI_PREFIX):], project_root, temp_dir_path)}"
+
         def copy_package_json(project_root: Path, temp_dir_path: Path):
             orig_package_json = project_root / "package.json"
             if not orig_package_json.is_file():
@@ -86,12 +92,7 @@ class TemporaryNpmProject:
 
                 for name, spec in dependencies.items():
                     if isinstance(spec, str) and spec.startswith(FILE_URI_PREFIX):
-                        relative_target = rewrite_relative_path(
-                            spec[len(FILE_URI_PREFIX):],
-                            project_root,
-                            temp_dir_path,
-                        )
-                        dependencies[name] = f"{FILE_URI_PREFIX}{relative_target}"
+                        dependencies[name] = rewrite_file_uri(spec, project_root, temp_dir_path)
 
             with open(temp_dir_path / "package.json", 'w') as f:
                 json.dump(temp_content, f)
@@ -114,7 +115,7 @@ class TemporaryNpmProject:
             # External entry keys (anything other than "" or a `node_modules/...` path)
             # are paths to linked sources, relative to the original project root
             for old_key in list(packages.keys()):
-                if old_key == "" or old_key.startswith("node_modules/"):
+                if old_key == "" or old_key.startswith(NODE_MODULES_PREFIX):
                     continue
                 packages[rewrite_relative_path(old_key, project_root, temp_dir_path)] = packages.pop(old_key)
 
@@ -128,12 +129,7 @@ class TemporaryNpmProject:
                 resolved = entry.get("resolved")
                 if isinstance(resolved, str):
                     if resolved.startswith(FILE_URI_PREFIX):
-                        resolved = rewrite_relative_path(
-                            resolved[len(FILE_URI_PREFIX):],
-                            project_root,
-                            temp_dir_path,
-                        )
-                        entry["resolved"] = f"{FILE_URI_PREFIX}{resolved}"
+                        entry["resolved"] = rewrite_file_uri(resolved, project_root, temp_dir_path)
                     elif resolved.startswith(("./", "../")):
                         entry["resolved"] = rewrite_relative_path(resolved, project_root, temp_dir_path)
 
@@ -142,12 +138,7 @@ class TemporaryNpmProject:
                     if isinstance(dependencies, dict):
                         for name, spec in dependencies.items():
                             if isinstance(spec, str) and spec.startswith(FILE_URI_PREFIX):
-                                spec = rewrite_relative_path(
-                                    spec[len(FILE_URI_PREFIX):],
-                                    project_root,
-                                    temp_dir_path,
-                                )
-                                dependencies[name] = f"{FILE_URI_PREFIX}{spec}"
+                                dependencies[name] = rewrite_file_uri(spec, project_root, temp_dir_path)
 
             with open(temp_lockfile, 'w') as f:
                 json.dump(temp_content, f)
@@ -290,7 +281,16 @@ class TemporaryNpmProject:
         ) -> Package:
             if not target_name:
                 # All supported npm versions adhere to this format
-                target_name = target_handle.rpartition("node_modules/")[2]
+                target_name = target_handle.rpartition(NODE_MODULES_PREFIX)[2]
+
+            def resolve_local_source(rel: str) -> Optional[LocalPackageSource]:
+                try:
+                    return LocalPackageSource((temp_dir_path / rel).resolve(strict=True))
+                except (OSError, RuntimeError) as e:
+                    _log.warning(
+                        f"Could not resolve local source path for installation target {target_name}: {e}"
+                    )
+                    return None
 
             if not (target_entry := dependencies.get(target_handle)):
                 raise KeyError(
@@ -306,14 +306,9 @@ class TemporaryNpmProject:
                         resolved_handle = resolved_handle[len(FILE_URI_PREFIX):]
                     # `copy_lockfile` rewrites link keys so that `temp_dir_path / resolved_handle`
                     # resolves back to the original local package on the user's filesystem
-                    link_source = None
-                    try:
-                        link_source = LocalPackageSource((temp_dir_path / resolved_handle).resolve(strict=True))
-                    except (OSError, RuntimeError) as e:
-                        _log.warning(
-                            f"Could not resolve local source path for installation target {target_name}: {e}"
-                        )
-                    return handle_to_install_target(dependencies, resolved_handle, target_name, link_source)
+                    return handle_to_install_target(
+                        dependencies, resolved_handle, target_name, resolve_local_source(resolved_handle)
+                    )
 
                 raise KeyError(
                     f"Missing version data for installation target {target_name} in package-lock.json"
@@ -324,14 +319,7 @@ class TemporaryNpmProject:
                 if resolved.startswith("http"):
                     target_source = RemotePackageSource(resolved)
                 elif resolved.startswith(FILE_URI_PREFIX):
-                    try:
-                        target_source = LocalPackageSource(
-                            (temp_dir_path / resolved[len(FILE_URI_PREFIX):]).resolve(strict=True)
-                        )
-                    except (OSError, RuntimeError) as e:
-                        _log.warning(
-                            f"Could not resolve local source path for installation target {target_name}: {e}"
-                        )
+                    target_source = resolve_local_source(resolved[len(FILE_URI_PREFIX):])
 
             return Package(ECOSYSTEM.Npm, target_name, version, source=target_source)
 

--- a/scfw/package_managers/npm/temp_project.py
+++ b/scfw/package_managers/npm/temp_project.py
@@ -311,7 +311,7 @@ class TemporaryNpmProject:
 
             # Derive source from this entry's `resolved` field unless a caller already supplied one
             if target_source is None and (resolved := target_entry.get("resolved")):
-                if resolved.startswith("http"):
+                if resolved.startswith(("http", "git")):
                     target_source = RemotePackageSource(resolved)
                 elif resolved.startswith(FILE_URI_PREFIX):
                     target_source = resolve_local_source(resolved[len(FILE_URI_PREFIX):])

--- a/scfw/package_managers/npm/temp_project.py
+++ b/scfw/package_managers/npm/temp_project.py
@@ -15,14 +15,9 @@ from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import LocalPackageSource, Package, RemotePackageSource
+from scfw.package_managers.npm.common import FILE_URI_PREFIX, NODE_MODULES_PREFIX
 
 _log = logging.getLogger(__name__)
-
-# URI scheme for npm local package dependencies
-FILE_URI_PREFIX = "file:"
-
-# Prefix for all installed-package entries in package-lock.json
-NODE_MODULES_PREFIX = "node_modules/"
 
 # Dependency sections present in npm package.json and package-lock.json files
 _DEPENDENCY_SECTIONS = {"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"}

--- a/tests/package_managers/test_npm_class.py
+++ b/tests/package_managers/test_npm_class.py
@@ -453,7 +453,7 @@ def test_list_installed_packages_uses_root_lockfile_for_missing_resolved(monkeyp
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
@@ -502,7 +502,7 @@ def test_list_installed_packages_uses_root_lockfile_for_non_hoisted_packages(mon
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
@@ -551,7 +551,7 @@ def test_list_installed_packages_uses_local_dep_lockfile_for_transitive_packages
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
@@ -580,7 +580,7 @@ def test_list_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tm
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
@@ -611,7 +611,7 @@ def test_list_installed_packages_keeps_dep_with_missing_local_source(monkeypatch
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
@@ -645,7 +645,7 @@ def test_list_installed_packages_skips_malformed_entries(monkeypatch, tmp_path):
         stderr = ""
         returncode = 0
 
-    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(npm.installed.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 

--- a/tests/package_managers/test_npm_class.py
+++ b/tests/package_managers/test_npm_class.py
@@ -353,12 +353,14 @@ def test_list_installed_packages_new_npm_project(monkeypatch, new_npm_project):
 def test_list_installed_packages_dependency_latest(monkeypatch, npm_project_dependency_latest):
     """
     Test that `Npm` correctly identifies installed packages in a new npm project
-    with an uninstalled dependency.
+    with an uninstalled dependency. `npm list` exits non-zero with ELSPROBLEMS in
+    this case, but the JSON report it writes to stdout is still consumed, and the
+    declared-but-uninstalled dependency is reported as not installed.
     """
     backend_test_list_installed_packages(
         monkeypatch,
         npm_project_dependency_latest,
-        should_fail=True,
+        should_fail=False,
         installed=set(),
     )
 
@@ -369,12 +371,13 @@ def test_list_installed_packages_dependency_latest_lockfile(
 ):
     """
     Test that `Npm` correctly identifies installed packages in a new npm project
-    with an uninstalled dependency and a lockfile.
+    with an uninstalled dependency and a lockfile. As above, `npm list` exits
+    non-zero but its JSON report is still consumed.
     """
     backend_test_list_installed_packages(
         monkeypatch,
         npm_project_dependency_latest_lockfile,
-        should_fail=True,
+        should_fail=False,
         installed=set(),
     )
 
@@ -447,6 +450,8 @@ def test_list_installed_packages_uses_root_lockfile_for_missing_resolved(monkeyp
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
@@ -494,6 +499,8 @@ def test_list_installed_packages_uses_root_lockfile_for_non_hoisted_packages(mon
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
@@ -541,6 +548,8 @@ def test_list_installed_packages_uses_local_dep_lockfile_for_transitive_packages
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
@@ -568,6 +577,8 @@ def test_list_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tm
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
@@ -597,6 +608,8 @@ def test_list_installed_packages_keeps_dep_with_missing_local_source(monkeypatch
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
@@ -629,6 +642,8 @@ def test_list_installed_packages_skips_malformed_entries(monkeypatch, tmp_path):
 
     class FakeCompletedProcess:
         stdout = npm_list_output
+        stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)

--- a/tests/package_managers/test_npm_class.py
+++ b/tests/package_managers/test_npm_class.py
@@ -3,6 +3,7 @@ Tests of `Npm`, the `PackageManager` subclass.
 """
 
 import json
+import logging
 from pathlib import Path
 import subprocess
 from typing import Optional
@@ -416,6 +417,167 @@ def test_list_installed_packages_local_dependency_installed(
             ),
         },
     )
+
+
+def test_list_installed_packages_uses_root_lockfile_for_missing_resolved(monkeypatch, tmp_path):
+    """
+    When `npm list` omits `resolved` for a deduped package but the root
+    package-lock.json has it, list_installed_packages populates source from
+    the lock file instead of leaving it None.
+    """
+    resolved_url = "https://registry.npmjs.org/deduped-pkg/-/deduped-pkg-1.0.0.tgz"
+    npm_list_output = json.dumps({
+        "dependencies": {
+            "parent-pkg": {
+                "version": "2.0.0",
+                "resolved": "https://registry.npmjs.org/parent-pkg/-/parent-pkg-2.0.0.tgz",
+                "dependencies": {
+                    "deduped-pkg": {"version": "1.0.0"},
+                },
+            },
+        },
+    })
+    lock_file_content = json.dumps({
+        "lockfileVersion": 3,
+        "packages": {
+            "node_modules/deduped-pkg": {"version": "1.0.0", "resolved": resolved_url},
+        },
+    })
+    (tmp_path / "package-lock.json").write_text(lock_file_content)
+
+    class FakeCompletedProcess:
+        stdout = npm_list_output
+
+    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    packages = PACKAGE_MANAGER.list_installed_packages()
+
+    assert Package(
+        ECOSYSTEM.Npm, "deduped-pkg", "1.0.0", source=RemotePackageSource(resolved_url)
+    ) in set(packages)
+
+
+def test_list_installed_packages_uses_root_lockfile_for_non_hoisted_packages(monkeypatch, tmp_path):
+    """
+    When a transitive dep can't be hoisted (version conflict with a top-level dep),
+    the lock file records it under `node_modules/<parent>/node_modules/<child>`.
+    The fallback map must still resolve `<child>` from such an entry.
+    """
+    nested_url = "https://registry.npmjs.org/conflict-pkg/-/conflict-pkg-2.0.0.tgz"
+    npm_list_output = json.dumps({
+        "dependencies": {
+            "parent-pkg": {
+                "version": "1.0.0",
+                "resolved": "https://registry.npmjs.org/parent-pkg/-/parent-pkg-1.0.0.tgz",
+                "dependencies": {
+                    "conflict-pkg": {"version": "2.0.0"},
+                },
+            },
+        },
+    })
+    lock_file_content = json.dumps({
+        "lockfileVersion": 3,
+        "packages": {
+            "node_modules/conflict-pkg": {
+                "version": "1.0.0",
+                "resolved": "https://registry.npmjs.org/conflict-pkg/-/conflict-pkg-1.0.0.tgz",
+            },
+            "node_modules/parent-pkg/node_modules/conflict-pkg": {
+                "version": "2.0.0",
+                "resolved": nested_url,
+            },
+        },
+    })
+    (tmp_path / "package-lock.json").write_text(lock_file_content)
+
+    class FakeCompletedProcess:
+        stdout = npm_list_output
+
+    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    packages = PACKAGE_MANAGER.list_installed_packages()
+
+    assert Package(
+        ECOSYSTEM.Npm, "conflict-pkg", "2.0.0", source=RemotePackageSource(nested_url)
+    ) in set(packages)
+
+
+def test_list_installed_packages_uses_local_dep_lockfile_for_transitive_packages(
+    monkeypatch, tmp_path
+):
+    """
+    When a local file: dependency's transitive packages lack `resolved` in
+    `npm list` output, list_installed_packages uses the local package's own
+    package-lock.json to populate source.
+    """
+    transitive_url = "https://registry.npmjs.org/transitive-pkg/-/transitive-pkg-3.0.0.tgz"
+
+    node_modules_dir = tmp_path / "node_modules"
+    node_modules_dir.mkdir()
+    local_pkg_dir = tmp_path / "my-local-pkg"
+    local_pkg_dir.mkdir()
+    (local_pkg_dir / "package-lock.json").write_text(json.dumps({
+        "lockfileVersion": 3,
+        "packages": {
+            "node_modules/transitive-pkg": {"version": "3.0.0", "resolved": transitive_url},
+        },
+    }))
+
+    npm_list_output = json.dumps({
+        "dependencies": {
+            "my-local-pkg": {
+                "version": "1.0.0",
+                "resolved": "file:../my-local-pkg",
+                "dependencies": {
+                    "transitive-pkg": {"version": "3.0.0"},
+                },
+            },
+        },
+    })
+
+    class FakeCompletedProcess:
+        stdout = npm_list_output
+
+    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    packages = PACKAGE_MANAGER.list_installed_packages()
+
+    assert Package(
+        ECOSYSTEM.Npm, "transitive-pkg", "3.0.0", source=RemotePackageSource(transitive_url)
+    ) in set(packages)
+
+
+def test_list_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tmp_path, caplog):
+    """
+    Dependencies that appear in `npm list` with no version field (e.g. uninstalled
+    optional peer deps) are silently skipped — no WARNING is emitted.
+    """
+    good_url = "https://registry.npmjs.org/good-package/-/good-package-1.2.3.tgz"
+    npm_list_output = json.dumps({
+        "dependencies": {
+            "good-package": {"version": "1.2.3", "resolved": good_url},
+            "uninstalled-peer": {},
+        },
+    })
+
+    class FakeCompletedProcess:
+        stdout = npm_list_output
+
+    monkeypatch.setattr(npm.subprocess, "run", lambda *args, **kwargs: FakeCompletedProcess())
+    monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="scfw.package_managers.npm"):
+        packages = PACKAGE_MANAGER.list_installed_packages()
+
+    assert set(packages) == {Package(ECOSYSTEM.Npm, "good-package", "1.2.3", source=RemotePackageSource(good_url))}
+    assert not any("uninstalled-peer" in r.message for r in caplog.records if r.levelno >= logging.WARNING)
 
 
 def test_list_installed_packages_keeps_dep_with_missing_local_source(monkeypatch, tmp_path):


### PR DESCRIPTION
This PR closes two gaps in the `scfw audit npm` implementation in which package artifact source data was not always being reported to verifiers for transitive dependencies or in cases of incomplete installation.

## Problem

`npm list --json` sometimes omits the `resolved` field for deduped or non-hoisted transitive dependencies, leaving those packages without source attribution.

Additionally, `npm list` exits non-zero for non-fatal conditions (e.g. `ELSPROBLEMS`) even when it produces a usable JSON report, causing the old `check=True` call to raise unnecessarily.

## Changes

- Extract installed package listing logic into a new `npm/installed.py` module, and shared constants (`FILE_URI_PREFIX`, `NODE_MODULES_PREFIX`) into `npm/common.py`.
- Fix the `npm list` exit code bug: use `check=False` and only raise if no output was produced at all.
- When `npm list` omits `resolved` for a package, fall back to the root `package-lock.json` to populate it. Non-hoisted entries (e.g. `node_modules/<parent>/node_modules/<child>`) are handled correctly.
- When traversing a `file:` local dependency's subtree, also consult that dependency's own `package-lock.json` as a nested fallback.
- Extend source detection to `git`-prefixed URLs in both `installed.py` and `temp_project.py`.
- Guard against malformed dependencies and packages fields in `npm list` output and lockfiles — log a warning and skip rather than raising and dropping valid packages.
- Uninstalled dependencies (no version field in `npm list` output) are silently skipped at `DEBUG` level.

## Tests

Added tests covering: root lockfile fallback for deduped packages, non-hoisted nested lockfile entries, local-dep lockfile for transitive packages, and silent skipping of uninstalled dependencies.