### PR TITLE
[SECRES-5232] Enrich Datadog logs and improve clarity

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -343,6 +343,24 @@ jobs:
           make test-npm
           make test-npm-class
 
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Install Supply-Chain Firewall
+        run: pip install .
+      - name: Test verification report class
+        run: make test-report
+
   verifiers:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ checks: typecheck lint test
 
 coverage: test coverage-report
 
-test: test-cli test-configure test-firewall test-npm test-npm-class test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-verifiers
+test: test-cli test-configure test-firewall test-npm test-npm-class test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-report test-verifiers
 
 typecheck:
 	mypy --install-types --non-interactive scfw
@@ -47,6 +47,9 @@ test-poetry:
 test-poetry-class:
 	COVERAGE_FILE=.coverage.poetry.class coverage run -m pytest tests/package_managers/test_poetry_class.py
 
+test-report:
+	COVERAGE_FILE=.coverage.report coverage run -m pytest tests/test_report.py
+
 test-verifiers:
 	COVERAGE_FILE=.coverage.verifiers coverage run -m pytest tests/verifiers
 
@@ -55,7 +58,7 @@ coverage-report:
 	.coverage.npm .coverage.npm.class \
 	.coverage.pip.executable .coverage.pip .coverage.pip.class \
 	.coverage.poetry .coverage.poetry.class \
-	.coverage.verifiers
+	.coverage.report .coverage.verifiers
 	coverage report
 
 docs:

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -33,7 +33,7 @@ class CustomFirewallLogger(FirewallLogger):
         action: FirewallAction,
         warned: bool,
         relevant_findings: Optional[FindingsReport],
-        verification_report: Optional[VerificationReport],
+        report: Optional[VerificationReport],
     ):
         return
 

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -16,24 +16,18 @@ directory for runtime import, no further modification required. Make sure to rei
 the `scfw` package after doing so.
 """
 
-from typing import Optional
-
 from scfw.ecosystem import ECOSYSTEM
-from scfw.logger import FirewallAction, FirewallLogger
-from scfw.report import FindingsReport, VerificationReport
+from scfw.logger import FirewallLogger, FirewallRunSummary
+from scfw.report import VerificationReport
 
 
 class CustomFirewallLogger(FirewallLogger):
-    def log_firewall_action(
+    def log_firewall_run(
         self,
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        command: list[str],
-        action: FirewallAction,
-        warned: bool,
-        relevant_findings: Optional[FindingsReport],
-        report: Optional[VerificationReport],
+        run_summary: FirewallRunSummary,
     ):
         return
 

--- a/examples/verifier.py
+++ b/examples/verifier.py
@@ -19,7 +19,7 @@ the `scfw` package after doing so.
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier
+from scfw.verifier import Finding, FindingSeverity, PackageVerifier
 
 
 class CustomPackageVerifier(PackageVerifier):
@@ -31,8 +31,8 @@ class CustomPackageVerifier(PackageVerifier):
     def supported_ecosystems(cls) -> set[ECOSYSTEM]:
         return set()
 
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
-        return []
+    def verify(self, package: Package) -> set[Finding]:
+        return set()
 
 
 def load_verifier() -> PackageVerifier:

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -7,6 +7,7 @@ import logging
 
 from scfw.loggers import FirewallLoggers
 import scfw.package_managers as package_managers
+from scfw.report import show_reports
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 
@@ -39,18 +40,13 @@ def run_audit(args: Namespace) -> int:
             report,
         )
 
-        # TODO(ikretz): Pretty print audit findings
-        found_issues = False
-        for severity in FindingSeverity:
-            if (findings := report.get_findings(severity)):
-                found_issues = True
-                print(findings)
-
-        if (unverified := report.get_unverified()):
-            found_issues = True
-            print(unverified)
-
-        if not found_issues:
+        output = show_reports(
+            [report.get_findings(severity) for severity in FindingSeverity],
+            report.get_unverified(),
+        )
+        if output:
+            print(output)
+        else:
             print("No issues found.")
 
     return 0

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -27,7 +27,7 @@ def run_audit(args: Namespace) -> int:
     package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
     if (installed_packages := package_manager.get_installed_packages()):
-        _log.info(f"Installed packages: [{', '.join(map(str, installed_packages))}]")
+        _log.info(f"Installed packages: [{', '.join(sorted(map(str, installed_packages)))}]")
 
         verifiers = FirewallVerifiers(package_manager.ecosystem())
         _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -7,7 +7,6 @@ import logging
 
 from scfw.loggers import FirewallLoggers
 import scfw.package_managers as package_managers
-from scfw.report import FindingsReport
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 
@@ -24,8 +23,6 @@ def run_audit(args: Namespace) -> int:
     Returns:
         An integer status code indicating normal exit.
     """
-    merged_report = FindingsReport()
-
     package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
     if (packages := package_manager.list_installed_packages()):
@@ -42,15 +39,18 @@ def run_audit(args: Namespace) -> int:
             report,
         )
 
+        # TODO(ikretz): Pretty print audit findings
+        found_issues = False
         for severity in FindingSeverity:
-            if (severity_report := report.get_findings_report(severity)):
-                merged_report.extend(severity_report)
+            if (findings := report.get_findings(severity)):
+                found_issues = True
+                print(findings)
 
-        merged_report.extend(report.unverifiable)
+        if (unverified := report.get_unverified()):
+            found_issues = True
+            print(unverified)
 
-    if merged_report:
-        print(merged_report)
-    else:
-        print("No issues found.")
+        if not found_issues:
+            print("No issues found.")
 
     return 0

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -42,7 +42,7 @@ def run_audit(args: Namespace) -> int:
 
         output = show_reports(
             [report.get_findings(severity) for severity in FindingSeverity],
-            report.get_unverified(),
+            report.get_unverifiable(),
         )
         if output:
             print(output)

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -26,13 +26,13 @@ def run_audit(args: Namespace) -> int:
     """
     package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
-    if (packages := package_manager.list_installed_packages()):
-        _log.info(f"Installed packages: [{', '.join(map(str, packages))}]")
+    if (installed_packages := package_manager.get_installed_packages()):
+        _log.info(f"Installed packages: [{', '.join(map(str, installed_packages))}]")
 
         verifiers = FirewallVerifiers(package_manager.ecosystem())
         _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-        report = verifiers.verify_packages(packages)
+        report = verifiers.verify_packages(installed_packages)
         FirewallLoggers().log_audit(
             package_manager.ecosystem(),
             package_manager.name(),

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -42,7 +42,7 @@ def run_firewall(args: Namespace) -> int:
         package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
         install_targets = package_manager.resolve_install_targets(args.command)
-        _log.info(f"Command would install: [{', '.join(map(str, install_targets))}]")
+        _log.info(f"Command would install: [{', '.join(sorted(map(str, install_targets)))}]")
 
         if install_targets:
             verifiers = FirewallVerifiers(package_manager.ecosystem())
@@ -147,8 +147,8 @@ def _determine_firewall_action(
 
         Note that on warning, the returned action is always equal to `warning_action`.
         In the case that Supply-Chain Firewall was unable to determine this action
-        from the environment or the command line, `run_firewall_action()` is required
-        to interactively prompt the user to select an action.
+        from the environment or the command line, `run_firewall()` is required to
+        interactively prompt the user to select an action.
     """
     critical_findings = report.get_findings(FindingSeverity.CRITICAL)
     warning_findings = report.get_findings(FindingSeverity.WARNING)

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -53,7 +53,7 @@ def run_firewall(args: Namespace) -> int:
             report = VerificationReport()
 
         warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
-        action, warned, relevant_findings = _determine_firewall_action(report, warning_action)
+        action, severity, relevant_findings = _determine_firewall_action(report, warning_action)
 
         output = show_reports(
             [relevant_findings] if relevant_findings else [],
@@ -67,7 +67,7 @@ def run_firewall(args: Namespace) -> int:
             print("Dry-run: exiting without running command.")
             return 1 if args.error_on_block and action == FirewallAction.BLOCK else 0
 
-        # This only occurs when `warned=True` and no automatic action was inferrable
+        # This only occurs on `severity=WARNING` when no automatic action was inferrable
         if action is None:
             user_confirmed = inquirer.confirm("Proceed with installation?", default=False)
             action = FirewallAction.ALLOW if user_confirmed else FirewallAction.BLOCK
@@ -81,7 +81,7 @@ def run_firewall(args: Namespace) -> int:
                 install_targets,
                 report,
                 relevant_findings,
-                warned,
+                severity == FindingSeverity.WARNING,
                 action,
             ),
         )
@@ -117,7 +117,7 @@ def run_firewall(args: Namespace) -> int:
                 install_targets=None,
                 report=None,
                 relevant_findings=None,
-                warned=False,
+                warning=False,
                 action=FirewallAction.ALLOW,
             ),
         )
@@ -127,7 +127,7 @@ def run_firewall(args: Namespace) -> int:
 def _determine_firewall_action(
     report: VerificationReport,
     warning_action: Optional[FirewallAction]
-) -> tuple[Optional[FirewallAction], bool, Optional[FindingsReport]]:
+) -> tuple[Optional[FirewallAction], Optional[FindingSeverity], Optional[FindingsReport]]:
     """
     Determine the firewall action and its relevant findings from the given inputs.
 
@@ -139,10 +139,11 @@ def _determine_firewall_action(
 
     Returns:
         A triple of an `Optional[FirewallAction]` representing the action that
-        Supply-Chain Firewall should take given `report` and `warning_action`, a `bool`
-        indicating whether or not the user should be given the option to continue the
-        action after a warning, and an `Optional[FindingsReport]` containing any
-        findings that were relevant to the returned action.
+        Supply-Chain Firewall should take given `report` and `warning_action`, an
+        `Optional[FindingSeverity]` indicating the highest severity level present in
+        `report` (where `FindingSeverity.WARNING` also covers unverifiable packages),
+        and an `Optional[FindingsReport]` containing any findings that were relevant
+        to the returned action.
 
         Note that on warning, the returned action is always equal to `warning_action`.
         In the case that Supply-Chain Firewall was unable to determine this action
@@ -154,14 +155,14 @@ def _determine_firewall_action(
 
     # Critical findings => BLOCK
     if critical_findings:
-        return FirewallAction.BLOCK, False, critical_findings
+        return FirewallAction.BLOCK, FindingSeverity.CRITICAL, critical_findings
 
     # No critical or warning findings and no unverifiable packages => ALLOW
     if not (warning_findings or report.get_unverifiable()):
-        return FirewallAction.ALLOW, False, None
+        return FirewallAction.ALLOW, None, None
 
     # Warning findings or unverifiable packages => configured warning action (or user confirmation)
-    return warning_action, True, warning_findings if warning_findings else None
+    return warning_action, FindingSeverity.WARNING, warning_findings if warning_findings else None
 
 
 def _get_warning_action(cli_allow_choice: bool, cli_block_choice: bool) -> Optional[FirewallAction]:

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -138,7 +138,16 @@ def _determine_firewall_action(
             contains only warning-level findings or unverifiable packages.
 
     Returns:
-        Lorem ipsum dolor sit amet.
+        A triple of an `Optional[FirewallAction]` representing the action that
+        Supply-Chain Firewall should take given `report` and `warning_action`, a `bool`
+        indicating whether or not the user should be given the option to continue the
+        action after a warning, and an `Optional[FindingsReport]` containing any
+        findings that were relevant to the returned action.
+
+        Note that on warning, the returned action is always equal to `warning_action`.
+        In the case that Supply-Chain Firewall was unable to determine this action
+        from the environment or the command line, `run_firewall_action()` is required
+        to interactively prompt the user to select an action.
     """
     critical_findings = report.get_findings(FindingSeverity.CRITICAL)
     warning_findings = report.get_findings(FindingSeverity.WARNING)

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -57,7 +57,7 @@ def run_firewall(args: Namespace) -> int:
 
         output = show_reports(
             [relevant_findings] if relevant_findings else [],
-            report.get_unverified(),
+            report.get_unverifiable(),
         )
         if output:
             print(output)
@@ -157,7 +157,7 @@ def _determine_firewall_action(
         return FirewallAction.BLOCK, False, critical_findings
 
     # No critical or warning findings and no unverifiable packages => ALLOW
-    if not (warning_findings or report.get_unverified()):
+    if not (warning_findings or report.get_unverifiable()):
         return FirewallAction.ALLOW, False, None
 
     # Warning findings or unverifiable packages => configured warning action (or user confirmation)

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -10,7 +10,7 @@ import sys
 from typing import Optional
 
 from scfw.constants import ON_WARNING_VAR
-from scfw.logger import FirewallAction
+from scfw.logger import FirewallAction, FirewallRunSummary
 from scfw.loggers import FirewallLoggers
 from scfw.package_manager import UnsupportedVersionError
 import scfw.package_managers as package_managers
@@ -41,14 +41,14 @@ def run_firewall(args: Namespace) -> int:
     try:
         package_manager = package_managers.get_package_manager(args.package_manager, executable=args.executable)
 
-        targets = package_manager.resolve_install_targets(args.command)
-        _log.info(f"Command would install: [{', '.join(map(str, targets))}]")
+        install_targets = package_manager.resolve_install_targets(args.command)
+        _log.info(f"Command would install: [{', '.join(map(str, install_targets))}]")
 
-        if targets:
+        if install_targets:
             verifiers = FirewallVerifiers(package_manager.ecosystem())
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-            report = verifiers.verify_packages(targets)
+            report = verifiers.verify_packages(install_targets)
         else:
             report = VerificationReport()
 
@@ -72,15 +72,18 @@ def run_firewall(args: Namespace) -> int:
             user_confirmed = inquirer.confirm("Proceed with installation?", default=False)
             action = FirewallAction.ALLOW if user_confirmed else FirewallAction.BLOCK
 
-        loggers.log_firewall_action(
+        loggers.log_firewall_run(
             package_manager.ecosystem(),
             package_manager.name(),
             package_manager.executable(),
-            args.command,
-            action,
-            warned,
-            relevant_findings,
-            report,
+            FirewallRunSummary(
+                args.command,
+                set(install_targets) if action == FirewallAction.ALLOW else set(),
+                report,
+                relevant_findings,
+                warned,
+                action,
+            ),
         )
 
         match action:
@@ -104,15 +107,18 @@ def run_firewall(args: Namespace) -> int:
         if not package_manager:
             raise RuntimeError("Failed to initialize package manager handle: cannot run command")
 
-        loggers.log_firewall_action(
+        loggers.log_firewall_run(
             package_manager.ecosystem(),
             package_manager.name(),
             package_manager.executable(),
-            args.command,
-            action=FirewallAction.ALLOW,
-            warned=False,
-            relevant_findings=None,
-            report=None,
+            FirewallRunSummary(
+                args.command,
+                install_targets=None,
+                report=None,
+                relevant_findings=None,
+                warned=False,
+                action=FirewallAction.ALLOW,
+            ),
         )
         return package_manager.run_command(args.command)
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -57,7 +57,7 @@ def run_firewall(args: Namespace) -> int:
 
         output = show_reports(
             [relevant_findings] if relevant_findings else [],
-            report.get_unverified()
+            report.get_unverified(),
         )
         if output:
             print(output)
@@ -78,7 +78,7 @@ def run_firewall(args: Namespace) -> int:
             package_manager.executable(),
             FirewallRunSummary(
                 args.command,
-                install_targets if action == FirewallAction.ALLOW else set(),
+                install_targets,
                 report,
                 relevant_findings,
                 warned,
@@ -90,6 +90,7 @@ def run_firewall(args: Namespace) -> int:
             case FirewallAction.BLOCK:
                 print("\nThe command was blocked. No changes have been made.")
                 return 1 if args.error_on_block else 0
+
             case FirewallAction.ALLOW:
                 return package_manager.run_command(args.command)
 

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -78,7 +78,7 @@ def run_firewall(args: Namespace) -> int:
             package_manager.executable(),
             FirewallRunSummary(
                 args.command,
-                set(install_targets) if action == FirewallAction.ALLOW else set(),
+                install_targets if action == FirewallAction.ALLOW else set(),
                 report,
                 relevant_findings,
                 warned,

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -14,7 +14,7 @@ from scfw.logger import FirewallAction
 from scfw.loggers import FirewallLoggers
 from scfw.package_manager import UnsupportedVersionError
 import scfw.package_managers as package_managers
-from scfw.report import FindingsReport, VerificationReport
+from scfw.report import FindingsReport, VerificationReport, show_reports
 from scfw.verifier import FindingSeverity
 from scfw.verifiers import FirewallVerifiers
 
@@ -55,10 +55,12 @@ def run_firewall(args: Namespace) -> int:
         warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
         action, warned, relevant_findings = _determine_firewall_action(report, warning_action)
 
-        # TODO(ikretz): Also print unverified packages
-        # TODO(ikretz): Pretty print `relevant_findings`
-        if relevant_findings:
-            print(relevant_findings)
+        output = show_reports(
+            [relevant_findings] if relevant_findings else [],
+            report.get_unverified()
+        )
+        if output:
+            print(output)
 
         if args.dry_run:
             _log.info("Firewall dry-run mode enabled: command will not be run")

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -48,13 +48,15 @@ def run_firewall(args: Namespace) -> int:
             verifiers = FirewallVerifiers(package_manager.ecosystem())
             _log.info(f"Using package verifiers: [{', '.join(verifiers.names())}]")
 
-            verification_report = verifiers.verify_packages(targets)
+            report = verifiers.verify_packages(targets)
         else:
-            verification_report = VerificationReport.empty()
+            report = VerificationReport()
 
         warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
-        action, warned, relevant_findings = _determine_firewall_action(verification_report, warning_action)
+        action, warned, relevant_findings = _determine_firewall_action(report, warning_action)
 
+        # TODO(ikretz): Also print unverified packages
+        # TODO(ikretz): Pretty print `relevant_findings`
         if relevant_findings:
             print(relevant_findings)
 
@@ -76,7 +78,7 @@ def run_firewall(args: Namespace) -> int:
             action,
             warned,
             relevant_findings,
-            verification_report,
+            report,
         )
 
         match action:
@@ -108,53 +110,40 @@ def run_firewall(args: Namespace) -> int:
             action=FirewallAction.ALLOW,
             warned=False,
             relevant_findings=None,
-            verification_report=None,
+            report=None,
         )
         return package_manager.run_command(args.command)
 
 
 def _determine_firewall_action(
-    verification_report: VerificationReport,
+    report: VerificationReport,
     warning_action: Optional[FirewallAction]
 ) -> tuple[Optional[FirewallAction], bool, Optional[FindingsReport]]:
     """
     Determine the firewall action and its relevant findings from the given inputs.
 
     Args:
-        verification_report: The `VerificationReport` on whose basis the action will be decided.
+        report: The `VerificationReport` on whose basis the action will be decided.
         warning_action:
-            The (possibly undefined) action to take in the case that `verification_report`
+            The (possibly undefined) action to take in the case that `report`
             contains only warning-level findings or unverifiable packages.
 
     Returns:
-        A `tuple[Optional[FirewallAction], bool, Optional[FindingsReport]]` representing:
-            1. The `FirewallAction` resulting from `verification_report`, if one could be determined.
-            2. A `bool` indicating whether or not the findings warrant warning the user.
-            3. An `Optional[FindingsReport]` containing the findings that are relevant to `action`.
-
-        A `FirewallAction` cannot be determined when `verification_report` contains at most
-        warning-level findings or unverifiable packages and no predetermined action to take
-        automatically in response may be inferred (e.g., from the environment). In this case,
-        the user must be prompted interactively for their intent to proceed with the command.
+        Lorem ipsum dolor sit amet.
     """
-    critical_report = verification_report.get_findings_report(FindingSeverity.CRITICAL)
-    warning_report = verification_report.get_findings_report(FindingSeverity.WARNING)
+    critical_findings = report.get_findings(FindingSeverity.CRITICAL)
+    warning_findings = report.get_findings(FindingSeverity.WARNING)
 
     # Critical findings => BLOCK
-    if critical_report:
-        return FirewallAction.BLOCK, False, critical_report
+    if critical_findings:
+        return FirewallAction.BLOCK, False, critical_findings
 
-    # No warning findings and no unverifiable packages => ALLOW
-    if not (warning_report or verification_report.unverifiable):
+    # No critical or warning findings and no unverifiable packages => ALLOW
+    if not (warning_findings or report.get_unverified()):
         return FirewallAction.ALLOW, False, None
 
     # Warning findings or unverifiable packages => configured warning action (or user confirmation)
-    relevant_findings = FindingsReport.merge(
-        warning_report if warning_report else FindingsReport(),
-        verification_report.unverifiable,
-    )
-
-    return warning_action, True, relevant_findings
+    return warning_action, True, warning_findings if warning_findings else None
 
 
 def _get_warning_action(cli_allow_choice: bool, cli_block_choice: bool) -> Optional[FirewallAction]:

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -85,7 +85,7 @@ class FirewallLogger(metaclass=ABCMeta):
         action: FirewallAction,
         warned: bool,
         relevant_findings: Optional[FindingsReport],
-        verification_report: Optional[VerificationReport],
+        report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -99,18 +99,8 @@ class FirewallLogger(metaclass=ABCMeta):
             warned:
                 Indicates whether the user was warned about findings for any installation
                 targets and prompted for approval to proceed with `command`.
-            relevant_findings:
-                The findings, if any, that are relevant to the `action` taken by Supply-Chain
-                Firewall. A `None` value indicates that the action was taken without relying
-                on any findings, which can occur when
-                    * There were no findings for any installation target
-                    * Installation target verification did not take place, usually because the
-                      underlying package manager was of an unsupported version
-            verification_report:
-                The complete `VerificationReport`, if any, resulting from installation target
-                verification. A `None` value indicates that installation target verification
-                did not take place, usually because the underlying package manager was of an
-                unsupported version.
+            relevant_findings: Lorem ipsum dolor sit amet.
+            report: Lorem ipsum dolor sit amet.
         """
         pass
 
@@ -129,10 +119,6 @@ class FirewallLogger(metaclass=ABCMeta):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            report:
-                The `VerificationReport` resulting from auditing the installed packages.
-
-                This report contains only those packages for which at least one verifier had
-                a finding. Packages with no findings are excluded from the audit results.
+            report: Lorem ipsum dolor sit amet.
         """
         pass

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -4,11 +4,13 @@ completed run of the supply-chain firewall.
 """
 
 from abc import (ABCMeta, abstractmethod)
+from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
+from scfw.package import Package
 from scfw.report import FindingsReport, VerificationReport
 
 
@@ -70,22 +72,31 @@ class FirewallAction(Enum):
         raise ValueError(f"Invalid firewall action '{s}'")
 
 
+@dataclass(eq=True, frozen=True)
+class FirewallRunSummary:
+    """
+    Lorem ipsum dolor sit amet
+    """
+    command: list[str]
+    install_targets: Optional[set[Package]]
+    report: Optional[VerificationReport]
+    relevant_findings: Optional[FindingsReport]
+    warned: bool
+    action: FirewallAction
+
+
 class FirewallLogger(metaclass=ABCMeta):
     """
     An interface for passing information about runs of Supply-Chain Firewall to
     client loggers.
     """
     @abstractmethod
-    def log_firewall_action(
+    def log_firewall_run(
         self,
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        command: list[str],
-        action: FirewallAction,
-        warned: bool,
-        relevant_findings: Optional[FindingsReport],
-        report: Optional[VerificationReport],
+        run_summary: FirewallRunSummary,
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -94,13 +105,7 @@ class FirewallLogger(metaclass=ABCMeta):
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            command: The package manager command line provided to the firewall.
-            action: The action taken by Supply-Chain Firewall.
-            warned:
-                Indicates whether the user was warned about findings for any installation
-                targets and prompted for approval to proceed with `command`.
-            relevant_findings: Lorem ipsum dolor sit amet.
-            report: Lorem ipsum dolor sit amet.
+            run_summary: Lorem ipsum dolor sit amet.
         """
         pass
 

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -81,7 +81,7 @@ class FirewallRunSummary:
     install_targets: Optional[set[Package]]
     report: Optional[VerificationReport]
     relevant_findings: Optional[FindingsReport]
-    warned: bool
+    warning: bool
     action: FirewallAction
 
 

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -72,7 +72,7 @@ class FirewallAction(Enum):
         raise ValueError(f"Invalid firewall action '{s}'")
 
 
-@dataclass(eq=True, frozen=True)
+@dataclass(eq=True)
 class FirewallRunSummary:
     """
     A structured summary of a run of Supply-Chain Firewall used for logging.

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -75,7 +75,7 @@ class FirewallAction(Enum):
 @dataclass(eq=True, frozen=True)
 class FirewallRunSummary:
     """
-    Lorem ipsum dolor sit amet
+    A structured summary of a run of Supply-Chain Firewall used for logging.
     """
     command: list[str]
     install_targets: Optional[set[Package]]
@@ -105,7 +105,7 @@ class FirewallLogger(metaclass=ABCMeta):
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: Lorem ipsum dolor sit amet.
+            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
         """
         pass
 
@@ -124,6 +124,6 @@ class FirewallLogger(metaclass=ABCMeta):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            report: Lorem ipsum dolor sit amet.
+            report: The report containing the verification results for the audited packages.
         """
         pass

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -25,11 +25,10 @@ import importlib
 import logging
 import os
 import pkgutil
-from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.logger import FirewallAction, FirewallLogger
-from scfw.report import FindingsReport, VerificationReport
+from scfw.logger import FirewallLogger, FirewallRunSummary
+from scfw.report import VerificationReport
 
 _log = logging.getLogger(__name__)
 
@@ -58,16 +57,12 @@ class FirewallLoggers(FirewallLogger):
         if not self._loggers:
             _log.warning("No loggers were discovered and successfully initialized")
 
-    def log_firewall_action(
+    def log_firewall_run(
         self,
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        command: list[str],
-        action: FirewallAction,
-        warned: bool,
-        relevant_findings: Optional[FindingsReport],
-        report: Optional[VerificationReport],
+        run_summary: FirewallRunSummary,
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall to
@@ -75,18 +70,14 @@ class FirewallLoggers(FirewallLogger):
         """
         for logger in self._loggers:
             try:
-                logger.log_firewall_action(
+                logger.log_firewall_run(
                     ecosystem,
                     package_manager,
                     executable,
-                    command,
-                    action,
-                    warned,
-                    relevant_findings,
-                    report,
+                    run_summary,
                 )
             except Exception as e:
-                _log.warning(f"Failed to log firewall action: {e}")
+                _log.warning(f"Failed to log firewall run: {e}")
 
     def log_audit(
         self,

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -67,7 +67,7 @@ class FirewallLoggers(FirewallLogger):
         action: FirewallAction,
         warned: bool,
         relevant_findings: Optional[FindingsReport],
-        verification_report: Optional[VerificationReport],
+        report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall to
@@ -83,7 +83,7 @@ class FirewallLoggers(FirewallLogger):
                     action,
                     warned,
                     relevant_findings,
-                    verification_report,
+                    report,
                 )
             except Exception as e:
                 _log.warning(f"Failed to log firewall action: {e}")

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -17,7 +17,7 @@ from scfw.constants import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE, SCFW
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger, FirewallRunSummary
 from scfw.package import Package
-from scfw.report import FindingsReport, UnverifiedReport, VerificationReport
+from scfw.report import FindingsReport, UnverifiablePackageReport, VerificationReport
 from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ _AUDIT_ATTRIBUTES = {
     "executable",
     "msg",
     "package_manager",
-    "unverified_packages",
+    "unverifiable",
 }
 _FIREWALL_ACTION_ATTRIBUTES = {
     "action",
@@ -42,7 +42,7 @@ _FIREWALL_ACTION_ATTRIBUTES = {
     "msg",
     "package_manager",
     "relevant_findings",
-    "unverified_packages",
+    "unverifiable",
     "verified",
     "warned",
 }
@@ -216,8 +216,8 @@ class DDLogger(FirewallLogger):
         if run_summary.relevant_findings:
             log_data["relevant_findings"] = _format_findings(run_summary.relevant_findings)
 
-        if run_summary.report is not None and (unverified_packages := run_summary.report.get_unverified()):
-            log_data["unverified_packages"] = _format_unverified(unverified_packages)
+        if run_summary.report is not None and (unverifiable := run_summary.report.get_unverifiable()):
+            log_data["unverifiable"] = _format_unverifiable(unverifiable)
 
         self._logger.info(
             f"Command '{' '.join(run_summary.command)}' was {str(run_summary.action).lower()}ed",
@@ -252,7 +252,7 @@ class DDLogger(FirewallLogger):
                     for severity in FindingSeverity
                     for formatted in _format_findings(report.get_findings(severity))
                 ],
-                "unverified_packages": _format_unverified(report.get_unverified()),
+                "unverifiable": _format_unverifiable(report.get_unverifiable()),
             }
         )
 
@@ -282,22 +282,22 @@ def _format_findings(
     ]
 
 
-def _format_unverified(
-    unverified_packages: UnverifiedReport,
+def _format_unverifiable(
+    unverifiable: UnverifiablePackageReport,
 ) -> list[dict[str, dict[str, Optional[str]] | list[dict[str, str]]]]:
     """
-    Format a set of unverified package errors for logging as JSON.
+    Format a set of unverifiable package error messages for logging as JSON.
     """
     return [
         {
             "package": package.to_dict(),
-            "unverified": [
+            "error_messages": [
                 {
-                    "verifier": unverified.verifier,
-                    "message": unverified.message,
+                    "verifier": error_message.verifier,
+                    "error_message": error_message.error_message,
                 }
-                for unverified in sorted(unverifieds, key=lambda u: u.verifier)
+                for error_message in sorted(error_messages, key=lambda e: e.verifier)
             ]
         }
-        for package, unverifieds in unverified_packages.items()
+        for package, error_messages in unverifiable.items()
     ]

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -36,9 +36,11 @@ _FIREWALL_ACTION_ATTRIBUTES = {
     "created",
     "ecosystem",
     "executable",
+    "installed_packages",
     "msg",
     "package_manager",
-    "targets",
+    "relevant_findings",
+    "unverified_packages",
     "verified",
     "warned",
 }
@@ -197,25 +199,50 @@ class DDLogger(FirewallLogger):
         if run_summary.action < self._level:
             return
 
-        # TODO(ikretz): Log unverifiable packages
-        if run_summary.action == FirewallAction.ALLOW and run_summary.report:
-            targets = sorted(map(str, run_summary.report.packages()))
-        elif run_summary.action == FirewallAction.BLOCK and run_summary.relevant_findings:
-            targets = sorted(map(str, run_summary.relevant_findings))
-        else:
-            targets = []
+        log_data = {
+            "ecosystem": str(ecosystem),
+            "package_manager": package_manager,
+            "executable": executable,
+            "action": str(run_summary.action),
+            "verified": run_summary.report is not None,
+            "warned": run_summary.warned,
+        }
+
+        if run_summary.action == FirewallAction.ALLOW and run_summary.install_targets:
+            log_data["installed_packages"] = list(
+                map(lambda p: p.to_dict(), sorted(run_summary.install_targets, key=str))
+            )
+
+        if run_summary.relevant_findings:
+            log_data["relevant_findings"] = [
+                {
+                    "package": package.to_dict(),
+                    "verifier": finding.verifier,
+                    "severity": str(finding.severity),
+                    "finding": finding.finding,
+                }
+                for package, findings in run_summary.relevant_findings.items()
+                for finding in sorted(findings, key=lambda f: f.severity)
+            ]
+
+        if run_summary.report is not None and (unverified_packages := run_summary.report.get_unverified()):
+            log_data["unverified_packages"] = [
+                {
+                    "package": package.to_dict(),
+                    "unverified": [
+                        {
+                            "verifier": unverified.verifier,
+                            "message": unverified.message,
+                        }
+                        for unverified in sorted(unverifieds, key=lambda u: u.verifier)
+                    ]
+                }
+                for package, unverifieds in unverified_packages.items()
+            ]
 
         self._logger.info(
             f"Command '{' '.join(run_summary.command)}' was {str(run_summary.action).lower()}ed",
-            extra={
-                "ecosystem": str(ecosystem),
-                "package_manager": package_manager,
-                "executable": executable,
-                "targets": targets,
-                "action": str(run_summary.action),
-                "verified": run_summary.report is not None,
-                "warned": run_summary.warned,
-            }
+            extra=log_data,
         )
 
     def log_audit(

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -38,7 +38,7 @@ _FIREWALL_ACTION_ATTRIBUTES = {
     "created",
     "ecosystem",
     "executable",
-    "installed_packages",
+    "install_targets",
     "msg",
     "package_manager",
     "relevant_findings",
@@ -210,8 +210,8 @@ class DDLogger(FirewallLogger):
             "warned": run_summary.warned,
         }
 
-        if run_summary.action == FirewallAction.ALLOW and run_summary.install_targets:
-            log_data["installed_packages"] = _format_packages(run_summary.install_targets)
+        if run_summary.install_targets:
+            log_data["install_targets"] = _format_packages(run_summary.install_targets)
 
         if run_summary.relevant_findings:
             log_data["relevant_findings"] = _format_findings(run_summary.relevant_findings)

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -8,7 +8,7 @@ import logging
 import os
 from pathlib import Path
 import socket
-from typing import Any
+from typing import Any, Iterable, Optional
 
 import dotenv
 
@@ -16,20 +16,22 @@ import scfw
 from scfw.constants import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE, SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger, FirewallRunSummary
-from scfw.report import VerificationReport
+from scfw.package import Package
+from scfw.report import FindingsReport, UnverifiedReport, VerificationReport
 from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
 # The `created` and `msg` attributes are provided by `logging.LogRecord`
 _AUDIT_ATTRIBUTES = {
+    "audited_packages",
     "created",
     "ecosystem",
+    "findings",
     "executable",
     "msg",
     "package_manager",
-    "reports",
-    "unverifiable",
+    "unverified_packages",
 }
 _FIREWALL_ACTION_ATTRIBUTES = {
     "action",
@@ -209,36 +211,13 @@ class DDLogger(FirewallLogger):
         }
 
         if run_summary.action == FirewallAction.ALLOW and run_summary.install_targets:
-            log_data["installed_packages"] = list(
-                map(lambda p: p.to_dict(), sorted(run_summary.install_targets, key=str))
-            )
+            log_data["installed_packages"] = _format_packages(run_summary.install_targets)
 
         if run_summary.relevant_findings:
-            log_data["relevant_findings"] = [
-                {
-                    "package": package.to_dict(),
-                    "verifier": finding.verifier,
-                    "severity": str(finding.severity),
-                    "finding": finding.finding,
-                }
-                for package, findings in run_summary.relevant_findings.items()
-                for finding in sorted(findings, key=lambda f: f.severity)
-            ]
+            log_data["relevant_findings"] = _format_findings(run_summary.relevant_findings)
 
         if run_summary.report is not None and (unverified_packages := run_summary.report.get_unverified()):
-            log_data["unverified_packages"] = [
-                {
-                    "package": package.to_dict(),
-                    "unverified": [
-                        {
-                            "verifier": unverified.verifier,
-                            "message": unverified.message,
-                        }
-                        for unverified in sorted(unverifieds, key=lambda u: u.verifier)
-                    ]
-                }
-                for package, unverifieds in unverified_packages.items()
-            ]
+            log_data["unverified_packages"] = _format_unverified(unverified_packages)
 
         self._logger.info(
             f"Command '{' '.join(run_summary.command)}' was {str(run_summary.action).lower()}ed",
@@ -267,10 +246,58 @@ class DDLogger(FirewallLogger):
                 "ecosystem": str(ecosystem),
                 "package_manager": package_manager,
                 "executable": executable,
-                "reports": {
-                    str(severity): sorted(map(str, report.get_findings(severity)))
+                "audited_packages": _format_packages(report.packages()),
+                "findings": [
+                    formatted
                     for severity in FindingSeverity
-                },
-                "unverifiable": sorted(map(str, report.get_unverified())),
+                    for formatted in _format_findings(report.get_findings(severity))
+                ],
+                "unverified_packages": _format_unverified(report.get_unverified()),
             }
         )
+
+
+def _format_packages(packages: Iterable[Package]) -> list[dict[str, Optional[str]]]:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    return list(map(lambda package: package.to_dict(), sorted(packages, key=str)))
+
+
+def _format_findings(
+    findings: FindingsReport,
+) -> list[dict[str, str | dict[str, Optional[str]]]]:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    return [
+        {
+            "package": package.to_dict(),
+            "verifier": finding.verifier,
+            "severity": str(finding.severity),
+            "finding": finding.finding,
+        }
+        for package, findings in findings.items()
+        for finding in sorted(findings, key=lambda f: f.severity)
+    ]
+
+
+def _format_unverified(
+    unverified_packages: UnverifiedReport,
+) -> list[dict[str, dict[str, Optional[str]] | list[dict[str, str]]]]:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    return [
+        {
+            "package": package.to_dict(),
+            "unverified": [
+                {
+                    "verifier": unverified.verifier,
+                    "message": unverified.message,
+                }
+                for unverified in sorted(unverifieds, key=lambda u: u.verifier)
+            ]
+        }
+        for package, unverifieds in unverified_packages.items()
+    ]

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -17,6 +17,7 @@ from scfw.constants import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE, SCFW
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger
 from scfw.report import FindingsReport, VerificationReport
+from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
 
@@ -186,7 +187,7 @@ class DDLogger(FirewallLogger):
         action: FirewallAction,
         warned: bool,
         relevant_findings: Optional[FindingsReport],
-        verification_report: Optional[VerificationReport],
+        report: Optional[VerificationReport],
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -199,15 +200,16 @@ class DDLogger(FirewallLogger):
             action: The action taken by the firewall.
             warned: Indicates whether the user was warned about findings and prompted for approval.
             relevant_findings: The findings, if any, relevant to the action taken.
-            verification_report: The complete `VerificationReport`, if any, resulting from verification.
+            report: The complete `VerificationReport`, if any, resulting from verification.
         """
         if action < self._level:
             return
 
-        if action == FirewallAction.ALLOW and verification_report:
-            targets = sorted(map(str, verification_report.verification_set))
+        # TODO(ikretz): Log unverifiable packages
+        if action == FirewallAction.ALLOW and report:
+            targets = sorted(map(str, report.packages()))
         elif action == FirewallAction.BLOCK and relevant_findings:
-            targets = sorted(map(str, relevant_findings.packages()))
+            targets = sorted(map(str, relevant_findings))
         else:
             targets = []
 
@@ -219,7 +221,7 @@ class DDLogger(FirewallLogger):
                 "executable": executable,
                 "targets": targets,
                 "action": str(action),
-                "verified": verification_report is not None,
+                "verified": report is not None,
                 "warned": warned,
             }
         )
@@ -247,9 +249,9 @@ class DDLogger(FirewallLogger):
                 "package_manager": package_manager,
                 "executable": executable,
                 "reports": {
-                    str(severity): list(map(str, findings_report.packages()))
-                    for severity, findings_report in report.findings_reports.items()
+                    str(severity): sorted(map(str, report.get_findings(severity)))
+                    for severity in FindingSeverity
                 },
-                "unverifiable": list(map(str, report.unverifiable.packages())),
+                "unverifiable": sorted(map(str, report.get_unverified())),
             }
         )

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -8,15 +8,15 @@ import logging
 import os
 from pathlib import Path
 import socket
-from typing import Any, Optional
+from typing import Any
 
 import dotenv
 
 import scfw
 from scfw.constants import DD_ENV, DD_LOG_LEVEL_VAR, DD_SERVICE, DD_SOURCE, SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
-from scfw.logger import FirewallAction, FirewallLogger
-from scfw.report import FindingsReport, VerificationReport
+from scfw.logger import FirewallAction, FirewallLogger, FirewallRunSummary
+from scfw.report import VerificationReport
 from scfw.verifier import FindingSeverity
 
 _log = logging.getLogger(__name__)
@@ -178,16 +178,12 @@ class DDLogger(FirewallLogger):
         except ValueError:
             _log.warning(f"Invalid value for {DD_LOG_LEVEL_VAR}: using default level {_DD_LOG_LEVEL_DEFAULT}")
 
-    def log_firewall_action(
+    def log_firewall_run(
         self,
         ecosystem: ECOSYSTEM,
         package_manager: str,
         executable: str,
-        command: list[str],
-        action: FirewallAction,
-        warned: bool,
-        relevant_findings: Optional[FindingsReport],
-        report: Optional[VerificationReport],
+        run_summary: FirewallRunSummary,
     ):
         """
         Log the data and action taken in a completed run of Supply-Chain Firewall.
@@ -196,33 +192,29 @@ class DDLogger(FirewallLogger):
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            command: The package manager command line provided to the firewall.
-            action: The action taken by the firewall.
-            warned: Indicates whether the user was warned about findings and prompted for approval.
-            relevant_findings: The findings, if any, relevant to the action taken.
-            report: The complete `VerificationReport`, if any, resulting from verification.
+            run_summary: Lorem ipsum dolor sit amet.
         """
-        if action < self._level:
+        if run_summary.action < self._level:
             return
 
         # TODO(ikretz): Log unverifiable packages
-        if action == FirewallAction.ALLOW and report:
-            targets = sorted(map(str, report.packages()))
-        elif action == FirewallAction.BLOCK and relevant_findings:
-            targets = sorted(map(str, relevant_findings))
+        if run_summary.action == FirewallAction.ALLOW and run_summary.report:
+            targets = sorted(map(str, run_summary.report.packages()))
+        elif run_summary.action == FirewallAction.BLOCK and run_summary.relevant_findings:
+            targets = sorted(map(str, run_summary.relevant_findings))
         else:
             targets = []
 
         self._logger.info(
-            f"Command '{' '.join(command)}' was {str(action).lower()}ed",
+            f"Command '{' '.join(run_summary.command)}' was {str(run_summary.action).lower()}ed",
             extra={
                 "ecosystem": str(ecosystem),
                 "package_manager": package_manager,
                 "executable": executable,
                 "targets": targets,
-                "action": str(action),
-                "verified": report is not None,
-                "warned": warned,
+                "action": str(run_summary.action),
+                "verified": run_summary.report is not None,
+                "warned": run_summary.warned,
             }
         )
 

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -196,7 +196,7 @@ class DDLogger(FirewallLogger):
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: Lorem ipsum dolor sit amet.
+            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
         """
         if run_summary.action < self._level:
             return
@@ -238,7 +238,7 @@ class DDLogger(FirewallLogger):
             ecosystem: The ecosystem of the audited packages.
             package_manager: The package manager that manages the audited packages.
             executable: The package manager executable used to enumerate audited packages.
-            report: The `VerificationReport` resulting from auditing the installed packages.
+            report: The report containing the verification results for the audited packages.
         """
         self._logger.info(
             f"Successfully audited {ecosystem} packages managed by {package_manager}",
@@ -259,7 +259,7 @@ class DDLogger(FirewallLogger):
 
 def _format_packages(packages: Iterable[Package]) -> list[dict[str, Optional[str]]]:
     """
-    Lorem ipsum dolor sit amet.
+    Format a set of `Package` for logging as JSON.
     """
     return list(map(lambda package: package.to_dict(), sorted(packages, key=str)))
 
@@ -268,7 +268,7 @@ def _format_findings(
     findings: FindingsReport,
 ) -> list[dict[str, str | dict[str, Optional[str]]]]:
     """
-    Lorem ipsum dolor sit amet.
+    Format a set of findings for logging as JSON.
     """
     return [
         {
@@ -286,7 +286,7 @@ def _format_unverified(
     unverified_packages: UnverifiedReport,
 ) -> list[dict[str, dict[str, Optional[str]] | list[dict[str, str]]]]:
     """
-    Lorem ipsum dolor sit amet.
+    Format a set of unverified package errors for logging as JSON.
     """
     return [
         {

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -44,7 +44,7 @@ _FIREWALL_ACTION_ATTRIBUTES = {
     "relevant_findings",
     "unverifiable",
     "verified",
-    "warned",
+    "warning",
 }
 
 _ALL_LOG_ATTRIBUTES = _AUDIT_ATTRIBUTES | _FIREWALL_ACTION_ATTRIBUTES
@@ -207,7 +207,7 @@ class DDLogger(FirewallLogger):
             "executable": executable,
             "action": str(run_summary.action),
             "verified": run_summary.report is not None,
-            "warned": run_summary.warned,
+            "warning": run_summary.warning,
         }
 
         if run_summary.install_targets:

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -106,3 +106,21 @@ class Package:
         }
 
         return any(re.match(pattern, remote_source.remote_source) is not None for pattern in patterns)
+
+    def to_dict(self) -> dict[str, Optional[str]]:
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        if (s := self.get_local_source()):
+            source = str(s.local_source)
+        elif (s := self.get_remote_source()):
+            source = s.remote_source
+        else:
+            source = None
+
+        return {
+            "ecosystem": str(self.ecosystem),
+            "name": self.name,
+            "version": self.version,
+            "source": source,
+        }

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -109,7 +109,14 @@ class Package:
 
     def to_dict(self) -> dict[str, Optional[str]]:
         """
-        Lorem ipsum dolor sit amet.
+        Generate a JSON-compatible dictionary representation of a `Package`.
+
+        Returns:
+            A JSON-compatible `dict` representing the contents of the given `Package`.
+
+            The distinction between local and remote package artifact sources is
+            erased in the returned `dict`: instead, a `str` representation of the
+            underlying URl or local file path is included (or `None`).
         """
         if (local_source := self.get_local_source()):
             source = str(local_source.local_source)

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -116,7 +116,7 @@ class Package:
 
             The distinction between local and remote package artifact sources is
             erased in the returned `dict`: instead, a `str` representation of the
-            underlying URl or local file path is included (or `None`).
+            underlying URL or local file path is included (or `None`).
         """
         if (local_source := self.get_local_source()):
             source = str(local_source.local_source)

--- a/scfw/package.py
+++ b/scfw/package.py
@@ -111,10 +111,10 @@ class Package:
         """
         Lorem ipsum dolor sit amet.
         """
-        if (s := self.get_local_source()):
-            source = str(s.local_source)
-        elif (s := self.get_remote_source()):
-            source = s.remote_source
+        if (local_source := self.get_local_source()):
+            source = str(local_source.local_source)
+        elif (remote_source := self.get_remote_source()):
+            source = remote_source.remote_source
         else:
             source = None
 

--- a/scfw/package_manager.py
+++ b/scfw/package_manager.py
@@ -64,7 +64,7 @@ class PackageManager(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def resolve_install_targets(self, command: list[str]) -> list[Package]:
+    def resolve_install_targets(self, command: list[str]) -> set[Package]:
         """
         Resolve the package targets that would be installed if the given package
         manager command were run (without running it).
@@ -73,18 +73,18 @@ class PackageManager(metaclass=ABCMeta):
             command: The package manager command whose installation targets are to be resolved.
 
         Returns:
-            A `list[Package]` representing the package targets that would be installed
+            A `set[Package]` representing the package targets that would be installed
             if `command` were run.
         """
         pass
 
     @abstractmethod
-    def list_installed_packages(self) -> list[Package]:
+    def get_installed_packages(self) -> set[Package]:
         """
-        List all installed packages.
+        Return the set of currently installed packages.
 
         Returns:
-            A `list[Package]` representing all currently installed packages.
+            A `set[Package]` representing all currently installed packages.
         """
         pass
 

--- a/scfw/package_managers/npm/__init__.py
+++ b/scfw/package_managers/npm/__init__.py
@@ -86,7 +86,7 @@ class Npm(PackageManager):
         """
         return subprocess.run(self._normalize_command(command)).returncode
 
-    def resolve_install_targets(self, command: list[str]) -> list[Package]:
+    def resolve_install_targets(self, command: list[str]) -> set[Package]:
         """
         Resolve the installation targets of the given `npm` command.
 
@@ -96,7 +96,7 @@ class Npm(PackageManager):
                 are to be resolved.
 
         Returns:
-            A `list[Package]` representing the package targets that would be installed
+            A `set[Package]` representing the package targets that would be installed
             if `command` were run.
 
         Raises:
@@ -109,13 +109,13 @@ class Npm(PackageManager):
 
         # For now, allow all non-`install` commands
         if not any(alias in command for alias in _INSTALL_COMMAND_ALIASES):
-            return []
+            return set()
 
         self._check_version()
 
         # On supported versions, the presence of these options prevents the command from running
         if any(opt in command for opt in {"-h", "--help", "--dry-run", "--version"}):
-            return []
+            return set()
 
         try:
             with TemporaryNpmProject(self._executable) as temp_project:
@@ -124,22 +124,22 @@ class Npm(PackageManager):
         except Exception as e:
             raise RuntimeError(f"Failed to resolve npm installation targets: {e}")
 
-    def list_installed_packages(self) -> list[Package]:
+    def get_installed_packages(self) -> set[Package]:
         """
-        List all `npm` packages installed in the active `npm` environment.
+        Return the set of `npm` packages installed in the active `npm` environment.
 
         Returns:
-            A `list[Package]` representing all `npm` packages installed in the active
+            A `set[Package]` representing all `npm` packages installed in the active
             `npm` environment.
 
         Raises:
-            RuntimeError: Failed to list installed packages or decode report JSON.
+            RuntimeError: Failed to determine installed packages or decode report JSON.
             UnsupportedVersionError: The underlying `npm` executable is of an unsupported version.
         """
         self._check_version()
 
         try:
-            return installed.list_installed_packages(self.executable())
+            return installed.get_installed_packages(self.executable())
 
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Failed to decode installed package report JSON: {e}")

--- a/scfw/package_managers/npm/installed.py
+++ b/scfw/package_managers/npm/installed.py
@@ -1,5 +1,5 @@
 """
-Provides logic for listing installed npm packages in the active environment.
+Provides logic for determining installed npm packages.
 """
 
 import json
@@ -15,15 +15,15 @@ from scfw.package_managers.npm.common import FILE_URI_PREFIX, NODE_MODULES_PREFI
 _log = logging.getLogger(__name__)
 
 
-def list_installed_packages(executable: str) -> list[Package]:
+def get_installed_packages(executable: str) -> set[Package]:
     """
-    List all npm packages installed in the active npm environment.
+    Return the set of npm packages installed in the active npm environment.
 
     Args:
         executable: Path to the npm executable.
 
     Returns:
-        A `list[Package]` representing all npm packages installed in the active environment.
+        A `set[Package]` representing all npm packages installed in the active environment.
 
     Raises:
         RuntimeError:
@@ -49,7 +49,7 @@ def list_installed_packages(executable: str) -> list[Package]:
 
     resolved_fallback = _load_lock_file_resolved_map(Path.cwd() / "package-lock.json")
 
-    return list(_dependencies_to_packages(dependencies, resolved_fallback))
+    return _dependencies_to_packages(dependencies, resolved_fallback)
 
 
 def _dependencies_to_packages(

--- a/scfw/package_managers/npm/temp_project.py
+++ b/scfw/package_managers/npm/temp_project.py
@@ -207,7 +207,7 @@ class TemporaryNpmProject:
         self._temp_dir.cleanup()
         self._temp_dir = None
 
-    def resolve_install_command_targets(self, install_command: list[str]) -> list[Package]:
+    def resolve_install_command_targets(self, install_command: list[str]) -> set[Package]:
         """
         Resolve installation targets for an `npm install` command in the temporary environment.
 
@@ -218,7 +218,7 @@ class TemporaryNpmProject:
                 to ensure only `npm install` commands are passed to this method.
 
         Returns:
-            A `list[Package]` representing the set of installation targets that would be
+            A `set[Package]` representing the set of installation targets that would be
             installed by the given `npm install` command.
 
         Raises:
@@ -340,14 +340,14 @@ class TemporaryNpmProject:
             )
         except subprocess.CalledProcessError:
             _log.info("Input npm install command results in error: nothing will be installed")
-            return []
+            return set()
 
         dry_run_log = dry_run_process.stderr.strip().split('\n')
 
         # Each target handle corresponds to a (possibly duplicated) installation target
         target_handles = extract_target_handles(dry_run_log, temp_dir_path)
         if not target_handles:
-            return []
+            return set()
 
         # Safely run the given `npm install` command to write or update the lockfile
         # All supported versions of npm support these additional `install` command options
@@ -366,7 +366,7 @@ class TemporaryNpmProject:
                 raise KeyError("Malformed dependencies data in package-lock.json")
 
         # Read added and changed packages out of the lockfile
-        return list({handle_to_install_target(dependencies, handle) for handle in target_handles})
+        return set({handle_to_install_target(dependencies, handle) for handle in target_handles})
 
     def _normalize_command(self, command: list[str]) -> list[str]:
         """

--- a/scfw/package_managers/pip.py
+++ b/scfw/package_managers/pip.py
@@ -95,7 +95,7 @@ class Pip(PackageManager):
         """
         return subprocess.run(self._normalize_command(command)).returncode
 
-    def resolve_install_targets(self, command: list[str]) -> list[Package]:
+    def resolve_install_targets(self, command: list[str]) -> set[Package]:
         """
         Resolve the installation targets of the given `pip` command.
 
@@ -105,7 +105,7 @@ class Pip(PackageManager):
                 are to be resolved.
 
         Returns:
-            A `list[Package]` representing the package targets that would be installed
+            A `set[Package]` representing the package targets that would be installed
             if `command` were run.
 
         Raises:
@@ -132,13 +132,13 @@ class Pip(PackageManager):
         # pip only installs or upgrades packages via the `pip install` subcommand
         # If `install` is not present, the command is automatically safe to run
         if "install" not in command:
-            return []
+            return set()
 
         self._check_version()
 
         # On supported versions, the presence of these options prevents the command from running
         if any(opt in command for opt in {"-h", "--help", "--dry-run"}):
-            return []
+            return set()
 
         # Otherwise, this is probably a live `pip install` command
         # To be certain, we would need to write a full parser for pip
@@ -146,23 +146,23 @@ class Pip(PackageManager):
             dry_run_command = command + ["--dry-run", "-qqqqq", "--report", "-"]
             dry_run = subprocess.run(dry_run_command, check=True, text=True, capture_output=True)
             install_reports = json.loads(dry_run.stdout).get("install", [])
-            return list(map(report_to_install_target, install_reports))
+            return set(map(report_to_install_target, install_reports))
         except subprocess.CalledProcessError:
             # An error must have resulted from the given pip command
             # As nothing will be installed in this case, allow the command
             _log.info("Encountered an error while resolving pip installation targets")
-            return []
+            return set()
 
-    def list_installed_packages(self) -> list[Package]:
+    def get_installed_packages(self) -> set[Package]:
         """
-        List all `PyPI` packages installed in the active `pip` environment.
+        Return the set of `PyPI` packages installed in the active `pip` environment.
 
         Returns:
-            A `list[Package]` representing all `PyPI` packages installed in the active
+            A `set[Package]` representing all `PyPI` packages installed in the active
             `pip` environment.
 
         Raises:
-            RuntimeError: Failed to list installed packages or decode report JSON.
+            RuntimeError: Failed to determine installed packages or decode report JSON.
             UnsupportedVersionError: The underlying `pip` executable is of an unsupported version.
         """
         def inspect_entry_to_package(entry: dict) -> Optional[Package]:
@@ -201,13 +201,13 @@ class Pip(PackageManager):
         try:
             pip_inspect_command = self._normalize_command(["pip", "inspect"])
             pip_inspect = subprocess.run(pip_inspect_command, check=True, text=True, capture_output=True)
-            return [
+            return {
                 p for entry in json.loads(pip_inspect.stdout).get("installed", [])
                 if (p := inspect_entry_to_package(entry)) is not None
-            ]
+            }
 
         except subprocess.CalledProcessError:
-            raise RuntimeError("Failed to list pip installed packages")
+            raise RuntimeError("Failed to determine pip installed packages")
 
         except json.JSONDecodeError:
             raise RuntimeError("Failed to decode installed package report JSON")

--- a/scfw/package_managers/poetry.py
+++ b/scfw/package_managers/poetry.py
@@ -81,7 +81,7 @@ class Poetry(PackageManager):
         """
         return subprocess.run(self._normalize_command(command)).returncode
 
-    def resolve_install_targets(self, command: list[str]) -> list[Package]:
+    def resolve_install_targets(self, command: list[str]) -> set[Package]:
         """
         Resolve the installation targets of the given `poetry` command.
 
@@ -91,7 +91,7 @@ class Poetry(PackageManager):
                 are to be resolved.
 
         Returns:
-            A `list[Package]` representing the package targets that would be installed
+            A `set[Package]` representing the package targets that would be installed
             if `command` were run.
 
         Raises:
@@ -113,33 +113,33 @@ class Poetry(PackageManager):
         command = self._normalize_command(command)
 
         if not any(subcommand in command for subcommand in INSPECTED_SUBCOMMANDS):
-            return []
+            return set()
 
         self._check_version()
 
         # On supported versions, the presence of these options prevents the command from running
         if any(opt in command for opt in {"-V", "--version", "-h", "--help", "--dry-run"}):
-            return []
+            return set()
 
         try:
             # Compute installation targets: new dependencies and updates/downgrades of existing ones
             dry_run = subprocess.run(command + ["--dry-run"], check=True, text=True, capture_output=True)
-            return list(filter(None, map(line_to_package, dry_run.stdout.split('\n'))))
+            return set(filter(None, map(line_to_package, dry_run.stdout.split('\n'))))
         except subprocess.CalledProcessError:
             # An erroring command does not install anything
             _log.info("Encountered an error while resolving poetry installation targets")
-            return []
+            return set()
 
-    def list_installed_packages(self) -> list[Package]:
+    def get_installed_packages(self) -> set[Package]:
         """
-        List all `PyPI` packages installed in the active `poetry` environment.
+        Return the set of `PyPI` packages installed in the active `poetry` environment.
 
         Returns:
-            A `list[Package]` representing all `PyPI` packages installed in the active
+            A `set[Package]` representing all `PyPI` packages installed in the active
             `poetry` environment.
 
         Raises:
-            RuntimeError: Failed to list installed packages.
+            RuntimeError: Failed to determine installed packages.
             ValueError: Malformed installed package report.
             UnsupportedVersionError: The underlying `poetry` executable is of an unsupported version.
         """
@@ -153,10 +153,10 @@ class Poetry(PackageManager):
             poetry_show_command = self._normalize_command(["poetry", "show", "--all"])
             poetry_show = subprocess.run(poetry_show_command, check=True, text=True, capture_output=True)
             installed_report = poetry_show.stdout.strip()
-            return list(map(line_to_package, installed_report.split('\n'))) if installed_report else []
+            return set(map(line_to_package, installed_report.split('\n'))) if installed_report else set()
 
         except subprocess.CalledProcessError:
-            raise RuntimeError("Failed to list poetry installed packages")
+            raise RuntimeError("Failed to determine poetry installed packages")
 
         except IndexError:
             raise ValueError("Malformed installed package report")

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -12,7 +12,7 @@ from scfw.verifier import Finding, FindingSeverity
 @dataclass(eq=True, frozen=True)
 class Unverified:
     """
-    Lorem ipsum dolor sit amet.
+    A message from a verifier indicating why it was unable to verify.
     """
     verifier: str
     message: str
@@ -20,22 +20,22 @@ class Unverified:
 
 FindingsReport: TypeAlias = dict[Package, set[Finding]]
 """
-Lorem ipsum dolor sit amet.
+A structured report containing findings for a set of `Package`.
 """
 
 UnverifiedReport: TypeAlias = dict[Package, set[Unverified]]
 """
-Lorem ipsum dolor sit amet.
+A structured report containing unverifiable messages for a set of `Package`.
 """
 
 
 class VerificationReport:
     """
-    Lorem ipsum dolor sit amet.
+    A structured report containing the results of verifying a set of `Package`.
     """
     def __init__(self) -> None:
         """
-        Lorem ipsum dolor sit amet.
+        Initialize an empty `VerificationReport`.
         """
         self._clean: set[Package] = set()
         self._findings: FindingsReport = {}
@@ -43,13 +43,21 @@ class VerificationReport:
 
     def get_clean(self) -> set[Package]:
         """
-        Lorem ipsum dolor sit amet.
+        Return the set of "clean" packages contained in the report.
+
+        Returns:
+            A `set[Package]` containing those packages in the report which were
+            able to be verified successfully and for which there were no findings.
         """
         return set(self._clean)
 
     def get_findings(self, severity: FindingSeverity) -> FindingsReport:
         """
-        Lorem ipsum dolor sit amet.
+        Return a structured report on packages that had findings of a given severity.
+
+        Returns:
+            A `FindingsReport` covering the `Package` contained in the report that
+            had reported findings of the given `FindingSeverity.
         """
         severity_findings = {}
 
@@ -61,13 +69,24 @@ class VerificationReport:
 
     def get_unverified(self) -> UnverifiedReport:
         """
-        Lorem ipsum dolor sit amet.
+        Return a structured report on packages that were unable to be verified.
+
+        Returns:
+            A `UnverifiedReport` covering the `Package` contained in the report
+            that were unable to be verified by at least one verifier.
         """
         return {package: set(unverified) for package, unverified in self._unverified.items()}
 
     def insert_clean(self, package: Package) -> None:
         """
-        Lorem ipsum dolor sit amet.
+        Insert a clean package into the report.
+
+        Args:
+            package:
+                The clean `Package` to be inserted into the report.
+
+                This function is a no-op if `package` already has findings in the report
+                or is known to be unverifiable by at least one verifier.
         """
         if package in self._findings or package in self._unverified:
             return
@@ -76,7 +95,11 @@ class VerificationReport:
 
     def insert_finding(self, package: Package, finding: Finding) -> None:
         """
-        Lorem ipsum dolor sit amet.
+        Insert a finding for a given package into the report.
+
+        Args:
+            `package`: The `Package` the finding pertains to.
+            `finding`: The `Finding` to be inserted for `package`.
         """
         if package not in self._findings:
             self._findings[package] = set()
@@ -87,7 +110,11 @@ class VerificationReport:
 
     def insert_unverified(self, package: Package, unverified: Unverified) -> None:
         """
-        Lorem ipsum dolor sit amet.
+        Insert an unverified message for a given package into the report.
+
+        Args:
+            `package`: The `Package` the unverified message pertains to.
+            `unverified`: The `Unverified` message to be inserted for `package`.
         """
         if package not in self._unverified:
             self._unverified[package] = set()
@@ -98,14 +125,25 @@ class VerificationReport:
 
     def packages(self) -> set[Package]:
         """
-        Lorem ipsum dolor sit amet.
+        Return the set of packages contained in the report.
+
+        Returns:
+            A `set[Package]` containing all packages mentioned in the report.
         """
         return self._clean | set(self._findings) | set(self._unverified)
 
 
 def show_reports(findings_reports: list[FindingsReport], unverified_report: UnverifiedReport) -> str:
     """
-    Lorem ipsum dolor sit amet.
+    Return a pretty-printed string representation of the given reports.
+
+    Args:
+        `findings_reports`: A `list[FindingsReports]` to be formatted for printing.
+        'unverified_report`: An `UnverifiedReport` to be formatted for printing.
+
+    Returns:
+        A pretty-printed `str` representation of the given reports suitable for displaying
+        to the user during a run of Supply-Chain Firewall.
     """
     def show_line(linenum: int, line: str) -> str:
         return (f"  - {line}" if linenum == 0 else f"    {line}")

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -101,3 +101,47 @@ class VerificationReport:
         Lorem ipsum dolor sit amet.
         """
         return self._clean | set(self._findings) | set(self._unverified)
+
+
+def show_reports(findings_reports: list[FindingsReport], unverified_report: UnverifiedReport) -> str:
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    def show_line(linenum: int, line: str) -> str:
+        return (f"  - {line}" if linenum == 0 else f"    {line}")
+
+    def show_finding(finding: str) -> str:
+        return '\n'.join(
+            show_line(linenum, line) for linenum, line in enumerate(finding.split('\n'))
+        )
+
+    def show_output(package: Package, findings: list[str]) -> str:
+        return f"Package {package}:\n" + '\n'.join(map(show_finding, findings))
+
+    # Combine the given `FindingsReport` into a single one
+    combined_findings_report: FindingsReport = {}
+    for findings_report in findings_reports:
+        for package, findings in findings_report.items():
+            if package not in combined_findings_report:
+                combined_findings_report[package] = set(findings)
+            else:
+                combined_findings_report[package] |= findings
+
+    # Sort the findings for each package based on severity
+    sorted_findings = {
+        package: sorted(findings, key=lambda f: f.severity)
+        for package, findings in combined_findings_report.items()
+    }
+
+    # Prepare the findings + unverified output for each package
+    combined_output = {}
+    for package in set(sorted_findings) | set(unverified_report):
+        findings = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
+        unverified = list(map(lambda u: u.message, unverified_report.get(package, {})))
+        combined_output[package] = findings + unverified
+
+    # Print the output to string, alphabetized by package name
+    return '\n'.join(
+        show_output(package, combined_output[package])
+        for package in sorted(set(sorted_findings) | set(unverified_report), key=str)
+    )

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -10,12 +10,12 @@ from scfw.verifier import Finding, FindingSeverity
 
 
 @dataclass(eq=True, frozen=True)
-class Unverified:
+class VerifierErrorMessage:
     """
-    A message from a verifier indicating why it was unable to verify.
+    An error message from a given verifier.
     """
     verifier: str
-    message: str
+    error_message: str
 
 
 FindingsReport: TypeAlias = dict[Package, set[Finding]]
@@ -23,9 +23,9 @@ FindingsReport: TypeAlias = dict[Package, set[Finding]]
 A structured report containing findings for a set of `Package`.
 """
 
-UnverifiedReport: TypeAlias = dict[Package, set[Unverified]]
+UnverifiablePackageReport: TypeAlias = dict[Package, set[VerifierErrorMessage]]
 """
-A structured report containing unverifiable messages for a set of `Package`.
+A structured report containing `UnverifiablePackage` error messages for a set of `Package`.
 """
 
 
@@ -39,7 +39,7 @@ class VerificationReport:
         """
         self._clean: set[Package] = set()
         self._findings: FindingsReport = {}
-        self._unverified: UnverifiedReport = {}
+        self._unverifiable: UnverifiablePackageReport = {}
 
     def get_clean(self) -> set[Package]:
         """
@@ -67,15 +67,17 @@ class VerificationReport:
 
         return severity_findings
 
-    def get_unverified(self) -> UnverifiedReport:
+    def get_unverifiable(self) -> UnverifiablePackageReport:
         """
         Return a structured report on packages that were unable to be verified.
 
         Returns:
-            A `UnverifiedReport` covering the `Package` contained in the report
-            that were unable to be verified by at least one verifier.
+            An `UnverifiablePackageReport` covering the `Package` contained in the report
+            for which a verifier raised an `UnverifiablePackage` error.
         """
-        return {package: set(unverified) for package, unverified in self._unverified.items()}
+        return {
+            package: set(error_message) for package, error_message in self._unverifiable.items()
+        }
 
     def insert_clean(self, package: Package) -> None:
         """
@@ -88,7 +90,7 @@ class VerificationReport:
                 This function is a no-op if `package` already has findings in the report
                 or is known to be unverifiable by at least one verifier.
         """
-        if package in self._findings or package in self._unverified:
+        if package in self._findings or package in self._unverifiable:
             return
 
         self._clean.add(package)
@@ -108,17 +110,17 @@ class VerificationReport:
         if package in self._clean:
             self._clean.remove(package)
 
-    def insert_unverified(self, package: Package, unverified: Unverified) -> None:
+    def insert_unverifiable(self, package: Package, error_message: VerifierErrorMessage) -> None:
         """
-        Insert an unverified message for a given package into the report.
+        Insert an unverifiable package error message for a given package into the report.
 
         Args:
             `package`: The `Package` the unverified message pertains to.
-            `unverified`: The `Unverified` message to be inserted for `package`.
+            `error_message`: The `VerifierErrorMessage` to be inserted for `package`.
         """
-        if package not in self._unverified:
-            self._unverified[package] = set()
-        self._unverified[package].add(unverified)
+        if package not in self._unverifiable:
+            self._unverifiable[package] = set()
+        self._unverifiable[package].add(error_message)
 
         if package in self._clean:
             self._clean.remove(package)
@@ -130,16 +132,19 @@ class VerificationReport:
         Returns:
             A `set[Package]` containing all packages mentioned in the report.
         """
-        return self._clean | set(self._findings) | set(self._unverified)
+        return self._clean | set(self._findings) | set(self._unverifiable)
 
 
-def show_reports(findings_reports: list[FindingsReport], unverified_report: UnverifiedReport) -> str:
+def show_reports(
+    findings_reports: list[FindingsReport],
+    unverifiable_report: UnverifiablePackageReport,
+) -> str:
     """
     Return a pretty-printed string representation of the given reports.
 
     Args:
         `findings_reports`: A `list[FindingsReports]` to be formatted for printing.
-        'unverified_report`: An `UnverifiedReport` to be formatted for printing.
+        'unverifiable_report`: An `UnverifiablePackageReport` to be formatted for printing.
 
     Returns:
         A pretty-printed `str` representation of the given reports suitable for displaying
@@ -171,15 +176,17 @@ def show_reports(findings_reports: list[FindingsReport], unverified_report: Unve
         for package, findings in combined_findings_report.items()
     }
 
-    # Prepare the findings + unverified output for each package
+    # Prepare the findings + unverifiable output for each package
     combined_output = {}
-    for package in set(sorted_findings) | set(unverified_report):
+    for package in set(sorted_findings) | set(unverifiable_report):
         findings_output = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
-        unverified_output = list(map(lambda u: u.message, unverified_report.get(package, {})))
-        combined_output[package] = findings_output + unverified_output
+        unverifiable_output = list(
+            map(lambda u: u.error_message, unverifiable_report.get(package, {}))
+        )
+        combined_output[package] = findings_output + unverifiable_output
 
     # Print the output to string, alphabetized by package name
     return '\n'.join(
         show_output(package, combined_output[package])
-        for package in sorted(set(sorted_findings) | set(unverified_report), key=str)
+        for package in sorted(set(sorted_findings) | set(unverifiable_report), key=str)
     )

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -76,7 +76,7 @@ class VerificationReport:
             for which a verifier raised an `UnverifiablePackage` error.
         """
         return {
-            package: set(error_message) for package, error_message in self._unverifiable.items()
+            package: set(error_messages) for package, error_messages in self._unverifiable.items()
         }
 
     def insert_clean(self, package: Package) -> None:
@@ -176,9 +176,11 @@ def show_reports(
         for package, findings in combined_findings_report.items()
     }
 
+    all_packages = set(sorted_findings) | set(unverifiable_report)
+
     # Prepare the findings + unverifiable output for each package
     combined_output = {}
-    for package in set(sorted_findings) | set(unverifiable_report):
+    for package in all_packages:
         findings_output = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
         unverifiable_output = list(
             map(lambda u: u.error_message, unverifiable_report.get(package, {}))
@@ -188,5 +190,5 @@ def show_reports(
     # Print the output to string, alphabetized by package name
     return '\n'.join(
         show_output(package, combined_output[package])
-        for package in sorted(set(sorted_findings) | set(unverifiable_report), key=str)
+        for package in sorted(all_packages, key=str)
     )

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -2,147 +2,102 @@
 Classes for structuring and displaying the results of package verification.
 """
 
-from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Optional
-from typing_extensions import Self
+from typing import TypeAlias
 
 from scfw.package import Package
-from scfw.verifier import FindingSeverity
+from scfw.verifier import Finding, FindingSeverity
 
 
-class FindingsReport:
+@dataclass(eq=True, frozen=True)
+class Unverified:
     """
-    A structured report containing verification findings for a set of `Package`.
+    Lorem ipsum dolor sit amet.
+    """
+    verifier: str
+    message: str
+
+
+FindingsReport: TypeAlias = dict[Package, set[Finding]]
+"""
+Lorem ipsum dolor sit amet.
+"""
+
+UnverifiedReport: TypeAlias = dict[Package, set[Unverified]]
+"""
+Lorem ipsum dolor sit amet.
+"""
+
+
+class VerificationReport:
+    """
+    Lorem ipsum dolor sit amet.
     """
     def __init__(self) -> None:
         """
-        Initialize a new, empty `FindingsReport`.
+        Lorem ipsum dolor sit amet.
         """
-        self._report: dict[Package, list[str]] = {}
+        self._clean: set[Package] = set()
+        self._findings: FindingsReport = {}
+        self._unverified: UnverifiedReport = {}
 
-    def __eq__(self, other: object) -> bool:
+    def get_clean(self) -> set[Package]:
         """
-        Determine whether two `FindingsReport` are equal.
+        Lorem ipsum dolor sit amet.
         """
-        if not isinstance(other, FindingsReport):
-            return NotImplemented
+        return set(self._clean)
 
-        return self._report == other._report
-
-    def __len__(self) -> int:
+    def get_findings(self, severity: FindingSeverity) -> FindingsReport:
         """
-        Return the number of entries in the report.
+        Lorem ipsum dolor sit amet.
         """
-        return len(self._report)
+        severity_findings = {}
 
-    def __str__(self) -> str:
+        for package, findings in self._findings.items():
+            if (s := {finding for finding in findings if finding.severity == severity}):
+                severity_findings[package] = s
+
+        return severity_findings
+
+    def get_unverified(self) -> UnverifiedReport:
         """
-        Return a human-readable version of a findings report.
-
-        Returns:
-            A `str` containing the formatted findings report.
+        Lorem ipsum dolor sit amet.
         """
-        def show_line(linenum: int, line: str) -> str:
-            return (f"  - {line}" if linenum == 0 else f"    {line}")
+        return {package: set(unverified) for package, unverified in self._unverified.items()}
 
-        def show_finding(finding: str) -> str:
-            return '\n'.join(
-                show_line(linenum, line) for linenum, line in enumerate(finding.split('\n'))
-            )
-
-        def show_findings(package: Package, findings: list[str]) -> str:
-            return f"Package {package}:\n" + '\n'.join(map(show_finding, findings))
-
-        return '\n'.join(
-            show_findings(package, findings) for package, findings in self._report.items()
-        )
-
-    @classmethod
-    def merge(cls, lhs: Self, rhs: Self) -> Self:
+    def insert_clean(self, package: Package) -> None:
         """
-        Merge two `FindingsReport` into a new one containing them both.
-
-        Args:
-            lhs: The first `FindingsReport` to be merged.
-            rhs: The second `FindingsReport` to be merged.
-
-        Returns:
-            A `FindingsReport` containing all of the findings in `lhs` and `rhs`.
+        Lorem ipsum dolor sit amet.
         """
-        merged = cls()
-        merged.extend(lhs)
-        merged.extend(rhs)
+        if package in self._findings or package in self._unverified:
+            return
 
-        return merged
+        self._clean.add(package)
 
-    def get(self, package: Package) -> Optional[list[str]]:
+    def insert_finding(self, package: Package, finding: Finding) -> None:
         """
-        Get the findings for the given package.
-
-        Args:
-            package: The `Package` to look up in the report.
-
-        Returns:
-            The reported findings for `package` or `None` if it is not present.
+        Lorem ipsum dolor sit amet.
         """
-        return self._report.get(package)
+        if package not in self._findings:
+            self._findings[package] = set()
+        self._findings[package].add(finding)
 
-    def insert(self, package: Package, finding: str) -> None:
-        """
-        Insert the given package and finding into the report.
+        if package in self._clean:
+            self._clean.remove(package)
 
-        Args:
-            package: The `Package` to insert into the report.
-            findings: The finding being reported for `package`.
+    def insert_unverified(self, package: Package, unverified: Unverified) -> None:
         """
-        if package in self._report:
-            self._report[package].append(finding)
-        else:
-            self._report[package] = [finding]
+        Lorem ipsum dolor sit amet.
+        """
+        if package not in self._unverified:
+            self._unverified[package] = set()
+        self._unverified[package].add(unverified)
 
-    def extend(self, other: Self) -> None:
-        """
-        Extend a `FindingsReport` with additional findings from another.
+        if package in self._clean:
+            self._clean.remove(package)
 
-        Args:
-            other: The `FindingsReport` whose findings will be extended into `self`.
+    def packages(self) -> set[Package]:
         """
-        for package, findings in other._report.items():
-            if package in self._report:
-                self._report[package].extend(findings)
-            else:
-                self._report[package] = list(findings)
-
-    def packages(self) -> Iterable[Package]:
+        Lorem ipsum dolor sit amet.
         """
-        Return an iterator over `Package` mentioned in the report.
-        """
-        return self._report.keys()
-
-
-@dataclass(eq=True)
-class VerificationReport:
-    """
-    A structured report containing the results of verifying a set of `Package`.
-    """
-    verification_set: frozenset[Package]
-    findings_reports: dict[FindingSeverity, FindingsReport]
-    unverifiable: FindingsReport
-
-    @classmethod
-    def empty(cls) -> Self:
-        """
-        Return an empty `VerificationReport`.
-        """
-        return cls(frozenset(), {}, FindingsReport())
-
-    def get_findings_report(self, severity: FindingSeverity) -> Optional[FindingsReport]:
-        """
-        Return the reported `FindingsReport` of the given severity level if one exists.
-
-        Returns:
-            The `FindingsReport` of the given `FindingSeverity` contained in the given
-            verification report's set of severity-ranked finding reports.
-        """
-        return self.findings_reports.get(severity)
+        return self._clean | set(self._findings) | set(self._unverified)

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -3,7 +3,7 @@ Classes for structuring and displaying the results of package verification.
 """
 
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Optional, TypeAlias
 
 from scfw.package import Package
 from scfw.verifier import Finding, FindingSeverity
@@ -51,14 +51,24 @@ class VerificationReport:
         """
         return set(self._clean)
 
-    def get_findings(self, severity: FindingSeverity) -> FindingsReport:
+    def get_findings(self, severity: Optional[FindingSeverity] = None) -> FindingsReport:
         """
         Return a structured report on packages that had findings of a given severity.
 
+        Args:
+            `severity`:
+                An `Optional[FindingSeverity]` describing the severity of the findings of
+                interest. If `None`, all findings present in the report are returned.
+
         Returns:
-            A `FindingsReport` covering the `Package` contained in the report that
-            had reported findings of the given `FindingSeverity.
+            A `FindingsReport` covering all findings in the report or optionally only
+            those of the given `severity`.
         """
+        if severity is None:
+            return {
+                package: set(findings) for package, findings in self._findings.items()
+            }
+
         severity_findings = {}
 
         for package, findings in self._findings.items():

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -136,9 +136,9 @@ def show_reports(findings_reports: list[FindingsReport], unverified_report: Unve
     # Prepare the findings + unverified output for each package
     combined_output = {}
     for package in set(sorted_findings) | set(unverified_report):
-        findings = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
-        unverified = list(map(lambda u: u.message, unverified_report.get(package, {})))
-        combined_output[package] = findings + unverified
+        findings_output = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
+        unverified_output = list(map(lambda u: u.message, unverified_report.get(package, {})))
+        combined_output[package] = findings_output + unverified_output
 
     # Print the output to string, alphabetized by package name
     return '\n'.join(

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -153,8 +153,8 @@ def show_reports(
     Return a pretty-printed string representation of the given reports.
 
     Args:
-        `findings_reports`: A `list[FindingsReports]` to be formatted for printing.
-        'unverifiable_report`: An `UnverifiablePackageReport` to be formatted for printing.
+        `findings_reports`: A `list[FindingsReport]` to be formatted for printing.
+        `unverifiable_report`: An `UnverifiablePackageReport` to be formatted for printing.
 
     Returns:
         A pretty-printed `str` representation of the given reports suitable for displaying
@@ -193,7 +193,7 @@ def show_reports(
     for package in all_packages:
         findings_output = list(map(lambda f: f.finding, sorted_findings.get(package, [])))
         unverifiable_output = list(
-            map(lambda u: u.error_message, unverifiable_report.get(package, {}))
+            map(lambda u: u.error_message, unverifiable_report.get(package, set()))
         )
         combined_output[package] = findings_output + unverifiable_output
 

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -25,6 +25,22 @@ class FindingSeverity(Enum):
     CRITICAL = "CRITICAL"
     WARNING = "WARNING"
 
+    def __lt__(self, other) -> bool:
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        order = {
+            "CRITICAL": 2,
+            "WARNING": 1,
+        }
+
+        if self.__class__ is not other.__class__:
+            raise TypeError(
+                f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
+            )
+
+        return order[self.name] < order[other.name]
+
     def __str__(self) -> str:
         """
         Format a `FindingSeverity` for printing.

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -27,7 +27,17 @@ class FindingSeverity(Enum):
 
     def __lt__(self, other) -> bool:
         """
-        Lorem ipsum dolor sit amet.
+        Compare two `FindingSeverity` instances on the basis of their severity ranking.
+
+        Args:
+            self: The `FindingSeverity` to be compared on the left-hand side
+            other: The `FindingSeverity` to be compared on the right-hand side
+
+        Returns:
+            A `bool` indicating whether `<` holds between the two given `FindingSeverity`.
+
+        Raises:
+            TypeError: The other argument given was not a `FindingSeverity`.
         """
         order = {
             "CRITICAL": 2,

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -3,6 +3,7 @@ Provides a base class for package verifiers.
 """
 
 from abc import (ABCMeta, abstractmethod)
+from dataclasses import dataclass
 from enum import Enum
 from typing_extensions import Self
 
@@ -55,6 +56,16 @@ class FindingSeverity(Enum):
             raise ValueError(f"Invalid finding severity: '{s}'")
 
 
+@dataclass(eq=True, frozen=True)
+class Finding:
+    """
+    A finding reported by a verifier with an accompanying severity assessment.
+    """
+    verifier: str
+    severity: FindingSeverity
+    finding: str
+
+
 class PackageVerifier(metaclass=ABCMeta):
     """
     Abstract base class for package verifiers.
@@ -87,7 +98,7 @@ class PackageVerifier(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
+    def verify(self, package: Package) -> set[Finding]:
         """
         Verify the given package.
 
@@ -95,12 +106,10 @@ class PackageVerifier(metaclass=ABCMeta):
             package: The `Package` to verify.
 
         Returns:
-            A `list[tuple[FindingSeverity, str]]` of all findings for the given package
-            reported by the backing data source, each tagged with a severity level.
+            A `set[Finding]` of all findings reported for the given package.
 
-            Each `str` in this list should be a concise summary of a single finding and
-            would ideally provide a link or handle to more information about that finding
-            for the benefit of the user.
+            The text of each finding should be concise and would ideally link to or
+            reference other sources of information for the benefit of the user.
         """
         pass
 

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -39,17 +39,12 @@ class FindingSeverity(Enum):
         Raises:
             TypeError: The other argument given was not a `FindingSeverity`.
         """
-        order = {
-            "CRITICAL": 2,
-            "WARNING": 1,
-        }
-
         if self.__class__ is not other.__class__:
             raise TypeError(
                 f"'<' not supported between instances of '{self.__class__}' and '{other.__class__}'"
             )
 
-        return order[self.name] < order[other.name]
+        return self == FindingSeverity.WARNING and other == FindingSeverity.CRITICAL
 
     def __str__(self) -> str:
         """

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -69,7 +69,7 @@ class FirewallVerifiers:
         """
         return [verifier.name() for verifier in self._verifiers]
 
-    def verify_packages(self, packages: list[Package]) -> VerificationReport:
+    def verify_packages(self, packages: set[Package]) -> VerificationReport:
         """
         Verify a set of packages against all discovered verifiers.
 
@@ -84,7 +84,7 @@ class FirewallVerifiers:
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
                 executor.submit(lambda v, t: v.verify(t), verifier, package): (verifier.name(), package)
-                for verifier, package in itertools.product(self._verifiers, set(packages))
+                for verifier, package in itertools.product(self._verifiers, packages)
             }
             for future in cf.as_completed(task_results):
                 verifier, package = task_results[future]

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -98,7 +98,14 @@ class FirewallVerifiers:
                         report.insert_clean(package)
 
                 except UnverifiablePackage as e:
-                    report.insert_unverified(package, Unverified(verifier, str(e)))
+                    _log.info("Lorem ipsum dolor sit amet")
+                    report.insert_unverified(
+                        package,
+                        Unverified(
+                            verifier,
+                            f"Verifier {verifier} was unable to verify package {package}: {e}",
+                        ),
+                    )
 
         _log.info("Verification of packages complete")
         return report

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -29,8 +29,8 @@ import pkgutil
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.report import FindingsReport, VerificationReport
-from scfw.verifier import FindingSeverity, UnverifiablePackage
+from scfw.report import Unverified, VerificationReport
+from scfw.verifier import UnverifiablePackage
 
 _log = logging.getLogger(__name__)
 
@@ -77,17 +77,14 @@ class FirewallVerifiers:
             packages: The set of `Package` to verify.
 
         Returns:
-            A `VerificationReport` resulting from verifying `packages` against all
-            discovered verifiers.
+            A `VerificationReport` resulting from verifying `packages` against all discovered verifiers.
         """
-        verification_set = frozenset(packages)
-        findings_reports: dict[FindingSeverity, FindingsReport] = {}
-        unverifiable = FindingsReport()
+        report = VerificationReport()
 
         with cf.ThreadPoolExecutor() as executor:
             task_results = {
                 executor.submit(lambda v, t: v.verify(t), verifier, package): (verifier.name(), package)
-                for verifier, package in itertools.product(self._verifiers, verification_set)
+                for verifier, package in itertools.product(self._verifiers, set(packages))
             }
             for future in cf.as_completed(task_results):
                 verifier, package = task_results[future]
@@ -95,17 +92,13 @@ class FirewallVerifiers:
                     if (findings := future.result()):
                         _log.info(f"Verifier {verifier} had findings for package {package}")
                         for finding in findings:
-                            if finding.severity not in findings_reports:
-                                findings_reports[finding.severity] = FindingsReport()
-                            findings_reports[finding.severity].insert(package, finding.finding)
+                            report.insert_finding(package, finding)
                     else:
                         _log.info(f"Verifier {verifier} had no findings for package {package}")
+                        report.insert_clean(package)
 
                 except UnverifiablePackage as e:
-                    unverifiable.insert(
-                        package,
-                        f"Verifier {verifier} was unable to verify package {package}: {e}",
-                    )
+                    report.insert_unverified(package, Unverified(verifier, str(e)))
 
         _log.info("Verification of packages complete")
-        return VerificationReport(verification_set, findings_reports, unverifiable)
+        return report

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -98,7 +98,7 @@ class FirewallVerifiers:
                         report.insert_clean(package)
 
                 except UnverifiablePackage as e:
-                    _log.info("Lorem ipsum dolor sit amet")
+                    _log.info(f"Verifier {verifier} was unable to verify package {package}")
                     report.insert_unverified(
                         package,
                         Unverified(

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -29,7 +29,7 @@ import pkgutil
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.report import Unverified, VerificationReport
+from scfw.report import VerificationReport, VerifierErrorMessage
 from scfw.verifier import UnverifiablePackage
 
 _log = logging.getLogger(__name__)
@@ -99,9 +99,9 @@ class FirewallVerifiers:
 
                 except UnverifiablePackage as e:
                     _log.info(f"Verifier {verifier} was unable to verify package {package}")
-                    report.insert_unverified(
+                    report.insert_unverifiable(
                         package,
-                        Unverified(
+                        VerifierErrorMessage(
                             verifier,
                             f"Verifier {verifier} was unable to verify package {package}: {e}",
                         ),

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -94,10 +94,10 @@ class FirewallVerifiers:
                 try:
                     if (findings := future.result()):
                         _log.info(f"Verifier {verifier} had findings for package {package}")
-                        for severity, finding in findings:
-                            if severity not in findings_reports:
-                                findings_reports[severity] = FindingsReport()
-                            findings_reports[severity].insert(package, finding)
+                        for finding in findings:
+                            if finding.severity not in findings_reports:
+                                findings_reports[finding.severity] = FindingsReport()
+                            findings_reports[finding.severity].insert(package, finding.finding)
                     else:
                         _log.info(f"Verifier {verifier} had no findings for package {package}")
 

--- a/scfw/verifiers/age_verifier/__init__.py
+++ b/scfw/verifiers/age_verifier/__init__.py
@@ -9,7 +9,7 @@ import os
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
+from scfw.verifier import Finding, FindingSeverity, PackageVerifier, UnverifiablePackage
 import scfw.verifiers.age_verifier.npm as npm
 import scfw.verifiers.age_verifier.pypi as pypi
 
@@ -73,7 +73,7 @@ class PackageAgeVerifier(PackageVerifier):
         """
         return {ECOSYSTEM.Npm, ECOSYSTEM.PyPI}
 
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
+    def verify(self, package: Package) -> set[Finding]:
         """
         Determine how recently a given package was published and warn if this is deemed
         too recent based on a user-configurable minimum age.
@@ -82,8 +82,8 @@ class PackageAgeVerifier(PackageVerifier):
             package: The `Package` to verify.
 
         Returns:
-            A list containing a single `WARNING` finding if `package` is deemed to have
-            been published too recently, otherwise an empty list.
+            A `set[Finding]` containing a single `WARNING` finding if `package` is deemed
+            to have been published too recently, otherwise an empty set.
 
         Raises:
             UnverifiablePackage:
@@ -101,7 +101,7 @@ class PackageAgeVerifier(PackageVerifier):
             )
 
         if self.minimum_age == timedelta(0):
-            return []
+            return set()
 
         try:
             match package.ecosystem:
@@ -112,18 +112,21 @@ class PackageAgeVerifier(PackageVerifier):
 
             if datetime.now(tz=timezone.utc) - release_datetime_utc < self.minimum_age:
                 minimum_age_hours = int(self.minimum_age.total_seconds()) // 3600
-                return [(
-                    FindingSeverity.WARNING,
-                    (
-                        f"Package {package} was published less than {minimum_age_hours} hours ago"
-                        ": treat new releases with caution"
-                    ),
-                )]
+                return {
+                    Finding(
+                        self.name(),
+                        FindingSeverity.WARNING,
+                        (
+                            f"Package {package} was published less than {minimum_age_hours} hours ago"
+                            ": treat new releases with caution"
+                        ),
+                    )
+                }
 
         except Exception as e:
             _log.warning(f"Failed to determine publication datetime for package {package}: {e}")
 
-        return []
+        return set()
 
 
 def load_verifier() -> PackageVerifier:

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -76,7 +76,7 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
             package: The `Package` to verify.
 
         Returns:
-            A `set[Package]` containing a single `CRITICAL` finding in the event that `package`
+            A `set[Finding]` containing a single `CRITICAL` finding in the event that `package`
             is found to be in the dataset, otherwise an empty set.
 
         Raises:

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
+from scfw.verifier import Finding, FindingSeverity, PackageVerifier, UnverifiablePackage
 import scfw.verifiers.dd_verifier.dataset as dataset
 
 _log = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
         """
         return {ECOSYSTEM.Npm, ECOSYSTEM.PyPI}
 
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
+    def verify(self, package: Package) -> set[Finding]:
         """
         Determine whether the given package is malicious by consulting the dataset's manifests.
 
@@ -76,9 +76,8 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
             package: The `Package` to verify.
 
         Returns:
-            A list containing any findings for the given package, obtained by checking for its
-            presence in the dataset's manifests.  Only a single `CRITICAL` finding to this effect
-            is present in this case.
+            A `set[Package]` containing a single `CRITICAL` finding in the event that `package`
+            is found to be in the dataset, otherwise an empty set.
 
         Raises:
             UnverifiablePackage:
@@ -100,14 +99,15 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
             package.name in manifest
             and (not manifest[package.name] or package.version in manifest[package.name])
         ):
-            return [
-                (
+            return {
+                Finding(
+                    self.name(),
                     FindingSeverity.CRITICAL,
-                    f"Datadog Security Research has determined that package {package} is malicious"
+                    f"Datadog Security Research has determined that package {package} is malicious",
                 )
-            ]
-        else:
-            return []
+            }
+
+        return set()
 
 
 def load_verifier() -> PackageVerifier:

--- a/scfw/verifiers/list_verifier/__init__.py
+++ b/scfw/verifiers/list_verifier/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import Finding, FindingSeverity, PackageVerifier, UnverifiablePackage
+from scfw.verifier import Finding, PackageVerifier, UnverifiablePackage
 from scfw.verifiers.list_verifier.findings_map import FindingsMap
 
 _log = logging.getLogger(__name__)

--- a/scfw/verifiers/list_verifier/__init__.py
+++ b/scfw/verifiers/list_verifier/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
+from scfw.verifier import Finding, FindingSeverity, PackageVerifier, UnverifiablePackage
 from scfw.verifiers.list_verifier.findings_map import FindingsMap
 
 _log = logging.getLogger(__name__)
@@ -70,7 +70,7 @@ class FindingsListVerifier(PackageVerifier):
         """
         return {ecosystem for ecosystem in ECOSYSTEM}
 
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
+    def verify(self, package: Package) -> set[Finding]:
         """
         Determine whether a package has findings in the user-provided findings lists.
 
@@ -78,8 +78,8 @@ class FindingsListVerifier(PackageVerifier):
             package: The `Package` to verify.
 
         Returns:
-            A list containing all findings for the given package present in the user-provided
-            findings list with which the `FindingsListVerifier` was initialized.
+            A `set[Finding]` containing all findings for the given package present in the
+            user-provided findings list with which the `FindingsListVerifier` was initialized.
 
         Raises:
             UnverifiablePackage:
@@ -96,7 +96,10 @@ class FindingsListVerifier(PackageVerifier):
                 f"{self.name()}: Unknown source for package {package}: assuming {package.ecosystem} registry source"
             )
 
-        return self._findings_map.get_findings(package)
+        return {
+            Finding(self.name(), severity, finding)
+            for severity, finding in self._findings_map.get_findings(package)
+        }
 
 
 def load_verifier() -> PackageVerifier:

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -13,7 +13,7 @@ import requests
 from scfw.constants import SCFW_HOME_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, PackageVerifier, UnverifiablePackage
+from scfw.verifier import Finding, FindingSeverity, PackageVerifier, UnverifiablePackage
 from scfw.verifiers.osv_verifier.osv_advisory import OsvAdvisory
 
 _log = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class OsvVerifier(PackageVerifier):
         """
         return {ECOSYSTEM.Npm, ECOSYSTEM.PyPI}
 
-    def verify(self, package: Package) -> list[tuple[FindingSeverity, str]]:
+    def verify(self, package: Package) -> set[Finding]:
         """
         Query a given package against the OSV.dev database.
 
@@ -104,8 +104,8 @@ class OsvVerifier(PackageVerifier):
             package: The `Package` to query.
 
         Returns:
-            A list containing any findings for the given package, obtained by querying
-            the OSV.dev API.
+            A `set[Finding]` containing any findings for the given package obtained by
+            querying the OSV.dev API.
 
             OSV.dev advisories with `MAL` IDs are treated as `CRITICAL` findings and all
             others are treated as `WARNING`.  *It is very important to note that most but
@@ -169,7 +169,7 @@ class OsvVerifier(PackageVerifier):
                     break
 
             if not vulns:
-                return []
+                return set()
 
             osvs = set(map(OsvAdvisory.from_json, filter(lambda vuln: vuln.get("id"), vulns)))
             mal_osvs = set(filter(lambda osv: osv.id.startswith("MAL"), osvs))
@@ -184,18 +184,26 @@ class OsvVerifier(PackageVerifier):
             sorted_mal_osvs = sorted(mal_osvs, reverse=True, key=osv_sort_key)
             sorted_non_mal_osvs = sorted(non_mal_osvs, reverse=True, key=osv_sort_key)
 
-            return (
-                [(FindingSeverity.CRITICAL, finding(osv)) for osv in sorted_mal_osvs]
-                + [(FindingSeverity.WARNING, finding(osv)) for osv in sorted_non_mal_osvs]
-            )
+            critical_findings = {
+                Finding(self.name(), FindingSeverity.CRITICAL, finding(osv)) for osv in sorted_mal_osvs
+            }
+            warning_findings = {
+                Finding(self.name(), FindingSeverity.WARNING, finding(osv)) for osv in sorted_non_mal_osvs
+            }
+
+            return critical_findings | warning_findings
 
         except requests.exceptions.RequestException as e:
             _log.warning(f"Failed to query OSV.dev API for package {package}: {e}")
-            return [(FindingSeverity.WARNING, failure_message())]
+            return {
+                Finding(self.name(), FindingSeverity.WARNING, failure_message())
+            }
 
         except Exception as e:
             _log.warning(f"Verification failed for package {package}: {e}")
-            return [(FindingSeverity.WARNING, failure_message())]
+            return {
+                Finding(self.name(), FindingSeverity.WARNING, failure_message())
+            }
 
 
 def load_verifier() -> PackageVerifier:

--- a/tests/package_managers/test_npm_class.py
+++ b/tests/package_managers/test_npm_class.py
@@ -325,11 +325,11 @@ def test_resolve_install_targets_local_dependency_installed(
     )
 
 
-def test_list_installed_packages_empty_directory(monkeypatch, empty_directory):
+def test_get_installed_packages_empty_directory(monkeypatch, empty_directory):
     """
     Test that `Npm` correctly identifies installed packages in an empty directory.
     """
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         empty_directory,
         should_fail=False,
@@ -337,12 +337,12 @@ def test_list_installed_packages_empty_directory(monkeypatch, empty_directory):
     )
 
 
-def test_list_installed_packages_new_npm_project(monkeypatch, new_npm_project):
+def test_get_installed_packages_new_npm_project(monkeypatch, new_npm_project):
     """
     Test that `Npm` correctly identifies installed packages in a new npm project
     with no dependencies.
     """
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         new_npm_project,
         should_fail=False,
@@ -350,14 +350,14 @@ def test_list_installed_packages_new_npm_project(monkeypatch, new_npm_project):
     )
 
 
-def test_list_installed_packages_dependency_latest(monkeypatch, npm_project_dependency_latest):
+def test_get_installed_packages_dependency_latest(monkeypatch, npm_project_dependency_latest):
     """
     Test that `Npm` correctly identifies installed packages in a new npm project
     with an uninstalled dependency. `npm list` exits non-zero with ELSPROBLEMS in
     this case, but the JSON report it writes to stdout is still consumed, and the
     declared-but-uninstalled dependency is reported as not installed.
     """
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         npm_project_dependency_latest,
         should_fail=False,
@@ -365,7 +365,7 @@ def test_list_installed_packages_dependency_latest(monkeypatch, npm_project_depe
     )
 
 
-def test_list_installed_packages_dependency_latest_lockfile(
+def test_get_installed_packages_dependency_latest_lockfile(
     monkeypatch,
     npm_project_dependency_latest_lockfile
 ):
@@ -374,7 +374,7 @@ def test_list_installed_packages_dependency_latest_lockfile(
     with an uninstalled dependency and a lockfile. As above, `npm list` exits
     non-zero but its JSON report is still consumed.
     """
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         npm_project_dependency_latest_lockfile,
         should_fail=False,
@@ -382,12 +382,12 @@ def test_list_installed_packages_dependency_latest_lockfile(
     )
 
 
-def test_list_installed_packages_installed_latest(monkeypatch, npm_project_installed_latest):
+def test_get_installed_packages_installed_latest(monkeypatch, npm_project_installed_latest):
     """
     Test that `Npm` correctly identifies installed packages in an npm project
     with an installed dependency.
     """
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         npm_project_installed_latest,
         should_fail=False,
@@ -395,19 +395,19 @@ def test_list_installed_packages_installed_latest(monkeypatch, npm_project_insta
     )
 
 
-def test_list_installed_packages_local_dependency_installed(
+def test_get_installed_packages_local_dependency_installed(
     monkeypatch,
     npm_project_local_dependency_installed,
 ):
     """
-    Test that `Npm.list_installed_packages` reports an installed local file:
+    Test that `Npm.get_installed_packages` reports an installed local file:
     dependency with its `LocalPackageSource` populated to the original source path.
     """
     expected_source = (
         npm_project_local_dependency_installed.parent / LOCAL_PACKAGE_NAME
     ).resolve(strict=True)
 
-    backend_test_list_installed_packages(
+    backend_test_get_installed_packages(
         monkeypatch,
         npm_project_local_dependency_installed,
         should_fail=False,
@@ -422,10 +422,10 @@ def test_list_installed_packages_local_dependency_installed(
     )
 
 
-def test_list_installed_packages_uses_root_lockfile_for_missing_resolved(monkeypatch, tmp_path):
+def test_get_installed_packages_uses_root_lockfile_for_missing_resolved(monkeypatch, tmp_path):
     """
     When `npm list` omits `resolved` for a deduped package but the root
-    package-lock.json has it, list_installed_packages populates source from
+    package-lock.json has it, `Npm.get_installed_packages` populates source from
     the lock file instead of leaving it None.
     """
     resolved_url = "https://registry.npmjs.org/deduped-pkg/-/deduped-pkg-1.0.0.tgz"
@@ -457,14 +457,14 @@ def test_list_installed_packages_uses_root_lockfile_for_missing_resolved(monkeyp
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
-    packages = PACKAGE_MANAGER.list_installed_packages()
+    packages = PACKAGE_MANAGER.get_installed_packages()
 
     assert Package(
         ECOSYSTEM.Npm, "deduped-pkg", "1.0.0", source=RemotePackageSource(resolved_url)
-    ) in set(packages)
+    ) in packages
 
 
-def test_list_installed_packages_uses_root_lockfile_for_non_hoisted_packages(monkeypatch, tmp_path):
+def test_get_installed_packages_uses_root_lockfile_for_non_hoisted_packages(monkeypatch, tmp_path):
     """
     When a transitive dep can't be hoisted (version conflict with a top-level dep),
     the lock file records it under `node_modules/<parent>/node_modules/<child>`.
@@ -506,19 +506,19 @@ def test_list_installed_packages_uses_root_lockfile_for_non_hoisted_packages(mon
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
-    packages = PACKAGE_MANAGER.list_installed_packages()
+    packages = PACKAGE_MANAGER.get_installed_packages()
 
     assert Package(
         ECOSYSTEM.Npm, "conflict-pkg", "2.0.0", source=RemotePackageSource(nested_url)
-    ) in set(packages)
+    ) in packages
 
 
-def test_list_installed_packages_uses_local_dep_lockfile_for_transitive_packages(
+def test_get_installed_packages_uses_local_dep_lockfile_for_transitive_packages(
     monkeypatch, tmp_path
 ):
     """
     When a local file: dependency's transitive packages lack `resolved` in
-    `npm list` output, list_installed_packages uses the local package's own
+    `npm list` output, get_installed_packages uses the local package's own
     package-lock.json to populate source.
     """
     transitive_url = "https://registry.npmjs.org/transitive-pkg/-/transitive-pkg-3.0.0.tgz"
@@ -555,14 +555,14 @@ def test_list_installed_packages_uses_local_dep_lockfile_for_transitive_packages
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
-    packages = PACKAGE_MANAGER.list_installed_packages()
+    packages = PACKAGE_MANAGER.get_installed_packages()
 
     assert Package(
         ECOSYSTEM.Npm, "transitive-pkg", "3.0.0", source=RemotePackageSource(transitive_url)
-    ) in set(packages)
+    ) in packages
 
 
-def test_list_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tmp_path, caplog):
+def test_get_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tmp_path, caplog):
     """
     Dependencies that appear in `npm list` with no version field (e.g. uninstalled
     optional peer deps) are silently skipped — no WARNING is emitted.
@@ -585,16 +585,16 @@ def test_list_installed_packages_silently_skips_uninstalled_deps(monkeypatch, tm
     monkeypatch.chdir(tmp_path)
 
     with caplog.at_level(logging.WARNING, logger="scfw.package_managers.npm"):
-        packages = PACKAGE_MANAGER.list_installed_packages()
+        packages = PACKAGE_MANAGER.get_installed_packages()
 
-    assert set(packages) == {Package(ECOSYSTEM.Npm, "good-package", "1.2.3", source=RemotePackageSource(good_url))}
+    assert packages == {Package(ECOSYSTEM.Npm, "good-package", "1.2.3", source=RemotePackageSource(good_url))}
     assert not any("uninstalled-peer" in r.message for r in caplog.records if r.levelno >= logging.WARNING)
 
 
-def test_list_installed_packages_keeps_dep_with_missing_local_source(monkeypatch, tmp_path):
+def test_get_installed_packages_keeps_dep_with_missing_local_source(monkeypatch, tmp_path):
     """
     Regression test: when `npm list` reports a `file:` dep whose target does
-    not exist on disk, `list_installed_packages` should still return the
+    not exist on disk, `Npm.get_installed_packages` should still return the
     package (without source data) instead of silently dropping it.
     """
     npm_list_output = json.dumps({
@@ -615,12 +615,12 @@ def test_list_installed_packages_keeps_dep_with_missing_local_source(monkeypatch
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
-    packages = PACKAGE_MANAGER.list_installed_packages()
+    packages = PACKAGE_MANAGER.get_installed_packages()
 
-    assert set(packages) == {Package(ECOSYSTEM.Npm, "ghost-package", "1.0.0")}
+    assert packages == {Package(ECOSYSTEM.Npm, "ghost-package", "1.0.0")}
 
 
-def test_list_installed_packages_skips_malformed_entries(monkeypatch, tmp_path):
+def test_get_installed_packages_skips_malformed_entries(monkeypatch, tmp_path):
     """
     Malformed entries (e.g., missing `version`, or a non-dict in place of an
     entry) are dropped with a warning, but well-formed sibling entries are
@@ -649,9 +649,9 @@ def test_list_installed_packages_skips_malformed_entries(monkeypatch, tmp_path):
     monkeypatch.setattr(PACKAGE_MANAGER, "_check_version", lambda: None)
     monkeypatch.chdir(tmp_path)
 
-    packages = PACKAGE_MANAGER.list_installed_packages()
+    packages = PACKAGE_MANAGER.get_installed_packages()
 
-    assert set(packages) == {
+    assert packages == {
         Package(ECOSYSTEM.Npm, "good-package", "1.2.3", source=RemotePackageSource(good_url)),
     }
 
@@ -680,14 +680,14 @@ def backend_test_resolve_install_targets(
     assert get_npm_project_state(project) == initial_state
 
 
-def backend_test_list_installed_packages(
+def backend_test_get_installed_packages(
     monkeypatch,
     project: Path,
     should_fail: bool,
     installed: set[Package],
 ):
     """
-    Backend function for testing that the `Npm.list_installed_packages()` method
+    Backend function for testing that the `Npm.get_installed_packages()` method
     correctly identifies installed packages or fails to do so in the given `project`.
 
     Args:
@@ -700,12 +700,12 @@ def backend_test_list_installed_packages(
 
     if should_fail:
         with pytest.raises(RuntimeError):
-            PACKAGE_MANAGER.list_installed_packages()
+            PACKAGE_MANAGER.get_installed_packages()
         return
 
-    experiment = PACKAGE_MANAGER.list_installed_packages()
+    experiment = PACKAGE_MANAGER.get_installed_packages()
     assert len(experiment) == len(installed)
-    assert set(experiment) == installed
+    assert experiment == installed
 
 
 def get_npm_project_state(project_path: Path) -> str:

--- a/tests/package_managers/test_pip.py
+++ b/tests/package_managers/test_pip.py
@@ -267,7 +267,7 @@ def test_pip_inspect_matches_pip_list_pip_project_local_dependency_installed(pip
 def test_pip_inspect_registry_package_no_direct_url(pip_project_remote_dependency_installed):
     """
     Test that a package installed from the PyPI registry has no `direct_url` entry in
-    `pip inspect` output. When `direct_url` is absent, `Pip.list_installed_packages`
+    `pip inspect` output. When `direct_url` is absent, `Pip.get_installed_packages`
     treats this as a registry install and uses the canonical PyPI project page URL as a
     stand-in `RemotePackageSource`.
     """

--- a/tests/package_managers/test_pip_class.py
+++ b/tests/package_managers/test_pip_class.py
@@ -72,7 +72,7 @@ def test_pip_command_resolve_install_targets_exact():
     Test that `Pip.resolve_install_targets` gives the right answer relative to
     an exact top-level installation target and its dependencies.
     """
-    true_targets = list(
+    true_targets = set(
         map(
             lambda p: Package(ECOSYSTEM.PyPI, p[0], p[1], RemotePackageSource(p[2])),
             [
@@ -116,9 +116,9 @@ def test_pip_command_resolve_install_targets_exact():
     assert all(target in true_targets for target in targets)
 
 
-def test_pip_list_installed_packages(monkeypatch):
+def test_pip_get_installed_packages(monkeypatch):
     """
-    Test that `Pip.list_installed_packages` returns a `Package` with a canonical PyPI
+    Test that `Pip.get_installed_packages` returns a `Package` with a canonical PyPI
     project page `RemotePackageSource` for a registry-installed package (no `direct_url`).
     """
     target = Package(
@@ -135,12 +135,12 @@ def test_pip_list_installed_packages(monkeypatch):
         subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
         subprocess.run([venv_pip, "install", f"{target.name}=={target.version}"], check=True)
 
-        assert target in Pip(executable=venv_pip).list_installed_packages()
+        assert target in Pip(executable=venv_pip).get_installed_packages()
 
 
-def test_pip_list_installed_packages_remote_source(monkeypatch):
+def test_pip_get_installed_packages_remote_source(monkeypatch):
     """
-    Test that `Pip.list_installed_packages` returns a `Package` with a `RemotePackageSource`
+    Test that `Pip.get_installed_packages` returns a `Package` with a `RemotePackageSource`
     for a package installed from a direct remote URL (not via the index).
     """
     jmespath_url = (
@@ -157,12 +157,12 @@ def test_pip_list_installed_packages_remote_source(monkeypatch):
         subprocess.run([sys.executable, "-m", "venv", "venv"], check=True)
         subprocess.run([venv_pip, "install", jmespath_url], check=True)
 
-        assert target in Pip(executable=venv_pip).list_installed_packages()
+        assert target in Pip(executable=venv_pip).get_installed_packages()
 
 
-def test_pip_list_installed_packages_local_source(new_pip_project_installed):
+def test_pip_get_installed_packages_local_source(new_pip_project_installed):
     """
-    Test that `Pip.list_installed_packages` returns a `Package` with a `LocalPackageSource`
+    Test that `Pip.get_installed_packages` returns a `Package` with a `LocalPackageSource`
     for a package installed from a local directory.
     """
     target = Package(
@@ -173,4 +173,4 @@ def test_pip_list_installed_packages_local_source(new_pip_project_installed):
     )
 
     venv_pip = new_pip_project_installed / "venv" / "bin" / "pip"
-    assert target in Pip(executable=venv_pip).list_installed_packages()
+    assert target in Pip(executable=venv_pip).get_installed_packages()

--- a/tests/package_managers/test_poetry_class.py
+++ b/tests/package_managers/test_poetry_class.py
@@ -59,12 +59,13 @@ def test_poetry_command_resolve_install_targets_add(
             ["poetry", "add", "--directory", poetry_project, target_spec]
         )
 
-        assert (
-            len(targets) == 1
-            and targets[0].ecosystem == ECOSYSTEM.PyPI
-            and targets[0].name == TARGET
-            and targets[0].version == target_version
-        )
+        assert len(targets) == 1
+
+        target = targets.pop()
+        assert target.ecosystem == ECOSYSTEM.PyPI
+        assert target.name == TARGET
+        assert target.version == target_version
+
         assert poetry_show(poetry_project) == init_state
 
 
@@ -143,14 +144,14 @@ def test_poetry_command_resolve_install_targets_update(
     )
 
 
-def test_poetry_list_installed_packages(monkeypatch, poetry_project_target_latest):
+def test_poetry_get_installed_packages(monkeypatch, poetry_project_target_latest):
     """
-    Tests that `Poetry.list_installed_packages` correctly parses `poetry` output.
+    Tests that `Poetry.get_installed_packages` correctly parses `poetry` output.
     """
     # Change directories into the test project directory for only this test
     monkeypatch.chdir(poetry_project_target_latest)
 
-    assert PACKAGE_MANAGER.list_installed_packages() == [Package(ECOSYSTEM.PyPI, TARGET, TARGET_LATEST)]
+    assert PACKAGE_MANAGER.get_installed_packages() == {Package(ECOSYSTEM.PyPI, TARGET, TARGET_LATEST)}
 
 
 def _test_poetry_command_resolve_install_targets(command, project, targets) -> bool:
@@ -160,6 +161,6 @@ def _test_poetry_command_resolve_install_targets(command, project, targets) -> b
     """
     init_state = poetry_show(project)
 
-    targets = [Package(ECOSYSTEM.PyPI, name, version) for name, version in targets]
+    targets = {Package(ECOSYSTEM.PyPI, name, version) for name, version in targets}
 
     return PACKAGE_MANAGER.resolve_install_targets(command) == targets and poetry_show(project) == init_state

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -5,16 +5,15 @@ Tests of the core firewall logic.
 import sys
 
 import pytest
-from typing import Iterable, Optional
+from typing import Optional
 from unittest.mock import MagicMock
 
 from scfw.constants import ON_WARNING_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.firewall import _determine_firewall_action, _get_warning_action
 from scfw.logger import FirewallAction
-from scfw.package import Package
-from scfw.report import FindingsReport, VerificationReport
-from scfw.verifier import FindingSeverity
+from scfw.report import Unverified, VerificationReport
+from scfw.verifier import Finding, FindingSeverity
 
 from tests.utils import build_registry_package
 
@@ -22,12 +21,17 @@ from tests.utils import build_registry_package
 _PKG_A = build_registry_package(ECOSYSTEM.PyPI, "requests", "2.31.0")
 _PKG_B = build_registry_package(ECOSYSTEM.PyPI, "numpy", "1.24.0")
 
+_CRITICAL_FINDING = Finding("foo", FindingSeverity.CRITICAL, "critical finding")
+_WARNING_FINDING = Finding("foo", FindingSeverity.WARNING, "warning finding")
+
+_UNVERIFIED = Unverified("foo", "unverified package")
+
 
 def test_no_findings():
     """
     A verification report with no findings and no unverifiable packages results in an ALLOW action.
     """
-    action, warned, relevant = _determine_firewall_action(make_verification_report(), None)
+    action, warned, relevant = _determine_firewall_action(VerificationReport(), None)
 
     assert action == FirewallAction.ALLOW
     assert not warned
@@ -38,12 +42,14 @@ def test_critical_findings_blocks():
     """
     A verification report with critical findings results in a BLOCK action with no user warning.
     """
-    critical = make_findings_report([(_PKG_A, "critical finding")])
-    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical), None)
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    action, warned, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
     assert not warned
-    assert relevant == critical
+    assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
 def test_critical_findings_take_precedence_over_warnings():
@@ -51,13 +57,15 @@ def test_critical_findings_take_precedence_over_warnings():
     When both critical and warning findings are present, the critical findings drive a BLOCK
     action and the warning findings are not included in the result.
     """
-    critical = make_findings_report([(_PKG_A, "critical finding")])
-    warning = make_findings_report([(_PKG_B, "warning finding")])
-    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical, warning=warning), None)
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_B, _WARNING_FINDING)
+
+    action, warned, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
     assert not warned
-    assert relevant == critical
+    assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
 def test_critical_findings_take_precedence_over_unverifiable():
@@ -65,13 +73,15 @@ def test_critical_findings_take_precedence_over_unverifiable():
     When both critical findings and unverifiable packages are present, the critical findings drive
     a BLOCK action and the unverifiable packages are not included in the result.
     """
-    critical = make_findings_report([(_PKG_A, "critical finding")])
-    unverifiable = make_findings_report([(_PKG_B, "unverifiable package")])
-    action, warned, relevant = _determine_firewall_action(make_verification_report(critical=critical, unverifiable=unverifiable), None)
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_unverified(_PKG_B, _UNVERIFIED)
+
+    action, warned, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
     assert not warned
-    assert relevant == critical
+    assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
 @pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
@@ -80,12 +90,14 @@ def test_warning_findings(warning_action: Optional[FirewallAction]):
     A verification report with only warning findings defers to the configured warning action,
     with the user warned and the warning findings returned as relevant findings.
     """
-    warning = make_findings_report([(_PKG_A, "warning finding")])
-    action, warned, relevant = _determine_firewall_action(make_verification_report(warning=warning), warning_action)
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _WARNING_FINDING)
+
+    action, warned, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
     assert warned
-    assert relevant == warning
+    assert relevant == report.get_findings(FindingSeverity.WARNING)
 
 
 @pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
@@ -94,12 +106,14 @@ def test_unverifiable_only(warning_action: Optional[FirewallAction]):
     Unverifiable packages are treated the same as warning-level findings: the configured
     warning action is returned with the user warned and the unverifiable packages as relevant findings.
     """
-    unverifiable = make_findings_report([(_PKG_A, "unverifiable package")])
-    action, warned, relevant = _determine_firewall_action(make_verification_report(unverifiable=unverifiable), warning_action)
+    report = VerificationReport()
+    report.insert_unverified(_PKG_A, _UNVERIFIED)
+
+    action, warned, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
     assert warned
-    assert relevant == unverifiable
+    assert relevant == None
 
 
 @pytest.mark.parametrize("warning_action", [FirewallAction.BLOCK, FirewallAction.ALLOW, None])
@@ -108,15 +122,15 @@ def test_warning_and_unverifiable_merged(warning_action: Optional[FirewallAction
     When both warning findings and unverifiable packages are present, the relevant findings
     returned are a merge of the two reports.
     """
-    warning = make_findings_report([(_PKG_A, "warning finding")])
-    unverifiable = make_findings_report([(_PKG_B, "unverifiable package")])
-    action, warned, relevant = _determine_firewall_action(
-        make_verification_report(warning=warning, unverifiable=unverifiable), warning_action
-    )
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _WARNING_FINDING)
+    report.insert_unverified(_PKG_B, _UNVERIFIED)
+
+    action, warned, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
     assert warned
-    assert relevant == FindingsReport.merge(warning, unverifiable)
+    assert relevant == report.get_findings(FindingSeverity.WARNING)
 
 
 def test_get_warning_action_cli_block():
@@ -217,38 +231,3 @@ def test_get_warning_action_interactive_terminal(monkeypatch):
     monkeypatch.setattr(sys, "stdin", mock_stdin)
 
     assert _get_warning_action(cli_allow_choice=False, cli_block_choice=False) is None
-
-
-def make_verification_report(
-    critical: Optional[FindingsReport] = None,
-    warning: Optional[FindingsReport] = None,
-    unverifiable: Optional[FindingsReport] = None,
-) -> VerificationReport:
-    """
-    Create a mocked `VerificationReport` from the given inputs.
-    """
-    findings_reports = {}
-
-    if critical is not None:
-        findings_reports[FindingSeverity.CRITICAL] = critical
-    if warning is not None:
-        findings_reports[FindingSeverity.WARNING] = warning
-
-    # `verification_set` is not used in these tests
-    return VerificationReport(
-        verification_set=frozenset(),
-        findings_reports=findings_reports,
-        unverifiable=unverifiable if unverifiable is not None else FindingsReport(),
-    )
-
-
-def make_findings_report(findings: Iterable[tuple[Package, str]]) -> FindingsReport:
-    """
-    Create a `FindingsReport` from the given `Package-str` pairs.
-    """
-    report = FindingsReport()
-
-    for package, finding in findings:
-        report.insert(package, finding)
-
-    return report

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -104,7 +104,8 @@ def test_warning_findings(warning_action: Optional[FirewallAction]):
 def test_unverifiable_only(warning_action: Optional[FirewallAction]):
     """
     Unverifiable packages are treated the same as warning-level findings: the configured
-    warning action is returned with the user warned and the unverifiable packages as relevant findings.
+    warning action is returned with the user warned. No relevant findings are returned,
+    as unverifiable package information is accessible via the verification report itself.
     """
     report = VerificationReport()
     report.insert_unverifiable(_PKG_A, _UNVERIFIABLE)

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -12,7 +12,7 @@ from scfw.constants import ON_WARNING_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.firewall import _determine_firewall_action, _get_warning_action
 from scfw.logger import FirewallAction
-from scfw.report import Unverified, VerificationReport
+from scfw.report import VerificationReport, VerifierErrorMessage
 from scfw.verifier import Finding, FindingSeverity
 
 from tests.utils import build_registry_package
@@ -24,7 +24,7 @@ _PKG_B = build_registry_package(ECOSYSTEM.PyPI, "numpy", "1.24.0")
 _CRITICAL_FINDING = Finding("foo", FindingSeverity.CRITICAL, "critical finding")
 _WARNING_FINDING = Finding("foo", FindingSeverity.WARNING, "warning finding")
 
-_UNVERIFIED = Unverified("foo", "unverified package")
+_UNVERIFIABLE = VerifierErrorMessage("foo", "unverified package")
 
 
 def test_no_findings():
@@ -75,7 +75,7 @@ def test_critical_findings_take_precedence_over_unverifiable():
     """
     report = VerificationReport()
     report.insert_finding(_PKG_A, _CRITICAL_FINDING)
-    report.insert_unverified(_PKG_B, _UNVERIFIED)
+    report.insert_unverifiable(_PKG_B, _UNVERIFIABLE)
 
     action, warned, relevant = _determine_firewall_action(report, None)
 
@@ -107,7 +107,7 @@ def test_unverifiable_only(warning_action: Optional[FirewallAction]):
     warning action is returned with the user warned and the unverifiable packages as relevant findings.
     """
     report = VerificationReport()
-    report.insert_unverified(_PKG_A, _UNVERIFIED)
+    report.insert_unverifiable(_PKG_A, _UNVERIFIABLE)
 
     action, warned, relevant = _determine_firewall_action(report, warning_action)
 
@@ -124,7 +124,7 @@ def test_warning_and_unverifiable_merged(warning_action: Optional[FirewallAction
     """
     report = VerificationReport()
     report.insert_finding(_PKG_A, _WARNING_FINDING)
-    report.insert_unverified(_PKG_B, _UNVERIFIED)
+    report.insert_unverifiable(_PKG_B, _UNVERIFIABLE)
 
     action, warned, relevant = _determine_firewall_action(report, warning_action)
 

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -31,10 +31,10 @@ def test_no_findings():
     """
     A verification report with no findings and no unverifiable packages results in an ALLOW action.
     """
-    action, warned, relevant = _determine_firewall_action(VerificationReport(), None)
+    action, severity, relevant = _determine_firewall_action(VerificationReport(), None)
 
     assert action == FirewallAction.ALLOW
-    assert not warned
+    assert severity is None
     assert relevant is None
 
 
@@ -45,10 +45,10 @@ def test_critical_findings_blocks():
     report = VerificationReport()
     report.insert_finding(_PKG_A, _CRITICAL_FINDING)
 
-    action, warned, relevant = _determine_firewall_action(report, None)
+    action, severity, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
-    assert not warned
+    assert severity == FindingSeverity.CRITICAL
     assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
@@ -61,10 +61,10 @@ def test_critical_findings_take_precedence_over_warnings():
     report.insert_finding(_PKG_A, _CRITICAL_FINDING)
     report.insert_finding(_PKG_B, _WARNING_FINDING)
 
-    action, warned, relevant = _determine_firewall_action(report, None)
+    action, severity, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
-    assert not warned
+    assert severity == FindingSeverity.CRITICAL
     assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
@@ -77,10 +77,10 @@ def test_critical_findings_take_precedence_over_unverifiable():
     report.insert_finding(_PKG_A, _CRITICAL_FINDING)
     report.insert_unverifiable(_PKG_B, _UNVERIFIABLE)
 
-    action, warned, relevant = _determine_firewall_action(report, None)
+    action, severity, relevant = _determine_firewall_action(report, None)
 
     assert action == FirewallAction.BLOCK
-    assert not warned
+    assert severity == FindingSeverity.CRITICAL
     assert relevant == report.get_findings(FindingSeverity.CRITICAL)
 
 
@@ -93,10 +93,10 @@ def test_warning_findings(warning_action: Optional[FirewallAction]):
     report = VerificationReport()
     report.insert_finding(_PKG_A, _WARNING_FINDING)
 
-    action, warned, relevant = _determine_firewall_action(report, warning_action)
+    action, severity, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
-    assert warned
+    assert severity == FindingSeverity.WARNING
     assert relevant == report.get_findings(FindingSeverity.WARNING)
 
 
@@ -110,10 +110,10 @@ def test_unverifiable_only(warning_action: Optional[FirewallAction]):
     report = VerificationReport()
     report.insert_unverifiable(_PKG_A, _UNVERIFIABLE)
 
-    action, warned, relevant = _determine_firewall_action(report, warning_action)
+    action, severity, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
-    assert warned
+    assert severity == FindingSeverity.WARNING
     assert relevant == None
 
 
@@ -127,10 +127,10 @@ def test_warning_and_unverifiable_merged(warning_action: Optional[FirewallAction
     report.insert_finding(_PKG_A, _WARNING_FINDING)
     report.insert_unverifiable(_PKG_B, _UNVERIFIABLE)
 
-    action, warned, relevant = _determine_firewall_action(report, warning_action)
+    action, severity, relevant = _determine_firewall_action(report, warning_action)
 
     assert action == warning_action
-    assert warned
+    assert severity == FindingSeverity.WARNING
     assert relevant == report.get_findings(FindingSeverity.WARNING)
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,299 @@
+"""
+Tests of the `VerificationReport` class.
+"""
+
+import pytest
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.report import VerificationReport, VerifierErrorMessage
+from scfw.verifier import Finding, FindingSeverity
+
+from tests.utils import build_registry_package
+
+
+_PKG_A = build_registry_package(ECOSYSTEM.PyPI, "requests", "2.31.0")
+_PKG_B = build_registry_package(ECOSYSTEM.PyPI, "numpy", "1.26.0")
+_PKG_C = build_registry_package(ECOSYSTEM.Npm, "lodash", "4.17.21")
+
+_CRITICAL_FINDING = Finding("verifier-a", FindingSeverity.CRITICAL, "critical issue")
+_WARNING_FINDING = Finding("verifier-b", FindingSeverity.WARNING, "warning issue")
+
+_ERROR_MESSAGE = VerifierErrorMessage("verifier-a", "package not sourced from main registry")
+
+
+def test_empty_report_get_clean():
+    """
+    A freshly initialized `VerificationReport` has no clean packages.
+    """
+    assert VerificationReport().get_clean() == set()
+
+
+def test_empty_report_get_findings():
+    """
+    A freshly initialized `VerificationReport` has no findings at any severity level.
+    """
+    assert VerificationReport().get_findings() == {}
+
+
+def test_empty_report_get_unverifiable():
+    """
+    A freshly initialized `VerificationReport` has no unverifiable packages.
+    """
+    assert VerificationReport().get_unverifiable() == {}
+
+
+def test_empty_report_packages():
+    """
+    A freshly initialized `VerificationReport` contains no packages.
+    """
+    assert VerificationReport().packages() == set()
+
+
+def test_insert_clean_appears_in_get_clean():
+    """
+    A clean package inserted into the report is returned by `get_clean()`.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    assert _PKG_A in report.get_clean()
+
+
+def test_insert_clean_appears_in_packages():
+    """
+    A clean package inserted into the report is returned by `packages()`.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    assert _PKG_A in report.packages()
+
+
+def test_insert_clean_not_in_findings_or_unverifiable():
+    """
+    A clean package does not appear in `get_findings()` or `get_unverifiable()`.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    assert report.get_findings() == {}
+    assert report.get_unverifiable() == {}
+
+
+def test_insert_clean_multiple_packages():
+    """
+    Multiple clean packages inserted into the report are all returned by `get_clean()`.
+    """
+    report = VerificationReport()
+    for pkg in (_PKG_A, _PKG_B, _PKG_C):
+        report.insert_clean(pkg)
+    assert report.get_clean() == {_PKG_A, _PKG_B, _PKG_C}
+
+
+def test_insert_clean_noop_if_package_has_finding():
+    """
+    `insert_clean()` is a no-op if the package already has a finding in the report.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_clean(_PKG_A)
+    assert _PKG_A not in report.get_clean()
+
+
+def test_insert_clean_noop_if_package_is_unverifiable():
+    """
+    `insert_clean()` is a no-op if the package is already marked unverifiable.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    report.insert_clean(_PKG_B)
+    assert _PKG_B not in report.get_clean()
+
+
+def test_insert_clean_idempotent():
+    """
+    Inserting the same clean package twice does not produce duplicate entries.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    report.insert_clean(_PKG_A)
+    assert report.get_clean() == {_PKG_A}
+
+
+@pytest.mark.parametrize("finding,severity", [
+    (_CRITICAL_FINDING, FindingSeverity.CRITICAL),
+    (_WARNING_FINDING, FindingSeverity.WARNING),
+])
+def test_insert_finding_appears_in_correct_severity_bucket(finding, severity):
+    """
+    A finding inserted into the report appears in `get_findings()` for its severity
+    and not in the other severity bucket.
+    """
+    other = FindingSeverity.WARNING if severity == FindingSeverity.CRITICAL else FindingSeverity.CRITICAL
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, finding)
+    assert report.get_findings() == {_PKG_A: {finding}}
+    assert report.get_findings(severity) == {_PKG_A: {finding}}
+    assert report.get_findings(other) == {}
+
+
+def test_insert_finding_multiple_same_severity():
+    """
+    Multiple findings of the same severity for the same package are all retained.
+    """
+    f1 = Finding("v1", FindingSeverity.CRITICAL, "issue one")
+    f2 = Finding("v2", FindingSeverity.CRITICAL, "issue two")
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, f1)
+    report.insert_finding(_PKG_A, f2)
+    assert report.get_findings(FindingSeverity.CRITICAL)[_PKG_A] == {f1, f2}
+
+
+def test_insert_finding_mixed_severities_same_package():
+    """
+    A package with findings of different severities has all findings returned by `get_findings()`.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_A, _WARNING_FINDING)
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING, _WARNING_FINDING}}
+
+
+def test_insert_finding_multiple_packages():
+    """
+    Findings for different packages are tracked independently.
+    """
+    f_b = Finding("verifier-a", FindingSeverity.CRITICAL, "issue in pkg_b")
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_B, f_b)
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}, _PKG_B: {f_b}}
+
+
+def test_insert_finding_removes_package_from_clean():
+    """
+    A package previously marked clean is removed from `get_clean()` once a finding is inserted.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    assert _PKG_A not in report.get_clean()
+
+
+def test_insert_finding_package_appears_in_packages():
+    """
+    A package with a finding is returned by `packages()`.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    assert _PKG_A in report.packages()
+
+
+def test_insert_finding_idempotent():
+    """
+    Inserting the same finding twice does not produce duplicate entries.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}}
+
+
+def test_insert_unverifiable_appears_in_get_unverifiable():
+    """
+    An unverifiable error message inserted into the report is returned by `get_unverifiable()`.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    unverifiable = report.get_unverifiable()
+    assert _PKG_B in unverifiable
+    assert _ERROR_MESSAGE in unverifiable[_PKG_B]
+
+
+def test_insert_unverifiable_multiple_error_messages():
+    """
+    Multiple error messages for the same unverifiable package are all retained.
+    """
+    em1 = VerifierErrorMessage("v1", "error from v1")
+    em2 = VerifierErrorMessage("v2", "error from v2")
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, em1)
+    report.insert_unverifiable(_PKG_B, em2)
+    assert report.get_unverifiable()[_PKG_B] == {em1, em2}
+
+
+def test_insert_unverifiable_removes_package_from_clean():
+    """
+    A package previously marked clean is removed from `get_clean()` once it is marked unverifiable.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_B)
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    assert _PKG_B not in report.get_clean()
+
+
+def test_insert_unverifiable_package_appears_in_packages():
+    """
+    A package marked unverifiable is returned by `packages()`.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    assert _PKG_B in report.packages()
+
+
+def test_insert_unverifiable_idempotent():
+    """
+    Inserting the same error message twice does not produce duplicate entries.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    assert len(report.get_unverifiable()[_PKG_B]) == 1
+
+
+def test_packages_union_of_all_three_buckets():
+    """
+    `packages()` returns the union of clean, findings, and unverifiable packages.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_C)
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    assert report.packages() == {_PKG_A, _PKG_B, _PKG_C}
+
+
+def test_packages_no_duplicates_after_clean_to_findings_promotion():
+    """
+    A package that moves from clean to findings is not double-counted by `packages()`.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    assert report.packages() == {_PKG_A}
+
+
+def test_get_findings_returns_copy():
+    """
+    Mutating the set returned by `get_findings()` does not affect the report's internal state.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.get_findings()[_PKG_A].add(_WARNING_FINDING)
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}}
+
+
+def test_get_clean_returns_copy():
+    """
+    Mutating the set returned by `get_clean()` does not affect the report's internal state.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    report.get_clean().add(_PKG_B)
+    assert _PKG_B not in report.get_clean()
+
+
+def test_get_unverifiable_returns_copy():
+    """
+    Mutating the set returned by `get_unverifiable()` does not affect the report's internal state.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    report.get_unverifiable()[_PKG_B].add(VerifierErrorMessage("other", "extra"))
+    assert len(report.get_unverifiable()[_PKG_B]) == 1

--- a/tests/verifiers/test_age_verifier.py
+++ b/tests/verifiers/test_age_verifier.py
@@ -45,7 +45,7 @@ def test_warn_on_recent_package(test_package: Package, unverifiable: bool):
 
     results = recency_verifier.verify(test_package)
     assert len(results) == 1
-    assert results[0][0] == FindingSeverity.WARNING
+    assert results.pop().severity == FindingSeverity.WARNING
 
 
 

--- a/tests/verifiers/test_dd_verifier.py
+++ b/tests/verifiers/test_dd_verifier.py
@@ -72,9 +72,9 @@ def test_dd_verifier_malicious(
         findings = dd_verifier.verify(package)
         assert len(findings) == 1
 
-        severity, finding = findings[0]
-        assert severity == FindingSeverity.CRITICAL
-        assert finding
+        finding = findings.pop()
+        assert finding.severity == FindingSeverity.CRITICAL
+        assert finding.finding
 
 
 @pytest.mark.parametrize("ecosystem", [ECOSYSTEM.Npm, ECOSYSTEM.PyPI])

--- a/tests/verifiers/test_list_verifier.py
+++ b/tests/verifiers/test_list_verifier.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.verifier import FindingSeverity, UnverifiablePackage
+from scfw.verifier import Finding, FindingSeverity, UnverifiablePackage
 from scfw.verifiers.list_verifier import FindingsListVerifier, FindingsMap
 
 from .. import utils
@@ -285,4 +285,6 @@ def backend_test_verify(
         return
 
     assert findings is not None
-    assert list_verifier.verify(package) == findings
+    assert list_verifier.verify(package) == {
+        Finding(list_verifier.name(), severity, finding) for severity, finding in findings
+    }

--- a/tests/verifiers/test_osv_verifier.py
+++ b/tests/verifiers/test_osv_verifier.py
@@ -264,8 +264,8 @@ def test_osv_verifier_malicious(
         findings = osv_verifier.verify(package)
         assert findings
 
-        any_critical = any(finding[0] == FindingSeverity.CRITICAL for finding in findings)
-        any_warning = any(finding[0] == FindingSeverity.WARNING for finding in findings)
+        any_critical = any(finding.severity == FindingSeverity.CRITICAL for finding in findings)
+        any_warning = any(finding.severity == FindingSeverity.WARNING for finding in findings)
 
         if has_critical:
             assert any_critical


### PR DESCRIPTION
This PR refactors the verification reporting and logging subsystems. The central change is replacing the `FindingsReport` class and bare `tuple[FindingSeverity, str]` verifier return type with proper `Finding` and `VerifierErrorMessage` dataclasses, while converting `FindingsReport` and `UnverifiablePackageReport` to plain `dict` type aliases. `VerificationReport` is rewritten from a dataclass into a class with typed accessor and mutator methods, and now also tracks "clean" packages that had no findings.

Display logic moves out of the data model into a standalone `show_reports()` function. On the logging side, the many-parameter `log_firewall_action` interface is replaced by `log_firewall_run` accepting a new `FirewallRunSummary` dataclass, and the Datadog logger is substantially enriched to emit structured per-package, per-verifier findings (with severity) rather than flat package-name lists. `_determine_firewall_action` also changes its second return value from a bool to `Optional[FindingSeverity]`, and package collections are migrated from list to set throughout.

Finally, unit tests and CI integration are added for the refactored `VerificationReport` class.