### PR TITLE
[SECRES-5203] Add package artifact source data during pip audit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pip-version: ["22.2", "22.3", "23.0", "23.1", "23.2", "23.3", "24.0", "24.1", "24.2", "24.3", "25.0", "25.1", "25.2", "25.3", "26.0"]
+        pip-version: ["22.2", "22.3", "23.0", "23.1", "23.2", "23.3", "24.0", "24.1", "24.2", "24.3", "25.0", "25.1", "25.2", "25.3", "26.0", "26.1"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Python 3.10
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        poetry-version: ["1.7.0", "1.8.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0"]
+        poetry-version: ["1.7.0", "1.8.0", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Python 3.10
@@ -288,6 +288,16 @@ jobs:
             npm-version: "11.11"
           - node-version: "22.9.0"
             npm-version: "11.12"
+          - node-version: "22.9.0"
+            npm-version: "11.13"
+          - node-version: "22.9.0"
+            npm-version: "11.14"
+          - node-version: "22.9.0"
+            npm-version: "11.15"
+          - node-version: "22.9.0"
+            npm-version: "11.16"
+          - node-version: "22.9.0"
+            npm-version: "11.17"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Python 3.10

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -50,7 +50,7 @@ class ECOSYSTEM(Enum):
 
         Returns:
             A `set[str]` containing the URL domains for the given package ecosystem,
-            those from which package artifacts are known to be sourced.
+            those associated with the ecosystem's main package registry.
         """
         match self:
             case ECOSYSTEM.Npm:

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -60,4 +60,5 @@ class ECOSYSTEM(Enum):
             case ECOSYSTEM.PyPI:
                 return {
                     "files.pythonhosted.org",
+                    "pypi.org",
                 }

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -125,13 +125,7 @@ class Pip(PackageManager):
             if not (download_info := install_report.get("download_info")) or not (url := download_info.get("url")):
                 return Package(ECOSYSTEM.PyPI, name, version)
 
-            source: Optional[LocalPackageSource | RemotePackageSource] = None
-            if url.startswith("http"):
-                source = RemotePackageSource(url)
-            elif url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
-                source = LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
-
-            return Package(ECOSYSTEM.PyPI, name, version, source=source)
+            return Package(ECOSYSTEM.PyPI, name, version, source=_url_to_package_source(url))
 
         command = self._normalize_command(command)
 
@@ -181,19 +175,18 @@ class Pip(PackageManager):
             # present for non-PyPI installs (local directories, direct URLs, VCS) and absent for
             # PyPI installs. It is also absent for locally-installed packages on pip < 23.1 whose
             # projects do not define a `pyproject.toml`, as those are installed via the legacy
-            # `setup.py install` path that predates PEP 610. We return `source=None` in this case.
+            # `setup.py install` path that predates PEP 610. We cannot distinguish these two cases,
+            # so we treat both as PyPI registry installs.
             source: Optional[LocalPackageSource | RemotePackageSource] = None
             if direct_url := entry.get("direct_url"):
-                url = direct_url.get("url", "")
-                if url.startswith("http"):
-                    source = RemotePackageSource(url)
-                elif url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
-                    source = LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
+                source = _url_to_package_source(direct_url.get("url", ""))
             else:
-                # PyPI registry installs lack a direct_url entry (PEP 610). We use the
-                # canonical project page URL as a stand-in for the registry source. This
-                # URL resolves to a human-readable page, not a downloadable artifact, so
-                # callers must not treat it as a direct artifact link.
+                # Both standard PyPI registry installs and legacy `setup.py install` packages
+                # (pip < 23.1, no pyproject.toml) lack a direct_url entry and are indistinguishable
+                # here. We use the canonical project page URL as a stand-in. This URL resolves to a
+                # human-readable page, not a downloadable artifact, so callers must not treat it as
+                # a direct artifact link.
+                _log.debug(f"No direct_url for {name}=={version}; assuming PyPI registry install")
                 source = RemotePackageSource(f"{_PYPI_PROJECT_BASE_URL}/{name}/{version}/")
 
             return Package(ECOSYSTEM.PyPI, name, version, source=source)
@@ -263,3 +256,13 @@ class Pip(PackageManager):
             raise ValueError("Received invalid pip command line")
 
         return [self._executable] + command[1:]
+
+
+def _url_to_package_source(url: str) -> Optional[LocalPackageSource | RemotePackageSource]:
+    if url.startswith(("http", "git")):
+        return RemotePackageSource(url)
+
+    if url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
+        return LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
+
+    return None

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -185,9 +185,10 @@ class Pip(PackageManager):
                         f"Missing or unrecognized URL in artifact source entry for {name}-{version}"
                     )
             else:
-                # Both standard PyPI registry installs and legacy `setup.py install` packages
-                # (pip < 23.1, no pyproject.toml) lack a direct_url entry and are indistinguishable
-                # here. We use the canonical project page URL as a stand-in. This URL resolves to a
+                # In the case of a PyPI install, reconstructing the precise artifact download link
+                # is not possible with the locally available data and would therefore require at
+                # least one network request and some complicated logic related to identifying wheels.
+                # Instead, we use the canonical project page URL as a stand-in. This URL resolves to a
                 # human-readable page, not a downloadable artifact, so callers must not treat it as
                 # a direct artifact link.
                 _log.debug(f"No artifact source data available for {name}-{version}: assuming PyPI source")

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -168,17 +168,39 @@ class Pip(PackageManager):
 
         Raises:
             RuntimeError: Failed to list installed packages or decode report JSON.
-            ValueError: Encountered a malformed report for an installed package.
             UnsupportedVersionError: The underlying `pip` executable is of an unsupported version.
         """
+        def inspect_entry_to_package(entry: dict) -> Optional[Package]:
+            metadata = entry.get("metadata", {})
+            if not (name := metadata.get("name")) or not (version := metadata.get("version")):
+                _log.warning("Skipping installed package with missing name or version")
+                return None
+
+            # The `direct_url` field (PEP 610) used to discover package artifact source data is
+            # present for non-PyPI installs (local directories, direct URLs, VCS) and absent for
+            # PyPI installs. It is also absent for locally-installed packages on pip < 23.1 whose
+            # projects do not define a `pyproject.toml`, as those are installed via the legacy
+            # `setup.py install` path that predates PEP 610. We return `source=None` in this case.
+            source: Optional[LocalPackageSource | RemotePackageSource] = None
+            if direct_url := entry.get("direct_url"):
+                url = direct_url.get("url", "")
+                if url.startswith("http"):
+                    source = RemotePackageSource(url)
+                elif url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
+                    source = LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
+            else:
+                _log.info(f"No artifact source data found for installed package {name}")
+
+            return Package(ECOSYSTEM.PyPI, name, version, source=source)
+
         self._check_version()
 
         try:
-            pip_list_command = self._normalize_command(["pip", "list", "--format", "json"])
-            pip_list = subprocess.run(pip_list_command, check=True, text=True, capture_output=True)
+            pip_inspect_command = self._normalize_command(["pip", "inspect"])
+            pip_inspect = subprocess.run(pip_inspect_command, check=True, text=True, capture_output=True)
             return [
-                Package(ECOSYSTEM.PyPI, package["name"], package["version"])
-                for package in json.loads(pip_list.stdout.strip())
+                p for entry in json.loads(pip_inspect.stdout).get("installed", [])
+                if (p := inspect_entry_to_package(entry)) is not None
             ]
 
         except subprocess.CalledProcessError:
@@ -186,9 +208,6 @@ class Pip(PackageManager):
 
         except json.JSONDecodeError:
             raise RuntimeError("Failed to decode installed package report JSON")
-
-        except KeyError:
-            raise ValueError("Malformed installed package report")
 
     def _check_version(self):
         """

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -186,7 +186,7 @@ class Pip(PackageManager):
                 # here. We use the canonical project page URL as a stand-in. This URL resolves to a
                 # human-readable page, not a downloadable artifact, so callers must not treat it as
                 # a direct artifact link.
-                _log.debug(f"No direct_url for {name}=={version}; assuming PyPI registry install")
+                _log.info(f"No artifact source data available for {name}-{version}: assuming PyPI source")
                 source = RemotePackageSource(f"{_PYPI_PROJECT_BASE_URL}/{name}/{version}/")
 
             return Package(ECOSYSTEM.PyPI, name, version, source=source)

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -19,6 +19,7 @@ from scfw.package_manager import PackageManager, UnsupportedVersionError
 _log = logging.getLogger(__name__)
 
 _LOCAL_PACKAGE_SOURCE_PREFIX = "file://"
+_PYPI_PROJECT_BASE_URL = "https://pypi.org/project"
 
 MIN_PIP_VERSION = version_parse("22.2")
 
@@ -189,7 +190,11 @@ class Pip(PackageManager):
                 elif url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
                     source = LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
             else:
-                _log.info(f"No artifact source data found for installed package {name}")
+                # PyPI registry installs lack a direct_url entry (PEP 610). We use the
+                # canonical project page URL as a stand-in for the registry source. This
+                # URL resolves to a human-readable page, not a downloadable artifact, so
+                # callers must not treat it as a direct artifact link.
+                source = RemotePackageSource(f"{_PYPI_PROJECT_BASE_URL}/{name}/{version}/")
 
             return Package(ECOSYSTEM.PyPI, name, version, source=source)
 

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -180,13 +180,17 @@ class Pip(PackageManager):
             source: Optional[LocalPackageSource | RemotePackageSource] = None
             if direct_url := entry.get("direct_url"):
                 source = _url_to_package_source(direct_url.get("url", ""))
+                if source is None:
+                    _log.warning(
+                        f"Missing or unrecognized URL in artifact source entry for {name}-{version}"
+                    )
             else:
                 # Both standard PyPI registry installs and legacy `setup.py install` packages
                 # (pip < 23.1, no pyproject.toml) lack a direct_url entry and are indistinguishable
                 # here. We use the canonical project page URL as a stand-in. This URL resolves to a
                 # human-readable page, not a downloadable artifact, so callers must not treat it as
                 # a direct artifact link.
-                _log.info(f"No artifact source data available for {name}-{version}: assuming PyPI source")
+                _log.debug(f"No artifact source data available for {name}-{version}: assuming PyPI source")
                 source = RemotePackageSource(f"{_PYPI_PROJECT_BASE_URL}/{name}/{version}/")
 
             return Package(ECOSYSTEM.PyPI, name, version, source=source)
@@ -259,10 +263,10 @@ class Pip(PackageManager):
 
 
 def _url_to_package_source(url: str) -> Optional[LocalPackageSource | RemotePackageSource]:
-    if url.startswith(("http", "git")):
-        return RemotePackageSource(url)
-
     if url.startswith(_LOCAL_PACKAGE_SOURCE_PREFIX):
         return LocalPackageSource(Path(url[len(_LOCAL_PACKAGE_SOURCE_PREFIX):]))
+
+    if url:
+        return RemotePackageSource(url)
 
     return None

--- a/tests/package_managers/pip_fixtures.py
+++ b/tests/package_managers/pip_fixtures.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import subprocess
 import sys
 from tempfile import TemporaryDirectory
+import textwrap
 from typing import Optional
 
 import pytest
@@ -153,9 +154,6 @@ def init_pip_project(
     project_dir = parent / package_name
     project_dir.mkdir()
 
-    venv_dir = project_dir / "venv"
-    subprocess.run([sys.executable, "-m", "venv", venv_dir], check=True)
-
     source_dir = project_dir / package_name
     source_dir.mkdir()
     (source_dir / "__init__.py").touch()
@@ -164,8 +162,16 @@ def init_pip_project(
     with open(pyproject_path, 'w') as f:
         f.write(generate_pyproject_toml(package_name, package_version, dependencies))
 
+    venv_dir = project_dir / "venv"
+    subprocess.run([sys.executable, "-m", "venv", venv_dir], check=True)
+
+    # Ensure the venv pip is the same version as the system pip
+    venv_pip = venv_dir / "bin" / "pip"
+    subprocess.run(
+        [venv_pip, "install", f"pip=={get_system_pip_version()}"], check=True,
+    )
+
     if installed:
-        venv_pip = venv_dir / "bin" / "pip"
         subprocess.run([venv_pip, "install", project_dir], check=True)
 
     return project_dir
@@ -199,13 +205,27 @@ def generate_pyproject_toml(
 
     dependencies_toml = f"dependencies = [{', '.join(dependency_specs)}]" if dependency_specs else ""
 
-    return f"""\
-    [build-system]
-    requires = ["setuptools"]
-    build-backend = "setuptools.build_meta"
+    return textwrap.dedent(
+        f"""\
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
 
-    [project]
-    name = "{package_name}"
-    version = "{package_version}"
-    {dependencies_toml}\
-    """
+            [project]
+            name = "{package_name}"
+            version = "{package_version}"
+            {dependencies_toml}\
+        """
+    )
+
+
+def get_system_pip_version() -> str:
+    p = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    # All supported versions adhere to this format
+    return p.stdout.strip().split()[1]

--- a/tests/package_managers/pip_fixtures.py
+++ b/tests/package_managers/pip_fixtures.py
@@ -3,42 +3,209 @@ Provides a collection of common fixtures for the pip tests.
 """
 
 from pathlib import Path
+import subprocess
+import sys
 from tempfile import TemporaryDirectory
+from typing import Optional
 
 import pytest
 
-LOCAL_PACKAGE_NAME = "foo"
-LOCAL_PACKAGE_VERSION = "0.1.0"
+TEST_PACKAGE_NAME = "foo"
+TEST_PACKAGE_VERSION = "0.1.0"
 
-LOCAL_PACKAGE_SETUP_FILE = f"""\
-from setuptools import setup, find_packages
+REMOTE_PACKAGE_NAME = "tree-sitter"
+REMOTE_PACKAGE_VERSION = "0.23.2"
 
-setup(
-    name='{LOCAL_PACKAGE_NAME}',
-    version='{LOCAL_PACKAGE_VERSION}',
-    packages=find_packages(),
-)
-"""
+LOCAL_PACKAGE_NAME = "bar"
+LOCAL_PACKAGE_VERSION = "1.0.0"
 
 
 @pytest.fixture
-def local_python_package():
+def new_pip_project():
+    """
+    Initialize a new `pip` project.
+    """
     tempdir = TemporaryDirectory()
     tempdir_path = Path(tempdir.name)
 
-    # Create a minimally installable local Python package
-    local_package_dir = tempdir_path / LOCAL_PACKAGE_NAME
-    local_package_dir.mkdir()
-
-    source_dir = local_package_dir / LOCAL_PACKAGE_NAME
-    source_dir.mkdir()
-    init_file_path = source_dir / "__init__.py"
-    init_file_path.touch()
-
-    setup_file = local_package_dir / "setup.py"
-    with open(setup_file, 'w') as f:
-        f.write(LOCAL_PACKAGE_SETUP_FILE)
-
-    yield local_package_dir
+    yield init_pip_project(tempdir_path, TEST_PACKAGE_NAME, TEST_PACKAGE_VERSION)
 
     tempdir.cleanup()
+
+
+@pytest.fixture
+def new_pip_project_installed():
+    """
+    Initialize and install a new `pip` project.
+    """
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    yield init_pip_project(tempdir_path, TEST_PACKAGE_NAME, TEST_PACKAGE_VERSION, installed=True)
+
+    tempdir.cleanup()
+
+
+@pytest.fixture
+def pip_project_remote_dependency():
+    """
+    Initialize a new `pip` project with a remote dependency from PyPI.
+    """
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    yield init_pip_project(
+        tempdir_path,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        dependencies=[(REMOTE_PACKAGE_NAME, REMOTE_PACKAGE_VERSION)],
+    )
+
+    tempdir.cleanup()
+
+
+@pytest.fixture
+def pip_project_remote_dependency_installed():
+    """
+    Initialize and install a new `pip` project with a remote dependency from PyPI.
+    """
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    yield init_pip_project(
+        tempdir_path,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        dependencies=[(REMOTE_PACKAGE_NAME, REMOTE_PACKAGE_VERSION)],
+        installed=True,
+    )
+
+    tempdir.cleanup()
+
+
+@pytest.fixture
+def pip_project_local_dependency():
+    """
+    Initialize a new `pip` project with a local dependency.
+    """
+    local_dependency_tempdir = TemporaryDirectory()
+    local_dependency_tempdir_path = Path(local_dependency_tempdir.name)
+
+    local_dependency_path = init_pip_project(
+        local_dependency_tempdir_path,
+        LOCAL_PACKAGE_NAME,
+        LOCAL_PACKAGE_VERSION,
+    )
+
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    yield init_pip_project(
+        tempdir_path,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        dependencies=[(LOCAL_PACKAGE_NAME, local_dependency_path)],
+    )
+
+    tempdir.cleanup()
+    local_dependency_tempdir.cleanup()
+
+
+@pytest.fixture
+def pip_project_local_dependency_installed():
+    """
+    Initialize and install a new `pip` project with a local dependency.
+    """
+    local_dependency_tempdir = TemporaryDirectory()
+    local_dependency_tempdir_path = Path(local_dependency_tempdir.name)
+
+    local_dependency_path = init_pip_project(
+        local_dependency_tempdir_path,
+        LOCAL_PACKAGE_NAME,
+        LOCAL_PACKAGE_VERSION,
+    )
+
+    tempdir = TemporaryDirectory()
+    tempdir_path = Path(tempdir.name)
+
+    yield init_pip_project(
+        tempdir_path,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        dependencies=[(LOCAL_PACKAGE_NAME, local_dependency_path)],
+        installed=True,
+    )
+
+    tempdir.cleanup()
+    local_dependency_tempdir.cleanup()
+
+
+def init_pip_project(
+    parent: Path,
+    package_name: str,
+    package_version: str,
+    dependencies: Optional[list[tuple[str, str] | tuple[str, Path]]] = None,
+    installed: bool = False,
+) -> Path:
+    """
+    Initialize a new `pip` project in the given directory and with the given parameters.
+    """
+    project_dir = parent / package_name
+    project_dir.mkdir()
+
+    venv_dir = project_dir / "venv"
+    subprocess.run([sys.executable, "-m", "venv", venv_dir], check=True)
+
+    source_dir = project_dir / package_name
+    source_dir.mkdir()
+    (source_dir / "__init__.py").touch()
+
+    pyproject_path = project_dir / "pyproject.toml"
+    with open(pyproject_path, 'w') as f:
+        f.write(generate_pyproject_toml(package_name, package_version, dependencies))
+
+    if installed:
+        venv_pip = venv_dir / "bin" / "pip"
+        subprocess.run([venv_pip, "install", project_dir], check=True)
+
+    return project_dir
+
+
+def generate_pyproject_toml(
+    package_name: str,
+    package_version: str,
+    dependencies: Optional[list[tuple[str, str] | tuple[str, Path]]] = None
+) -> str:
+    """
+    Generate `pyproject.toml` content from the given parameters.
+    """
+    dependency_specs = []
+    for dependency in dependencies or []:
+        if not (isinstance(dependency, tuple) and len(dependency) == 2):
+            raise ValueError(f"Invalid test dependency specification: {dependency}")
+
+        package, spec = dependency
+        if not isinstance(package, str):
+            raise ValueError(f"Invalid test dependency specification package component: {package}")
+
+        # Dependency sourced from PyPI
+        if isinstance(spec, str):
+            dependency_specs.append(f'"{package}=={spec}"')
+        # Dependency sourced from local directory
+        elif isinstance(spec, Path):
+            dependency_specs.append(f'"{package} @ file://{spec}"')
+        else:
+            raise ValueError(f"Invalid test dependency specification spec component: {spec}")
+
+    dependencies_toml = f"dependencies = [{', '.join(dependency_specs)}]" if dependency_specs else ""
+
+    return f"""\
+    [build-system]
+    requires = ["setuptools"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "{package_name}"
+    version = "{package_version}"
+    {dependencies_toml}\
+    """

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -14,9 +14,6 @@ import pytest
 
 from .pip_fixtures import *
 
-_INSPECT_PACKAGE_NAME = "tree-sitter"
-_INSPECT_PACKAGE_VERSION = "0.24.0"
-
 PIP_COMMAND_PREFIX = [sys.executable, "-m", "pip"]
 
 
@@ -270,10 +267,9 @@ def test_pip_inspect_matches_pip_list_pip_project_local_dependency_installed(pip
 def test_pip_inspect_registry_package_no_direct_url(pip_project_remote_dependency_installed):
     """
     Test that a package installed from the PyPI registry has no `direct_url` entry in
-    `pip inspect` output. The implementation logs "No artifact source data found" and
-    sets `source=None` when `direct_url` is absent, treating absence as a registry install.
-    This also covers the case of packages installed by non-pip tools, which similarly
-    lack `direct_url`.
+    `pip inspect` output. When `direct_url` is absent, `Pip.list_installed_packages`
+    treats this as a registry install and uses the canonical PyPI project page URL as a
+    stand-in `RemotePackageSource`.
     """
     venv_pip = pip_project_remote_dependency_installed / "venv" / "bin" / "pip"
 

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -14,6 +14,9 @@ import pytest
 
 from .pip_fixtures import *
 
+_INSPECT_PACKAGE_NAME = "tree-sitter"
+_INSPECT_PACKAGE_VERSION = "0.24.0"
+
 PIP_COMMAND_PREFIX = [sys.executable, "-m", "pip"]
 
 
@@ -155,15 +158,15 @@ def test_pip_install_report_override():
         assert tmpfile.read() == b''
 
 
-def test_pip_install_report_format_local(local_python_package):
+def test_pip_install_report_format_local(new_pip_project):
     """
     Test that the dry-run report has the expected format for a local package target.
     """
     _test_pip_install_report_format(
-        str(local_python_package),
-        LOCAL_PACKAGE_NAME,
-        LOCAL_PACKAGE_VERSION,
-        local_python_package
+        str(new_pip_project),
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        new_pip_project,
     )
 
 
@@ -216,3 +219,132 @@ def _test_pip_install_report_format(
         assert url == f"file://{local_package_source}"
     else:
         assert url.startswith("https://files.pythonhosted.org")
+
+
+def test_pip_inspect_output_has_installed_key():
+    """
+    Test that `pip inspect` output contains an `"installed"` key whose value is a list.
+    The implementation calls `.get("installed", [])` on this output; if the key were
+    absent or mapped to a non-list, packages would be silently omitted from audit results.
+    """
+    result = subprocess.run(PIP_COMMAND_PREFIX + ["inspect"], check=True, text=True, capture_output=True)
+    output = json.loads(result.stdout)
+    assert isinstance(output.get("installed"), list)
+
+
+def test_pip_inspect_matches_pip_list_new_pip_project(new_pip_project):
+    """
+    Test that `pip inspect` and `pip list` output match in an uninstalled `pip` project.
+    """
+    backend_test_pip_inspect_matches_pip_list(new_pip_project)
+
+
+def test_pip_inspect_matches_pip_list_new_pip_project_installed(new_pip_project_installed):
+    """
+    Test that `pip inspect` and `pip list` output match in an installed `pip` project.
+    """
+    backend_test_pip_inspect_matches_pip_list(new_pip_project_installed)
+
+
+def test_pip_inspect_matches_pip_list_pip_project_remote_dependency(pip_project_remote_dependency):
+    """
+    Test that `pip inspect` and `pip list` output match in an uninstalled `pip` project
+    with a remote dependency from PyPI.
+    """
+    backend_test_pip_inspect_matches_pip_list(pip_project_remote_dependency)
+
+
+def test_pip_inspect_matches_pip_list_pip_project_remote_dependency_installed(pip_project_remote_dependency_installed):
+    """
+    Test that `pip inspect` and `pip list` output match in an installed `pip` project
+    with a remote dependency from PyPI.
+    """
+    backend_test_pip_inspect_matches_pip_list(pip_project_remote_dependency_installed)
+
+
+def test_pip_inspect_matches_pip_list_pip_project_local_dependency(pip_project_local_dependency):
+    """
+    Test that `pip inspect` and `pip list` output match in an uninstalled `pip` project
+    with a local dependency.
+    """
+    backend_test_pip_inspect_matches_pip_list(pip_project_local_dependency)
+
+
+def test_pip_inspect_matches_pip_list_pip_project_local_dependency_installed(pip_project_local_dependency_installed):
+    """
+    Test that `pip inspect` and `pip list` output match in an installed `pip` project
+    with a local dependency.
+    """
+    backend_test_pip_inspect_matches_pip_list(pip_project_local_dependency_installed)
+
+
+def test_pip_inspect_registry_package_no_direct_url(pip_project_remote_dependency_installed):
+    """
+    Test that a package installed from the PyPI registry has no `direct_url` entry in
+    `pip inspect` output. The implementation logs "No artifact source data found" and
+    sets `source=None` when `direct_url` is absent, treating absence as a registry install.
+    This also covers the case of packages installed by non-pip tools, which similarly
+    lack `direct_url`.
+    """
+    venv_pip = pip_project_remote_dependency_installed / "venv" / "bin" / "pip"
+
+    result = subprocess.run([venv_pip, "inspect"], check=True, text=True, capture_output=True)
+    installed = json.loads(result.stdout).get("installed", [])
+
+    matching = [
+        e for e in installed
+        if e.get("metadata", {}).get("name", "").lower() == REMOTE_PACKAGE_NAME
+    ]
+    assert len(matching) == 1
+    assert "direct_url" not in matching[0]
+
+
+def test_pip_inspect_local_package_direct_url_format(pip_project_local_dependency_installed):
+    """
+    Test that a locally-installed package has a `direct_url` entry in `pip inspect`
+    output whose `url` field uses the `file://` scheme with an absolute path (PEP 610).
+    The implementation strips the `file://` prefix and passes the remainder to `Path()`,
+    relying on this path being absolute so that `LocalPackageSource` resolves correctly.
+    """
+    venv_pip = pip_project_local_dependency_installed / "venv" / "bin" / "pip"
+
+    result = subprocess.run([venv_pip, "inspect"], check=True, text=True, capture_output=True)
+    installed = json.loads(result.stdout).get("installed", [])
+
+    matching = [
+        e for e in installed
+        if e.get("metadata", {}).get("name", "").lower() == LOCAL_PACKAGE_NAME
+    ]
+    assert len(matching) == 1
+
+    direct_url = matching[0].get("direct_url")
+    assert direct_url is not None
+
+    url = direct_url.get("url", "")
+    assert url.startswith("file://")
+    assert Path(url[len("file://"):]).is_absolute()
+
+
+def backend_test_pip_inspect_matches_pip_list(project_dir: Path):
+    """
+    Backend function for testing that `pip inspect` and `pip list` output match.
+    """
+    venv_pip = project_dir / "venv" / "bin" / "pip"
+
+    pip_inspect = subprocess.run(
+        [venv_pip, "inspect"], check=True, text=True, capture_output=True
+    )
+    inspect_packages = {
+        (e["metadata"]["name"].lower(), e["metadata"]["version"])
+        for e in json.loads(pip_inspect.stdout.strip()).get("installed", [])
+    }
+
+    pip_list = subprocess.run(
+        [venv_pip, "list", "--format", "json"], check=True, text=True, capture_output=True
+    )
+    list_packages = {
+        (pkg["name"].lower(), pkg["version"])
+        for pkg in json.loads(pip_list.stdout.strip())
+    }
+
+    assert inspect_packages == list_packages

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -320,16 +320,29 @@ def backend_test_pip_inspect_matches_pip_list(project_dir: Path):
         [venv_pip, "inspect"], check=True, text=True, capture_output=True
     )
     inspect_packages = {
-        (e["metadata"]["name"].lower(), e["metadata"]["version"])
+        (e["metadata"]["name"], e["metadata"]["version"])
         for e in json.loads(pip_inspect.stdout.strip()).get("installed", [])
     }
 
     pip_list = subprocess.run(
         [venv_pip, "list", "--format", "json"], check=True, text=True, capture_output=True
     )
-    list_packages = {
-        (pkg["name"].lower(), pkg["version"])
-        for pkg in json.loads(pip_list.stdout.strip())
-    }
+
+    # pip v22.2 prints non-JSON to stdout...
+    report = None
+    for line in pip_list.stdout.strip().split('\n'):
+        try:
+            maybe_report = json.loads(line)
+            if report is None:
+                report = maybe_report
+            else:
+                raise RuntimeError("Multiple JSON output lines detected")
+
+        except json.JSONDecodeError:
+            pass
+
+    assert report is not None, "Malformed `pip list` output: no JSON report detected"
+
+    list_packages = {(pkg["name"], pkg["version"]) for pkg in report}
 
     assert inspect_packages == list_packages

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -221,17 +221,6 @@ def _test_pip_install_report_format(
         assert url.startswith("https://files.pythonhosted.org")
 
 
-def test_pip_inspect_output_has_installed_key():
-    """
-    Test that `pip inspect` output contains an `"installed"` key whose value is a list.
-    The implementation calls `.get("installed", [])` on this output; if the key were
-    absent or mapped to a non-list, packages would be silently omitted from audit results.
-    """
-    result = subprocess.run(PIP_COMMAND_PREFIX + ["inspect"], check=True, text=True, capture_output=True)
-    output = json.loads(result.stdout)
-    assert isinstance(output.get("installed"), list)
-
-
 def test_pip_inspect_matches_pip_list_new_pip_project(new_pip_project):
     """
     Test that `pip inspect` and `pip list` output match in an uninstalled `pip` project.

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -10,9 +10,10 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package, RemotePackageSource
+from scfw.package import LocalPackageSource, Package, RemotePackageSource
 from scfw.package_managers.pip import Pip
 
+from .pip_fixtures import *
 from .test_pip import INIT_PIP_STATE, TEST_TARGET, pip_list
 
 PACKAGE_MANAGER = Pip()
@@ -117,7 +118,8 @@ def test_pip_command_resolve_install_targets_exact():
 
 def test_pip_list_installed_packages(monkeypatch):
     """
-    Test that `Pip.list_installed_packages` correctly parses `pip` output.
+    Test that `Pip.list_installed_packages` correctly parses `pip` output for a
+    registry-installed package (no `direct_url`, so `source=None`).
     """
     target = Package(ECOSYSTEM.PyPI, "tree-sitter", "0.24.0")
 
@@ -127,5 +129,49 @@ def test_pip_list_installed_packages(monkeypatch):
         venv_pip = "venv/bin/pip"
         subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
         subprocess.run([venv_pip, "install", f"{target.name}=={target.version}"], check=True)
+
+        assert target in Pip(executable=venv_pip).list_installed_packages()
+
+
+def test_pip_list_installed_packages_remote_source(monkeypatch):
+    """
+    Test that `Pip.list_installed_packages` returns a `Package` with a `RemotePackageSource`
+    for a package installed from a direct remote URL (not via the index).
+    """
+    jmespath_url = (
+        "https://files.pythonhosted.org/packages/07/cb/"
+        "5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/"
+        "jmespath-0.10.0-py2.py3-none-any.whl"
+    )
+    target = Package(ECOSYSTEM.PyPI, "jmespath", "0.10.0", source=RemotePackageSource(jmespath_url))
+
+    with TemporaryDirectory() as tmp:
+        monkeypatch.chdir(tmp)
+
+        venv_pip = "venv/bin/pip"
+        subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
+        subprocess.run([venv_pip, "install", jmespath_url], check=True)
+
+        assert target in Pip(executable=venv_pip).list_installed_packages()
+
+
+def test_pip_list_installed_packages_local_source(monkeypatch, new_pip_project):
+    """
+    Test that `Pip.list_installed_packages` returns a `Package` with a `LocalPackageSource`
+    for a package installed from a local directory.
+    """
+    target = Package(
+        ECOSYSTEM.PyPI,
+        TEST_PACKAGE_NAME,
+        TEST_PACKAGE_VERSION,
+        source=LocalPackageSource(new_pip_project),
+    )
+
+    with TemporaryDirectory() as tmp:
+        monkeypatch.chdir(tmp)
+
+        venv_pip = "venv/bin/pip"
+        subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
+        subprocess.run([venv_pip, "install", str(new_pip_project)], check=True)
 
         assert target in Pip(executable=venv_pip).list_installed_packages()

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -118,10 +118,15 @@ def test_pip_command_resolve_install_targets_exact():
 
 def test_pip_list_installed_packages(monkeypatch):
     """
-    Test that `Pip.list_installed_packages` correctly parses `pip` output for a
-    registry-installed package (no `direct_url`, so `source=None`).
+    Test that `Pip.list_installed_packages` returns a `Package` with a canonical PyPI
+    project page `RemotePackageSource` for a registry-installed package (no `direct_url`).
     """
-    target = Package(ECOSYSTEM.PyPI, "tree-sitter", "0.24.0")
+    target = Package(
+        ECOSYSTEM.PyPI,
+        "tree-sitter",
+        "0.24.0",
+        source=RemotePackageSource("https://pypi.org/project/tree-sitter/0.24.0/"),
+    )
 
     with TemporaryDirectory() as tmp:
         monkeypatch.chdir(tmp)

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -160,7 +160,7 @@ def test_pip_list_installed_packages_remote_source(monkeypatch):
         assert target in Pip(executable=venv_pip).list_installed_packages()
 
 
-def test_pip_list_installed_packages_local_source(monkeypatch, new_pip_project):
+def test_pip_list_installed_packages_local_source(new_pip_project_installed):
     """
     Test that `Pip.list_installed_packages` returns a `Package` with a `LocalPackageSource`
     for a package installed from a local directory.
@@ -169,14 +169,8 @@ def test_pip_list_installed_packages_local_source(monkeypatch, new_pip_project):
         ECOSYSTEM.PyPI,
         TEST_PACKAGE_NAME,
         TEST_PACKAGE_VERSION,
-        source=LocalPackageSource(new_pip_project),
+        source=LocalPackageSource(new_pip_project_installed),
     )
 
-    with TemporaryDirectory() as tmp:
-        monkeypatch.chdir(tmp)
-
-        venv_pip = "venv/bin/pip"
-        subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
-        subprocess.run([venv_pip, "install", str(new_pip_project)], check=True)
-
-        assert target in Pip(executable=venv_pip).list_installed_packages()
+    venv_pip = new_pip_project_installed / "venv" / "bin" / "pip"
+    assert target in Pip(executable=venv_pip).list_installed_packages()


### PR DESCRIPTION
This PR switches the backing interaction with the `pip` command line during `Pip.list_installed_packages` from `pip list --format json` to `pip inspect` to enable SCFW to populate each returned `Package` with an artifact source — a real artifact URL for direct/VCS/local installs, or a canonical PyPI project page URL as a stand-in for registry installs. This admittedly somewhat hacky solution was deemed acceptable because reconstructing the true artifact download URL from the locally available information is not possible and would thus require a network connection to complete the audit.

A suite of new fixtures and tests covers the local, remote, and registry source cases for both the install interception and installed-package listing paths.  We also add tests for the latest releases of all supported package managers.