### PR TITLE
[SECRES-5211] Update logging protocol to include VerificationReport

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,24 @@ jobs:
       - name: Test firewall configure script
         run: make test-configure
 
+  firewall:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Install Supply-Chain Firewall
+        run: pip install .
+      - name: Test core firewall logic
+        run: make test-firewall
+
   pip-executable:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ checks: typecheck lint test
 
 coverage: test coverage-report
 
-test: test-cli test-configure test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-npm test-npm-class test-verifiers
+test: test-cli test-configure test-firewall test-npm test-npm-class test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-verifiers
 
 typecheck:
 	mypy --install-types --non-interactive scfw
@@ -22,6 +22,15 @@ test-cli:
 
 test-configure:
 	COVERAGE_FILE=.coverage.configure coverage run -m pytest tests/test_configure.py
+
+test-firewall:
+	COVERAGE_FILE=.coverage.firewall coverage run -m pytest tests/test_firewall.py
+
+test-npm:
+	COVERAGE_FILE=.coverage.npm coverage run -m pytest tests/package_managers/test_npm.py
+
+test-npm-class:
+	COVERAGE_FILE=.coverage.npm.class coverage run -m pytest tests/package_managers/test_npm_class.py
 
 test-pip-executable:
 	COVERAGE_FILE=.coverage.pip.executable coverage run -m pytest tests/package_managers/test_pip_class.py -k test_executable
@@ -38,20 +47,14 @@ test-poetry:
 test-poetry-class:
 	COVERAGE_FILE=.coverage.poetry.class coverage run -m pytest tests/package_managers/test_poetry_class.py
 
-test-npm:
-	COVERAGE_FILE=.coverage.npm coverage run -m pytest tests/package_managers/test_npm.py
-
-test-npm-class:
-	COVERAGE_FILE=.coverage.npm.class coverage run -m pytest tests/package_managers/test_npm_class.py
-
 test-verifiers:
 	COVERAGE_FILE=.coverage.verifiers coverage run -m pytest tests/verifiers
 
 coverage-report:
-	coverage combine .coverage.cli .coverage.configure \
+	coverage combine .coverage.cli .coverage.configure .coverage.firewall \
+	.coverage.npm .coverage.npm.class \
 	.coverage.pip.executable .coverage.pip .coverage.pip.class \
 	.coverage.poetry .coverage.poetry.class \
-	.coverage.npm .coverage.npm.class \
 	.coverage.verifiers
 	coverage report
 

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -16,10 +16,11 @@ directory for runtime import, no further modification required. Make sure to rei
 the `scfw` package after doing so.
 """
 
+from typing import Optional
+
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
-from scfw.package import Package
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport, VerificationReport
 
 
 class CustomFirewallLogger(FirewallLogger):
@@ -29,10 +30,10 @@ class CustomFirewallLogger(FirewallLogger):
         package_manager: str,
         executable: str,
         command: list[str],
-        targets: list[Package],
         action: FirewallAction,
-        verified: bool,
         warned: bool,
+        relevant_findings: Optional[FindingsReport],
+        verification_report: Optional[VerificationReport],
     ):
         return
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -45,10 +45,14 @@ def run_firewall(args: Namespace) -> int:
         targets = package_manager.resolve_install_targets(args.command)
         _log.info(f"Command would install: [{', '.join(map(str, targets))}]")
 
-        verifiers = FirewallVerifiers(package_manager.ecosystem())
-        _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
+        if targets:
+            verifiers = FirewallVerifiers(package_manager.ecosystem())
+            _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-        verification_report = verifiers.verify_packages(targets)
+            verification_report = verifiers.verify_packages(targets)
+        else:
+            verification_report = VerificationReport.empty()
+
         action, warned, relevant_findings = _determine_firewall_action(verification_report, warning_action)
 
         if relevant_findings:
@@ -145,12 +149,10 @@ def _determine_firewall_action(
         return FirewallAction.ALLOW, False, None
 
     # Warning findings or unverifiable packages => configured warning action (or user confirmation)
-    if warning_report and verification_report.unverifiable:
-        relevant_findings = FindingsReport.merge(warning_report, verification_report.unverifiable)
-    elif warning_report:
-        relevant_findings = warning_report
-    else:
-        relevant_findings = verification_report.unverifiable
+    relevant_findings = FindingsReport.merge(
+        warning_report if warning_report else FindingsReport(),
+        verification_report.unverifiable,
+    )
 
     return warning_action, True, relevant_findings
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -57,13 +57,10 @@ def run_firewall(args: Namespace) -> int:
         if args.dry_run:
             _log.info("Firewall dry-run mode enabled: command will not be run")
             print("Dry-run: exiting without running command.")
-            return 1 if action == FirewallAction.BLOCK else 0
+            return 1 if args.error_on_block and action == FirewallAction.BLOCK else 0
 
+        # This only occurs when `warned=True` and no automatic action was inferrable
         if action is None:
-            if not warned:
-                # This should never occur: immediately error out if it does
-                raise RuntimeError("Invariant violation: action=None requires warned=True")
-
             user_confirmed = inquirer.confirm("Proceed with installation?", default=False)
             action = FirewallAction.ALLOW if user_confirmed else FirewallAction.BLOCK
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -34,7 +34,6 @@ def run_firewall(args: Namespace) -> int:
         An integer status code indicating normal or error exit.
     """
     package_manager = None
-    warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
 
     loggers = FirewallLoggers()
     _log.info(f"Command: '{' '.join(args.command)}'")
@@ -53,6 +52,7 @@ def run_firewall(args: Namespace) -> int:
         else:
             verification_report = VerificationReport.empty()
 
+        warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
         action, warned, relevant_findings = _determine_firewall_action(verification_report, warning_action)
 
         if relevant_findings:

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -45,53 +45,52 @@ def run_firewall(args: Namespace) -> int:
         targets = package_manager.resolve_install_targets(args.command)
         _log.info(f"Command would install: [{', '.join(map(str, targets))}]")
 
-        if targets:
-            verifiers = FirewallVerifiers(package_manager.ecosystem())
-            _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
+        verifiers = FirewallVerifiers(package_manager.ecosystem())
+        _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-            report = verifiers.verify_packages(targets)
-            critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
-            warning_report = report.get_findings_report(FindingSeverity.WARNING)
+        report = verifiers.verify_packages(targets)
+        critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
+        warning_report = report.get_findings_report(FindingSeverity.WARNING)
 
-            # Treat unverifiable packages as warning-level findings
-            if warning_report is not None:
-                warning_report.extend(report.unverifiable)
-            else:
-                warning_report = report.unverifiable
+        # Treat unverifiable packages as warning-level findings
+        if warning_report is not None:
+            warning_report.extend(report.unverifiable)
+        else:
+            warning_report = report.unverifiable
 
-            if not args.dry_run and critical_report:
+        if not args.dry_run and critical_report:
+            loggers.log_firewall_action(
+                package_manager.ecosystem(),
+                package_manager.name(),
+                package_manager.executable(),
+                args.command,
+                action=FirewallAction.BLOCK,
+                warned=False,
+                relevant_findings=critical_report,
+                verification_report=report,
+            )
+            print(critical_report)
+            print("\nThe installation request was blocked. No changes have been made.")
+            return 1 if args.error_on_block else 0
+
+        if not args.dry_run and warning_report:
+            print(warning_report)
+            if (
+                warning_action == FirewallAction.BLOCK
+                or not (warning_action or inquirer.confirm("Proceed with installation?", default=False))
+            ):
                 loggers.log_firewall_action(
                     package_manager.ecosystem(),
                     package_manager.name(),
                     package_manager.executable(),
                     args.command,
-                    list(critical_report.packages()),
                     action=FirewallAction.BLOCK,
-                    verified=True,
-                    warned=False,
+                    warned=True,
+                    relevant_findings=warning_report,
+                    verification_report=report,
                 )
-                print(critical_report)
-                print("\nThe installation request was blocked. No changes have been made.")
+                print("The installation request was aborted. No changes have been made.")
                 return 1 if args.error_on_block else 0
-
-            if not args.dry_run and warning_report:
-                print(warning_report)
-                if (
-                    warning_action == FirewallAction.BLOCK
-                    or not (warning_action or inquirer.confirm("Proceed with installation?", default=False))
-                ):
-                    loggers.log_firewall_action(
-                        package_manager.ecosystem(),
-                        package_manager.name(),
-                        package_manager.executable(),
-                        args.command,
-                        list(warning_report.packages()),
-                        action=FirewallAction.BLOCK,
-                        verified=True,
-                        warned=True,
-                    )
-                    print("The installation request was aborted. No changes have been made.")
-                    return 1 if args.error_on_block else 0
 
         if args.dry_run:
             _log.info("Firewall dry-run mode enabled: command will not be run")
@@ -107,10 +106,10 @@ def run_firewall(args: Namespace) -> int:
             package_manager.name(),
             package_manager.executable(),
             args.command,
-            targets,
             action=FirewallAction.ALLOW,
-            verified=True,
             warned=True if warning_report else False,
+            relevant_findings=warning_report if warning_report else None,
+            verification_report=report,
         )
         return package_manager.run_command(args.command)
 
@@ -133,10 +132,10 @@ def run_firewall(args: Namespace) -> int:
             package_manager.name(),
             package_manager.executable(),
             args.command,
-            targets=[],
             action=FirewallAction.ALLOW,
-            verified=False,
             warned=False,
+            relevant_findings=None,
+            verification_report=None,
         )
         return package_manager.run_command(args.command)
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -14,6 +14,7 @@ from scfw.logger import FirewallAction
 from scfw.loggers import FirewallLoggers
 from scfw.package_manager import UnsupportedVersionError
 import scfw.package_managers as package_managers
+from scfw.report import FindingsReport, VerificationReport
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 
@@ -33,7 +34,6 @@ def run_firewall(args: Namespace) -> int:
         An integer status code indicating normal or error exit.
     """
     package_manager = None
-    critical_report, warning_report = None, None
     warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
 
     loggers = FirewallLoggers()
@@ -48,70 +48,42 @@ def run_firewall(args: Namespace) -> int:
         verifiers = FirewallVerifiers(package_manager.ecosystem())
         _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-        report = verifiers.verify_packages(targets)
-        critical_report = report.get_findings_report(FindingSeverity.CRITICAL)
-        warning_report = report.get_findings_report(FindingSeverity.WARNING)
+        verification_report = verifiers.verify_packages(targets)
+        action, warned, relevant_findings = _determine_firewall_action(verification_report, warning_action)
 
-        # Treat unverifiable packages as warning-level findings
-        if warning_report is not None:
-            warning_report.extend(report.unverifiable)
-        else:
-            warning_report = report.unverifiable
-
-        if not args.dry_run and critical_report:
-            loggers.log_firewall_action(
-                package_manager.ecosystem(),
-                package_manager.name(),
-                package_manager.executable(),
-                args.command,
-                action=FirewallAction.BLOCK,
-                warned=False,
-                relevant_findings=critical_report,
-                verification_report=report,
-            )
-            print(critical_report)
-            print("\nThe installation request was blocked. No changes have been made.")
-            return 1 if args.error_on_block else 0
-
-        if not args.dry_run and warning_report:
-            print(warning_report)
-            if (
-                warning_action == FirewallAction.BLOCK
-                or not (warning_action or inquirer.confirm("Proceed with installation?", default=False))
-            ):
-                loggers.log_firewall_action(
-                    package_manager.ecosystem(),
-                    package_manager.name(),
-                    package_manager.executable(),
-                    args.command,
-                    action=FirewallAction.BLOCK,
-                    warned=True,
-                    relevant_findings=warning_report,
-                    verification_report=report,
-                )
-                print("The installation request was aborted. No changes have been made.")
-                return 1 if args.error_on_block else 0
+        if relevant_findings:
+            print(relevant_findings)
 
         if args.dry_run:
             _log.info("Firewall dry-run mode enabled: command will not be run")
-            if critical_report:
-                print(critical_report)
-            elif warning_report:
-                print(warning_report)
             print("Dry-run: exiting without running command.")
-            return 1 if critical_report or (warning_report and warning_action == FirewallAction.BLOCK) else 0
+            return 1 if action == FirewallAction.BLOCK else 0
+
+        if action is None:
+            if not warned:
+                # This should never occur: immediately error out if it does
+                raise RuntimeError("Invariant violation: action=None requires warned=True")
+
+            user_confirmed = inquirer.confirm("Proceed with installation?", default=False)
+            action = FirewallAction.ALLOW if user_confirmed else FirewallAction.BLOCK
 
         loggers.log_firewall_action(
             package_manager.ecosystem(),
             package_manager.name(),
             package_manager.executable(),
             args.command,
-            action=FirewallAction.ALLOW,
-            warned=True if warning_report else False,
-            relevant_findings=warning_report if warning_report else None,
-            verification_report=report,
+            action,
+            warned,
+            relevant_findings,
+            verification_report,
         )
-        return package_manager.run_command(args.command)
+
+        match action:
+            case FirewallAction.BLOCK:
+                print("\nThe command was blocked. No changes have been made.")
+                return 1 if args.error_on_block else 0
+            case FirewallAction.ALLOW:
+                return package_manager.run_command(args.command)
 
     except UnsupportedVersionError as e:
         if not args.allow_unsupported:
@@ -138,6 +110,52 @@ def run_firewall(args: Namespace) -> int:
             verification_report=None,
         )
         return package_manager.run_command(args.command)
+
+
+def _determine_firewall_action(
+    verification_report: VerificationReport,
+    warning_action: Optional[FirewallAction]
+) -> tuple[Optional[FirewallAction], bool, Optional[FindingsReport]]:
+    """
+    Determine the firewall action and its relevant findings from the given inputs.
+
+    Args:
+        verification_report: The `VerificationReport` on whose basis the action will be decided.
+        warning_action:
+            The (possibly undefined) action to take in the case that `verification_report`
+            contains only warning-level findings or unverifiable packages.
+
+    Returns:
+        A `tuple[Optional[FirewallAction], bool, Optional[FindingsReport]]` representing:
+            1. The `FirewallAction` resulting from `verification_report`, if one could be determined.
+            2. A `bool` indicating whether or not the findings warrant warning the user.
+            3. An `Optional[FindingsReport]` containing the findings that are relevant to `action`.
+
+        A `FirewallAction` cannot be determined when `verification_report` contains at most
+        warning-level findings or unverifiable packages and no predetermined action to take
+        automatically in response may be inferred (e.g., from the environment). In this case,
+        the user must be prompted interactively for their intent to proceed with the command.
+    """
+    critical_report = verification_report.get_findings_report(FindingSeverity.CRITICAL)
+    warning_report = verification_report.get_findings_report(FindingSeverity.WARNING)
+
+    # Critical findings => BLOCK
+    if critical_report:
+        return FirewallAction.BLOCK, False, critical_report
+
+    # No warning findings and no unverifiable packages => ALLOW
+    if not (warning_report or verification_report.unverifiable):
+        return FirewallAction.ALLOW, False, None
+
+    # Warning findings or unverifiable packages => configured warning action (or user confirmation)
+    if warning_report and verification_report.unverifiable:
+        relevant_findings = FindingsReport.merge(warning_report, verification_report.unverifiable)
+    elif warning_report:
+        relevant_findings = warning_report
+    else:
+        relevant_findings = verification_report.unverifiable
+
+    return warning_action, True, relevant_findings
 
 
 def _get_warning_action(cli_allow_choice: bool, cli_block_choice: bool) -> Optional[FirewallAction]:

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -5,11 +5,11 @@ completed run of the supply-chain firewall.
 
 from abc import (ABCMeta, abstractmethod)
 from enum import Enum
+from typing import Optional
 from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport, VerificationReport
 
 
 class FirewallAction(Enum):
@@ -82,10 +82,10 @@ class FirewallLogger(metaclass=ABCMeta):
         package_manager: str,
         executable: str,
         command: list[str],
-        targets: list[Package],
         action: FirewallAction,
-        verified: bool,
         warned: bool,
+        relevant_findings: Optional[FindingsReport],
+        verification_report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -95,20 +95,22 @@ class FirewallLogger(metaclass=ABCMeta):
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
             command: The package manager command line provided to the firewall.
-            targets:
-                The installation targets relevant to Supply-Chain Firewall's action:
-                  * For `BLOCK` actions, contains the installation targets that caused the block
-                  * For `ALLOW` actions, contains all installation targets
             action: The action taken by Supply-Chain Firewall.
-            verified:
-                Indicates whether Supply-Chain Firewall performed installation target
-                verification in deciding to take the specified `action`. Verification is not
-                performed **only** under the following conditions:
-                  * The package manager is of an unsupported version and the user has passed the
-                    command-line option `--allow-unsupported`
             warned:
                 Indicates whether the user was warned about findings for any installation
                 targets and prompted for approval to proceed with `command`.
+            relevant_findings:
+                The findings, if any, that are relevant to the `action` taken by Supply-Chain
+                Firewall. A `None` value indicates that the action was taken without relying
+                on any findings, which can occur when
+                    * There were no findings for any installation target
+                    * Installation target verification did not take place, usually because the
+                      underlying package manager was of an unsupported version
+            verification_report:
+                The complete `VerificationReport`, if any, resulting from installation target
+                verification. A `None` value indicates that installation target verification
+                did not take place, usually because the underlying package manager was of an
+                unsupported version.
         """
         pass
 

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -25,11 +25,11 @@ import importlib
 import logging
 import os
 import pkgutil
+from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
-from scfw.package import Package
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport, VerificationReport
 
 _log = logging.getLogger(__name__)
 
@@ -64,10 +64,10 @@ class FirewallLoggers(FirewallLogger):
         package_manager: str,
         executable: str,
         command: list[str],
-        targets: list[Package],
         action: FirewallAction,
-        verified: bool,
         warned: bool,
+        relevant_findings: Optional[FindingsReport],
+        verification_report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall to
@@ -80,10 +80,10 @@ class FirewallLoggers(FirewallLogger):
                     package_manager,
                     executable,
                     command,
-                    targets,
                     action,
-                    verified,
                     warned,
+                    relevant_findings,
+                    verification_report,
                 )
             except Exception as e:
                 _log.warning(f"Failed to log firewall action: {e}")

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -204,10 +204,10 @@ class DDLogger(FirewallLogger):
         if action < self._level:
             return
 
-        if relevant_findings:
-            targets = list(map(str, relevant_findings.packages()))
-        elif verification_report:
-            targets = list(map(str, verification_report.verification_set))
+        if action == FirewallAction.ALLOW and verification_report:
+            targets = sorted(map(str, verification_report.verification_set))
+        elif action == FirewallAction.BLOCK and relevant_findings:
+            targets = sorted(map(str, relevant_findings.packages()))
         else:
             targets = []
 

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -42,6 +42,8 @@ _FIREWALL_ACTION_ATTRIBUTES = {
     "warned",
 }
 
+_ALL_LOG_ATTRIBUTES = _AUDIT_ATTRIBUTES | _FIREWALL_ACTION_ATTRIBUTES
+
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
 
 DD_LOGGER_HOME = Path("dd_logger/")
@@ -132,7 +134,7 @@ class DDLogFormatter(logging.Formatter):
         except Exception as e:
             _log.warning(f"Failed to query username while formatting log: {e}")
 
-        for key in _AUDIT_ATTRIBUTES | _FIREWALL_ACTION_ATTRIBUTES:
+        for key in _ALL_LOG_ATTRIBUTES:
             try:
                 log_record[key] = record.__dict__[key]
             except KeyError:
@@ -173,7 +175,7 @@ class DDLogger(FirewallLogger):
             if (dd_log_level := os.getenv(DD_LOG_LEVEL_VAR)) is not None:
                 self._level = FirewallAction.from_string(dd_log_level)
         except ValueError:
-            _log.warning(f"Undefined or invalid Datadog log level: using default level {_DD_LOG_LEVEL_DEFAULT}")
+            _log.warning(f"Invalid value for {DD_LOG_LEVEL_VAR}: using default level {_DD_LOG_LEVEL_DEFAULT}")
 
     def log_firewall_action(
         self,
@@ -199,7 +201,7 @@ class DDLogger(FirewallLogger):
             relevant_findings: The findings, if any, relevant to the action taken.
             verification_report: The complete `VerificationReport`, if any, resulting from verification.
         """
-        if not self._level or action < self._level:
+        if action < self._level:
             return
 
         if relevant_findings:

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 import socket
-from typing import Any
+from typing import Any, Optional
 
 import dotenv
 
@@ -16,8 +16,7 @@ import scfw
 from scfw.constants import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE, SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
-from scfw.package import Package
-from scfw.report import VerificationReport
+from scfw.report import FindingsReport, VerificationReport
 
 _log = logging.getLogger(__name__)
 
@@ -182,10 +181,10 @@ class DDLogger(FirewallLogger):
         package_manager: str,
         executable: str,
         command: list[str],
-        targets: list[Package],
         action: FirewallAction,
-        verified: bool,
         warned: bool,
+        relevant_findings: Optional[FindingsReport],
+        verification_report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -195,13 +194,20 @@ class DDLogger(FirewallLogger):
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
             command: The package manager command line provided to the firewall.
-            targets: The installation targets relevant to firewall's action.
             action: The action taken by the firewall.
-            verified: Indicates whether verification was performed in taking the specified `action`.
             warned: Indicates whether the user was warned about findings and prompted for approval.
+            relevant_findings: The findings, if any, relevant to the action taken.
+            verification_report: The complete `VerificationReport`, if any, resulting from verification.
         """
         if not self._level or action < self._level:
             return
+
+        if relevant_findings:
+            targets = list(map(str, relevant_findings.packages()))
+        elif verification_report:
+            targets = list(map(str, verification_report.verification_set))
+        else:
+            targets = []
 
         self._logger.info(
             f"Command '{' '.join(command)}' was {str(action).lower()}ed",
@@ -209,9 +215,9 @@ class DDLogger(FirewallLogger):
                 "ecosystem": str(ecosystem),
                 "package_manager": package_manager,
                 "executable": executable,
-                "targets": list(map(str, targets)),
+                "targets": targets,
                 "action": str(action),
-                "verified": verified,
+                "verified": verification_report is not None,
                 "warned": warned,
             }
         )

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -61,7 +61,7 @@ class FindingsReport:
     @classmethod
     def merge(cls, lhs: Self, rhs: Self) -> Self:
         """
-        Merge two `FindingsReports` into a new one containing them both.
+        Merge two `FindingsReport` into a new one containing them both.
 
         Args:
             lhs: The first `FindingsReport` to be merged.

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -94,11 +94,12 @@ class FindingsReport:
         return (package for package in self._report)
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True)
 class VerificationReport:
     """
     A structured report containing the results of verifying a set of `Package`.
     """
+    verification_set: set[Package]
     findings_reports: dict[FindingSeverity, FindingsReport]
     unverifiable: FindingsReport
 

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -21,6 +21,15 @@ class FindingsReport:
         """
         self._report: dict[Package, list[str]] = {}
 
+    def __eq__(self, other: object) -> bool:
+        """
+        Determine whether two `FindingsReport` are equal.
+        """
+        if not isinstance(other, FindingsReport):
+            return NotImplemented
+
+        return self._report == other._report
+
     def __len__(self) -> int:
         """
         Return the number of entries in the report.
@@ -48,6 +57,24 @@ class FindingsReport:
         return '\n'.join(
             show_findings(package, findings) for package, findings in self._report.items()
         )
+
+    @classmethod
+    def merge(cls, lhs: Self, rhs: Self) -> Self:
+        """
+        Merge two `FindingsReports` into a new one containing them both.
+
+        Args:
+            lhs: The first `FindingsReport` to be merged.
+            rhs: The second `FindingsReport` to be merged.
+
+        Returns:
+            A `FindingsReport` containing all of the findings in `lhs` and `rhs`.
+        """
+        merged = cls()
+        merged.extend(lhs)
+        merged.extend(rhs)
+
+        return merged
 
     def get(self, package: Package) -> Optional[list[str]]:
         """
@@ -85,7 +112,7 @@ class FindingsReport:
             if package in self._report:
                 self._report[package].extend(findings)
             else:
-                self._report[package] = findings
+                self._report[package] = list(findings)
 
     def packages(self) -> Iterable[Package]:
         """

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -126,7 +126,7 @@ class VerificationReport:
     """
     A structured report containing the results of verifying a set of `Package`.
     """
-    verification_set: set[Package]
+    verification_set: frozenset[Package]
     findings_reports: dict[FindingSeverity, FindingsReport]
     unverifiable: FindingsReport
 

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -130,6 +130,13 @@ class VerificationReport:
     findings_reports: dict[FindingSeverity, FindingsReport]
     unverifiable: FindingsReport
 
+    @classmethod
+    def empty(cls) -> Self:
+        """
+        Return an empty `VerificationReport`.
+        """
+        return cls(frozenset(), {}, FindingsReport())
+
     def get_findings_report(self, severity: FindingSeverity) -> Optional[FindingsReport]:
         """
         Return the reported `FindingsReport` of the given severity level if one exists.

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -118,7 +118,7 @@ class FindingsReport:
         """
         Return an iterator over `Package` mentioned in the report.
         """
-        return (package for package in self._report)
+        return self._report.keys()
 
 
 @dataclass(eq=True)

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -80,7 +80,7 @@ class FirewallVerifiers:
             A `VerificationReport` resulting from verifying `packages` against all
             discovered verifiers.
         """
-        verification_set = set(packages)
+        verification_set = frozenset(packages)
         findings_reports: dict[FindingSeverity, FindingsReport] = {}
         unverifiable = FindingsReport()
 

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -80,13 +80,14 @@ class FirewallVerifiers:
             A `VerificationReport` resulting from verifying `packages` against all
             discovered verifiers.
         """
+        verification_set = set(packages)
         findings_reports: dict[FindingSeverity, FindingsReport] = {}
         unverifiable = FindingsReport()
 
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
                 executor.submit(lambda v, t: v.verify(t), verifier, package): (verifier.name(), package)
-                for verifier, package in itertools.product(self._verifiers, packages)
+                for verifier, package in itertools.product(self._verifiers, verification_set)
             }
             for future in cf.as_completed(task_results):
                 verifier, package = task_results[future]
@@ -107,4 +108,4 @@ class FirewallVerifiers:
                     )
 
         _log.info("Verification of packages complete")
-        return VerificationReport(findings_reports, unverifiable)
+        return VerificationReport(verification_set, findings_reports, unverifiable)

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -236,7 +236,7 @@ def make_verification_report(
 
     # `verification_set` is not used in these tests
     return VerificationReport(
-        verification_set=set(),
+        verification_set=frozenset(),
         findings_reports=findings_reports,
         unverifiable=unverifiable if unverifiable is not None else FindingsReport(),
     )

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -1,0 +1,218 @@
+"""
+Tests of the core firewall logic.
+"""
+
+import sys
+
+import pytest
+from typing import Iterable, Optional
+from unittest.mock import MagicMock
+
+from scfw.constants import ON_WARNING_VAR
+from scfw.ecosystem import ECOSYSTEM
+from scfw.firewall import _determine_firewall_action, _get_warning_action
+from scfw.logger import FirewallAction
+from scfw.package import Package
+from scfw.report import FindingsReport, VerificationReport
+from scfw.verifier import FindingSeverity
+
+from tests.utils import build_registry_package
+
+
+_PKG_A = build_registry_package(ECOSYSTEM.PyPI, "requests", "2.31.0")
+_PKG_B = build_registry_package(ECOSYSTEM.PyPI, "numpy", "1.24.0")
+
+
+def test_no_findings():
+    """
+    A verification report with no findings and no unverifiable packages results in an ALLOW action.
+    """
+    action, warned, relevant = _determine_firewall_action(make_verification_report(), None)
+
+    assert action == FirewallAction.ALLOW
+    assert not warned
+    assert relevant is None
+
+
+def test_critical_findings_blocks():
+    """
+    A verification report with critical findings results in a BLOCK action with no user warning.
+    """
+    critical = make_findings_report([(_PKG_A, "critical finding")])
+    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical), None)
+
+    assert action == FirewallAction.BLOCK
+    assert not warned
+    assert relevant == critical
+
+
+def test_critical_findings_take_precedence_over_warnings():
+    """
+    When both critical and warning findings are present, the critical findings drive a BLOCK
+    action and the warning findings are not included in the result.
+    """
+    critical = make_findings_report([(_PKG_A, "critical finding")])
+    warning = make_findings_report([(_PKG_B, "warning finding")])
+    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical, warning=warning), None)
+
+    assert action == FirewallAction.BLOCK
+    assert not warned
+    assert relevant == critical
+
+
+@pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
+def test_warning_findings(warning_action: Optional[FirewallAction]):
+    """
+    A verification report with only warning findings defers to the configured warning action,
+    with the user warned and the warning findings returned as relevant findings.
+    """
+    warning = make_findings_report([(_PKG_A, "warning finding")])
+    action, warned, relevant = _determine_firewall_action(make_verification_report(warning=warning), warning_action)
+
+    assert action == warning_action
+    assert warned
+    assert relevant == warning
+
+
+@pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
+def test_unverifiable_only(warning_action: Optional[FirewallAction]):
+    """
+    Unverifiable packages are treated the same as warning-level findings: the configured
+    warning action is returned with the user warned and the unverifiable packages as relevant findings.
+    """
+    unverifiable = make_findings_report([(_PKG_A, "unverifiable package")])
+    action, warned, relevant = _determine_firewall_action(make_verification_report(unverifiable=unverifiable), warning_action)
+
+    assert action == warning_action
+    assert warned
+    assert relevant == unverifiable
+
+
+@pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
+def test_warning_and_unverifiable_merged(warning_action: Optional[FirewallAction]):
+    """
+    When both warning findings and unverifiable packages are present, the relevant findings
+    returned are a merge of the two reports.
+    """
+    warning = make_findings_report([(_PKG_A, "warning finding")])
+    unverifiable = make_findings_report([(_PKG_B, "unverifiable package")])
+    action, warned, relevant = _determine_firewall_action(
+        make_verification_report(warning=warning, unverifiable=unverifiable), warning_action
+    )
+
+    assert action == warning_action
+    assert warned
+    assert relevant == FindingsReport.merge(warning, unverifiable)
+
+
+def test_get_warning_action_cli_block():
+    """
+    The --block-on-warning CLI flag results in a BLOCK warning action.
+    """
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=True) == FirewallAction.BLOCK
+
+
+def test_get_warning_action_cli_allow():
+    """
+    The --allow-on-warning CLI flag results in an ALLOW warning action.
+    """
+    assert _get_warning_action(cli_allow_choice=True, cli_block_choice=False) == FirewallAction.ALLOW
+
+
+def test_get_warning_action_cli_block_takes_precedence_over_allow():
+    """
+    When both --block-on-warning and --allow-on-warning are set, block takes precedence.
+    """
+    assert _get_warning_action(cli_allow_choice=True, cli_block_choice=True) == FirewallAction.BLOCK
+
+
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("BLOCK", FirewallAction.BLOCK),
+        ("block", FirewallAction.BLOCK),
+        ("ALLOW", FirewallAction.ALLOW),
+        ("allow", FirewallAction.ALLOW),
+    ]
+)
+def test_get_warning_action_env_var(env_value: str, expected: FirewallAction, monkeypatch):
+    """
+    A valid `ON_WARNING_VAR` environment variable determines the warning action,
+    case-insensitively.
+    """
+    monkeypatch.setenv(ON_WARNING_VAR, env_value)
+
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) == expected
+
+
+def test_get_warning_action_env_var_invalid_falls_through(monkeypatch):
+    """
+    An invalid `ON_WARNING_VAR` value is ignored and the terminal interactivity check
+    is used as the fallback.
+    """
+    monkeypatch.setenv(ON_WARNING_VAR, "invalid")
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = False
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) == FirewallAction.BLOCK
+
+
+def test_get_warning_action_non_interactive_terminal(monkeypatch):
+    """
+    A non-interactive terminal with no CLI flags or environment variable defaults to BLOCK.
+    """
+    monkeypatch.delenv(ON_WARNING_VAR, raising=False)
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = False
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) == FirewallAction.BLOCK
+
+
+def test_get_warning_action_interactive_terminal(monkeypatch):
+    """
+    An interactive terminal with no CLI flags or environment variable returns None,
+    deferring to the user's runtime decision.
+    """
+    monkeypatch.delenv(ON_WARNING_VAR, raising=False)
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) is None
+
+
+def make_verification_report(
+    critical: Optional[FindingsReport] = None,
+    warning: Optional[FindingsReport] = None,
+    unverifiable: Optional[FindingsReport] = None,
+) -> VerificationReport:
+    """
+    Create a mocked `VerificationReport` from the given inputs.
+    """
+    findings_reports = {}
+
+    if critical is not None:
+        findings_reports[FindingSeverity.CRITICAL] = critical
+    if warning is not None:
+        findings_reports[FindingSeverity.WARNING] = warning
+
+    # `verification_set` is not used in these tests
+    return VerificationReport(
+        verification_set=set(),
+        findings_reports=findings_reports,
+        unverifiable=unverifiable if unverifiable is not None else FindingsReport(),
+    )
+
+
+def make_findings_report(findings: Iterable[tuple[Package, str]]) -> FindingsReport:
+    """
+    Create a `FindingsReport` from the given `Package-str` pairs.
+    """
+    report = FindingsReport()
+
+    for package, finding in findings:
+        report.insert(package, finding)
+
+    return report

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -60,6 +60,20 @@ def test_critical_findings_take_precedence_over_warnings():
     assert relevant == critical
 
 
+def test_critical_findings_take_precedence_over_unverifiable():
+    """
+    When both critical findings and unverifiable packages are present, the critical findings drive
+    a BLOCK action and the unverifiable packages are not included in the result.
+    """
+    critical = make_findings_report([(_PKG_A, "critical finding")])
+    unverifiable = make_findings_report([(_PKG_B, "unverifiable package")])
+    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical, unverifiable=unverifiable), None)
+
+    assert action == FirewallAction.BLOCK
+    assert not warned
+    assert relevant == critical
+
+
 @pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
 def test_warning_findings(warning_action: Optional[FirewallAction]):
     """
@@ -126,6 +140,15 @@ def test_get_warning_action_cli_block_takes_precedence_over_allow():
     assert _get_warning_action(cli_allow_choice=True, cli_block_choice=True) == FirewallAction.BLOCK
 
 
+def test_get_warning_action_cli_flag_takes_precedence_over_env_var(monkeypatch):
+    """
+    A CLI flag takes precedence over ON_WARNING_VAR, even when the env var specifies a
+    conflicting action.
+    """
+    monkeypatch.setenv(ON_WARNING_VAR, "ALLOW")
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=True) == FirewallAction.BLOCK
+
+
 @pytest.mark.parametrize(
     "env_value,expected",
     [
@@ -156,6 +179,19 @@ def test_get_warning_action_env_var_invalid_falls_through(monkeypatch):
     monkeypatch.setattr(sys, "stdin", mock_stdin)
 
     assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) == FirewallAction.BLOCK
+
+
+def test_get_warning_action_env_var_empty_falls_through_silently(monkeypatch):
+    """
+    An empty `ON_WARNING_VAR` value is treated as unset and the terminal interactivity
+    check is used as the fallback, without logging a warning.
+    """
+    monkeypatch.setenv(ON_WARNING_VAR, "")
+    mock_stdin = MagicMock()
+    mock_stdin.isatty.return_value = True
+    monkeypatch.setattr(sys, "stdin", mock_stdin)
+
+    assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) is None
 
 
 def test_get_warning_action_non_interactive_terminal(monkeypatch):


### PR DESCRIPTION
This PR refactors and clarifies the core firewall decision logic in `firewall.py` by extracting it into a dedicated `_determine_firewall_action` function. This also makes the decision logic independently testable and removes the previously entangled control flow where logging, printing, and early returns were mixed together throughout run_firewall.

The `log_firewall_action` interface is overhauled to replace the old `verified: bool` and `targets: list[Package]` parameters with `relevant_findings: Optional[FindingsReport]` and `verification_report: Optional[VerificationReport]`, giving loggers access to the full verification context rather than a pre-filtered list.  Now, `verification_report=None` indicates that verification did not take place, obsoleting the `verified` boolean.  Meanwhile, `VerificationReport` has been extended with a `verification_set: set[Package]` attribute, the set of packages that were submitted for verification.  This corresponds to the set of installed packages on `ALLOW` runs with no findings.  The `DDLogger` class now derives the targets and verified log fields from these richer inputs.

A new test module `tests/test_firewall.py` covers all branches of `_determine_firewall_action` — no findings, critical-only, warning-only, unverifiable-only, mixed cases, and the interaction with the configured warning action.