### PR TITLE
[SECRES-5198] Add custom logger for Code Security integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Supply-Chain Firewall can optionally send logs of blocked and successful install
 
 ![scfw datadog log](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/images/datadog_log.png?raw=true)
 
-Logs may be forwarded to Datadog via the HTTP API (requires an API key) or via a local Datadog Agent process.  Documentation on how to enable and configure these loggers may be found [here](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md).
+Logs may be forwarded to Datadog via the HTTP API or a local Datadog Agent process.  A Datadog API key is required to enable log forwarding.  Documentation on how to enable and configure these loggers may be found [here](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md).
 
 Supply-Chain Firewall can maintain a local JSON Lines log file that records all completed `run` and `audit` executions.  Users are strongly encouraged to [enable](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md#local-file-logger) this logger, as having a centralized record of executed package manager commands, their outcomes, and installed packages over time can be useful in incident response scenarios.  Once file logging has been enabled, users may separately [configure](https://docs.datadoghq.com/agent/logs/?tab=tailfiles#custom-log-collection) the local Datadog Agent to tail this file and thereby ingest logs from SCFW with no additional overhead.
 

--- a/docs/loggers.md
+++ b/docs/loggers.md
@@ -48,8 +48,11 @@ The Datadog API logger submits JSON logs of successful `run` and `audit` actions
 
 Users may configure the behavior of this logger via the following environment variables:
 
+* `SCFW_DD_API_LOGGER_ENABLED`:
+    Setting this environment variable to any nonempty value is required to enable this logger.
+
 * `DD_API_KEY`:
-    Takes a Datadog API key.  Required to enable this logger.
+    Takes a Datadog API key.  Required to successfully use this logger.
 
     The `scfw configure` [subcommand](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/subcommands.md#scfw-configure) can be used to write this environment variable into the user's `~/.bashrc` and `~/.zshrc` files.
 
@@ -84,6 +87,28 @@ Users may configure the behavior of this logger via the following environment va
     Takes the local filesystem path of the SCFW home directory.
 
     If `SCFW_DD_LOG_ATTRIBUTES_FILE` is not set, this logger will look for custom log attributes at `$SCFW_HOME/dd_logger/log_attributes.json` by default, with `SCFW_DD_LOG_ATTRIBUTES` again taking precedence over attributes read from file.
+
+## Datadog Code Security API logger
+
+> **Preview:** The Datadog Code Security API logger is currently available only as a preview for Datadog customers and upon request.
+
+This logger submits reports of `run` actions taken by Supply-Chain Firewall to Datadog Code Security's Supply-Chain Firewall API over HTTPS.  Note that `audit` actions are not currently supported by this logger.
+
+Users may configure the behavior of this logger via the following environment variables:
+
+* `SCFW_DD_CODESEC_LOGGER_ENABLED`:
+    Setting this environment variable to any nonempty value is required to enable this logger.
+
+* `DD_API_KEY`:
+    Takes a Datadog API key.  Required to successfully use this logger.
+
+    The `scfw configure` [subcommand](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/subcommands.md#scfw-configure) can be used to write this environment variable into the user's `~/.bashrc` and `~/.zshrc` files.
+
+* `DD_APP_KEY`:
+    Takes a Datadog application key.  Required to successfully use this logger.
+
+* `DD_SITE`:
+    Takes a [Datadog site parameter](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) for setting the region where the target Datadog organization is hosted.  Defaults to `datadoghq.com` if not set.
 
 ## Local file logger
 

--- a/examples/verifier.py
+++ b/examples/verifier.py
@@ -1,7 +1,7 @@
 """
 Users of Supply-Chain Firewall may provide custom package verifiers representing
-alternative sources of truth for the firewall to use. This module contains a template
-for writing such a custom verifier.
+alternative sources of truth for SCFW to use. This module contains a template for
+writing such a custom verifier.
 
 Supply-Chain Firewall discovers verifiers at runtime via the following simple protocol.
 The module implementing the custom verifier must contain a function with the following

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -1,5 +1,5 @@
 """
-A supply-chain "firewall" for preventing the installation of vulnerable or malicious `pip` and `npm` packages.
+Supply-Chain Firewall (SCFW) is a tool for preventing the installation of malicious npm and PyPI packages.
 """
 
 __version__ = "2.6.1"

--- a/scfw/cli/__init__.py
+++ b/scfw/cli/__init__.py
@@ -1,5 +1,5 @@
 """
-Defines the supply-chain firewall's command-line interface and performs argument parsing.
+Defines Supply-Chain Firewall's command-line interface and performs argument parsing.
 """
 
 from argparse import ArgumentError, Namespace, SUPPRESS
@@ -24,7 +24,7 @@ _DEFAULT_LOG_LEVEL = logging.getLevelName(logging.WARNING)
 
 def _add_audit_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for the firewall's `audit` subcommand.
+    Defines the command-line interface for Supply-Chain Firewall's `audit` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `audit` command line will be added.
@@ -47,7 +47,7 @@ def _add_audit_cli(parser: ArgumentParser):
 
 def _add_configure_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for the firewall's `configure` subcommand.
+    Defines the command-line interface for Supply-Chain Firewall's `configure` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `configure` command line will be added.
@@ -113,7 +113,7 @@ def _add_configure_cli(parser: ArgumentParser):
 
 def _add_run_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for the firewall's `run` subcommand.
+    Defines the command-line interface for Supply-Chain Firewall's `run` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `run` command line will be added.
@@ -168,7 +168,7 @@ def _add_run_cli(parser: ArgumentParser):
 
 class Subcommand(Enum):
     """
-    The set of subcommands that comprise the supply-chain firewall's command line.
+    The set of subcommands that comprise Supply-Chain Firewall's command line.
     """
     Audit = "audit"
     Configure = "configure"
@@ -230,13 +230,13 @@ class Subcommand(Enum):
 
 def _cli() -> ArgumentParser:
     """
-    Defines the command-line interface for the supply-chain firewall.
+    Defines the command-line interface for Supply-Chain Firewall.
 
     Returns:
-        A parser for the supply-chain firewall's command line.
+        A parser for Supply-Chain Firewall's command line.
 
-        This parser only handles the firewall's own optional arguments and subcommands.
-        It does not parse the package manager commands being run through the firewall.
+        This parser only handles SCFW's own optional arguments and subcommands.
+        It does not parse the package manager commands being run through it.
     """
     parser = ArgumentParser(
         prog="scfw",
@@ -271,7 +271,7 @@ def _cli() -> ArgumentParser:
 
 def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
     """
-    Parse the supply-chain firewall's command line from a given argument vector.
+    Parse Supply-Chain Firewall's command line from a given argument vector.
 
     Args:
         argv: The argument vector to be parsed.
@@ -328,18 +328,16 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
 
 def parse_command_line() -> tuple[Optional[Namespace], str]:
     """
-    Parse the supply-chain firewall's command line.
+    Parse Supply-Chain Firewall's command line.
 
     Returns:
-        A `tuple` of a `Namespace` object containing the results of parsing the
-        firewall's command line and a `str` help message for the caller's use in
-        early exits. In the case of a parsing failure, `None` is returned instead
-        of a `Namespace`.
+        A `tuple` of a `Namespace` object containing the results of parsing SCFW's
+        command line and a `str` help message for the caller's use in early exits.
+        In the case of a parsing failure, `None` is returned instead of a `Namespace`.
 
         On successful parsing of a command line for the `run` subcommand, the
-        returned `Namespace` contains the package manager command provided to the
-        firewall as a `list[str]` under the `command` attribute. Meanwhile, the name
-        of the selected package manager is contained under the `package_manager`
-        attribute.
+        returned `Namespace` contains the package manager command provided to SCFW
+        as a `list[str]` under the `command` attribute. Meanwhile, the name of the
+        selected package manager is contained under the `package_manager` attribute.
     """
     return _parse_command_line(sys.argv)

--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -15,7 +15,7 @@ _log = logging.getLogger(__name__)
 
 def run_configure(args: Namespace) -> int:
     """
-    Configure the environment for use with the supply-chain firewall.
+    Configure the environment for using Supply-Chain Firewall.
 
     Args:
         args: A `Namespace` containing the parsed `configure` subcommand command line.

--- a/scfw/configure/dd_agent.py
+++ b/scfw/configure/dd_agent.py
@@ -1,5 +1,5 @@
 """
-Provides utilities for configuring the local Datadog Agent to receive logs from Supply-Chain Firewall.
+Provides utilities for configuring the local Datadog Agent to receive logs from SCFW.
 """
 
 import json
@@ -16,10 +16,10 @@ _log = logging.getLogger(__name__)
 
 def configure_agent_logging(port: str):
     """
-    Configure a local Datadog Agent for accepting logs from the firewall.
+    Configure a local Datadog Agent for accepting logs from Supply-Chain Firewall.
 
     Args:
-        port: The local port number where the firewall logs will be sent to the Agent.
+        port: The local port number where logs will be sent to the Agent.
 
     Raises:
         ValueError: An invalid port number was provided.

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 import re
 
-from scfw.constants import DD_AGENT_PORT_VAR, DD_API_KEY_VAR, DD_LOG_LEVEL_VAR, SCFW_HOME_VAR
+from scfw.constants import DD_AGENT_PORT_VAR, DD_API_KEY_VAR, DD_API_LOGGER_ENABLED_VAR, DD_LOG_LEVEL_VAR, SCFW_HOME_VAR
 
 _log = logging.getLogger(__name__)
 
@@ -106,6 +106,8 @@ def _format_answers(answers: dict) -> str:
         config += 'alias poetry="scfw run poetry"\n'
     if (dd_agent_port := answers.get("dd_agent_port")):
         config += f'export {DD_AGENT_PORT_VAR}="{dd_agent_port}"\n'
+    if answers.get("dd_api_logging"):
+        config += f'export {DD_API_LOGGER_ENABLED_VAR}="1"\n'
     if (dd_api_key := answers.get("dd_api_key")):
         config += f'export {DD_API_KEY_VAR}="{dd_api_key}"\n'
     if (dd_log_level := answers.get("dd_log_level")):

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -23,7 +23,7 @@ def remove_config() -> int:
     Returns:
         An integer status code indicating normal or error exit.
     """
-    # These options result in the firewall's configuration block being removed
+    # These options result in SCFW's configuration block being removed
     return update_config_files({
         "alias_npm": False,
         "alias_pip": False,

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -38,28 +38,28 @@ def get_answers() -> dict:
         inquirer.Text(
             name="scfw_home",
             message=(
-                "Enter a directory the firewall can use as a local cache"
+                "Enter a directory that Supply-Chain Firewall can use as a local cache"
                 f" (default: {home_dir_default})" if home_dir_default else ""
             )
         ),
         inquirer.Confirm(
             name="alias_npm",
-            message="Would you like to set a shell alias to run all npm commands through the firewall?",
+            message="Would you like to set a shell alias to run all npm commands through SCFW?",
             default=True
         ),
         inquirer.Confirm(
             name="alias_pip",
-            message="Would you like to set a shell alias to run all pip commands through the firewall?",
+            message="Would you like to set a shell alias to run all pip commands through SCFW?",
             default=True
         ),
         inquirer.Confirm(
             name="alias_poetry",
-            message="Would you like to set a shell alias to run all Poetry commands through the firewall?",
+            message="Would you like to set a shell alias to run all Poetry commands through SCFW?",
             default=True
         ),
         inquirer.Confirm(
             name="dd_agent_logging",
-            message="If you have the Datadog Agent installed locally, would you like to forward firewall logs to it?",
+            message="If you have the Datadog Agent installed locally, would you like to forward SCFW logs to it?",
             default=False
         ),
         inquirer.Text(
@@ -69,7 +69,7 @@ def get_answers() -> dict:
         ),
         inquirer.Confirm(
             name="dd_api_logging",
-            message="Would you like to enable sending firewall logs to Datadog using an API key?",
+            message="Would you like to enable sending SCFW logs to Datadog using an API key?",
             default=False,
             ignore=lambda answers: has_dd_api_key or answers["dd_agent_logging"]
         ),
@@ -120,7 +120,7 @@ def get_farewell(answers: dict) -> str:
     )
 
     if answers.get("dd_agent_logging"):
-        farewell += "\n* Restart the Datadog Agent in order for it to accept firewall logs."
+        farewell += "\n* Restart the Datadog Agent in order for it to accept logs from SCFW."
 
     farewell += "\n\nGood luck!"
 
@@ -146,10 +146,10 @@ def _describe_log_level(action: FirewallAction) -> str:
 
 def _get_home_dir_default() -> Optional[str]:
     """
-    Resolve the default firewall cache directory from the user's home directory.
+    Resolve the default SCFW cache directory from the user's home directory.
 
     Returns:
-        A `str` representing the default firewall cache directory, which is contained
+        A `str` representing the default SCFW cache directory, which is contained
         inside the user's home directory, or `None` if the home directory cannot be resolved.
     """
     try:

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -71,7 +71,7 @@ def get_answers() -> dict:
             name="dd_api_logging",
             message="Would you like to enable sending SCFW logs to Datadog using an API key?",
             default=False,
-            ignore=lambda answers: has_dd_api_key or answers["dd_agent_logging"]
+            ignore=lambda answers: answers["dd_agent_logging"]
         ),
         inquirer.Text(
             name="dd_api_key",
@@ -83,7 +83,7 @@ def get_answers() -> dict:
             name="dd_log_level",
             message="Select the desired log level for Datadog logging",
             choices=[(_describe_log_level(action), str(action)) for action in FirewallAction],
-            ignore=lambda answers: not (answers["dd_agent_logging"] or has_dd_api_key or answers["dd_api_logging"])
+            ignore=lambda answers: not (answers["dd_agent_logging"] or answers["dd_api_logging"])
         )
     ]
 

--- a/scfw/constants.py
+++ b/scfw/constants.py
@@ -32,6 +32,11 @@ DD_APP_KEY_VAR = "DD_APP_KEY"
 The environment variable under which SCFW looks for a Datadog application key.
 """
 
+DD_API_LOGGER_ENABLED_VAR = "SCFW_DD_API_LOGGER_ENABLED"
+"""
+The environment variable that must be set to enable the Datadog API logger.
+"""
+
 DD_LOG_LEVEL_VAR = "SCFW_DD_LOG_LEVEL"
 """
 The environment variable under which SCFW looks for a Datadog log level setting.

--- a/scfw/constants.py
+++ b/scfw/constants.py
@@ -17,6 +17,11 @@ DD_ENV = "dev"
 Default environment value for Datadog logging.
 """
 
+DD_SITE_VAR = "DD_SITE"
+"""
+Lorem ipsum dolor sit amet.
+"""
+
 DD_API_KEY_VAR = "DD_API_KEY"
 """
 The environment variable under which the firewall looks for a Datadog API key.

--- a/scfw/constants.py
+++ b/scfw/constants.py
@@ -22,6 +22,11 @@ DD_API_KEY_VAR = "DD_API_KEY"
 The environment variable under which the firewall looks for a Datadog API key.
 """
 
+DD_APP_KEY_VAR = "DD_APP_KEY"
+"""
+Lorem ipsum dolor sit amet.
+"""
+
 DD_LOG_LEVEL_VAR = "SCFW_DD_LOG_LEVEL"
 """
 The environment variable under which the firewall looks for a Datadog log level setting.

--- a/scfw/constants.py
+++ b/scfw/constants.py
@@ -19,37 +19,37 @@ Default environment value for Datadog logging.
 
 DD_SITE_VAR = "DD_SITE"
 """
-Lorem ipsum dolor sit amet.
+The environment variable under which SCFW looks for a Datadog site parameter.
 """
 
 DD_API_KEY_VAR = "DD_API_KEY"
 """
-The environment variable under which the firewall looks for a Datadog API key.
+The environment variable under which SCFW looks for a Datadog API key.
 """
 
 DD_APP_KEY_VAR = "DD_APP_KEY"
 """
-Lorem ipsum dolor sit amet.
+The environment variable under which SCFW looks for a Datadog application key.
 """
 
 DD_LOG_LEVEL_VAR = "SCFW_DD_LOG_LEVEL"
 """
-The environment variable under which the firewall looks for a Datadog log level setting.
+The environment variable under which SCFW looks for a Datadog log level setting.
 """
 
 DD_AGENT_PORT_VAR = "SCFW_DD_AGENT_LOG_PORT"
 """
-The environment variable under which the firewall looks for a port number on which to
-forward firewall logs to the local Datadog Agent.
+The environment variable under which SCFW looks for a port number on which to
+forward logs to a local Datadog Agent.
 """
 
 ON_WARNING_VAR = "SCFW_ON_WARNING"
 """
-The environment variable under which the firewall looks for the user's choice of
+The environment variable under which SCFW looks for the user's choice of
 `FirewallAction` to take for commands with only warning-level findings.
 """
 
 SCFW_HOME_VAR = "SCFW_HOME"
 """
-The environment variable under which the firewall looks for its home (cache) directory.
+The environment variable under which SCFW looks for its home (cache) directory.
 """

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -1,5 +1,5 @@
 """
-A representation of package ecosystems supported by the supply-chain firewall.
+A representation of package ecosystems supported by Supply-Chain Firewall.
 """
 
 from enum import Enum
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 class ECOSYSTEM(Enum):
     """
-    Package ecosystems supported by the supply-chain firewall.
+    Package ecosystems supported by Supply-Chain Firewall.
     """
     Npm = "npm"
     PyPI = "PyPI"

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -1,5 +1,5 @@
 """
-Implements the supply-chain firewall's core `run` subcommand.
+Implements Supply-Chain Firewall's core `run` subcommand.
 """
 
 from argparse import Namespace
@@ -23,12 +23,12 @@ _log = logging.getLogger(__name__)
 
 def run_firewall(args: Namespace) -> int:
     """
-    Run a package manager command through the supply-chain firewall.
+    Run a package manager command through Supply-Chain Firewall.
 
     Args:
         args:
             A `Namespace` parsed from a `run` subcommand command line containing a
-            command to run through the firewall.
+            package manager command to inspect with Supply-Chain Firewall.
 
     Returns:
         An integer status code indicating normal or error exit.
@@ -63,7 +63,7 @@ def run_firewall(args: Namespace) -> int:
             print(output)
 
         if args.dry_run:
-            _log.info("Firewall dry-run mode enabled: command will not be run")
+            _log.info("Dry-run mode enabled: command will not be run")
             print("Dry-run: exiting without running command.")
             return 1 if args.error_on_block and action == FirewallAction.BLOCK else 0
 

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -1,6 +1,6 @@
 """
-Provides an interface for client loggers to receive information about a
-completed run of the supply-chain firewall.
+Provides an interface for client loggers to receive data from completed runs
+of Supply-Chain Firewall.
 """
 
 from abc import (ABCMeta, abstractmethod)
@@ -16,8 +16,7 @@ from scfw.report import FindingsReport, VerificationReport
 
 class FirewallAction(Enum):
     """
-    The various actions the firewall may take in response to inspecting a
-    package manager command.
+    The actions that SCFW may take in response to an inspected package manager command.
     """
     ALLOW = 0
     BLOCK = 1
@@ -87,8 +86,7 @@ class FirewallRunSummary:
 
 class FirewallLogger(metaclass=ABCMeta):
     """
-    An interface for passing information about runs of Supply-Chain Firewall to
-    client loggers.
+    An interface for client loggers to receive data from completed runs of SCFW.
     """
     @abstractmethod
     def log_firewall_run(

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -1,24 +1,20 @@
 """
-Exposes the currently discoverable set of client loggers implementing the
-firewall's logging protocol.
+Exposes the currently discoverable set of client loggers implementing SCFW's
+logging protocol.
 
-Two loggers ship with the supply chain firewall by default: `DDAgentLogger`
-and `DDAPILogger`, which send logs to Datadog via a local Datadog Agent
-or the HTTP API, respectively. Firewall users may additionally provide custom
-loggers according to their own logging needs.
-
-The firewall discovers loggers at runtime via the following simple protocol.
-The module implementing the custom logger must contain a function with the
-following name and signature:
+Firewall users may provide custom loggers according to their own logging needs.
+SCFW discovers loggers at runtime via the following simple protocol. The module
+implementing the custom logger must contain a function with the following name
+and signature:
 
 ```
 def load_logger() -> FirewallLogger
 ```
 
 This `load_logger` function should return an instance of the custom logger
-for the firewall's use. The module may then be placed in the same directory
-as this source file for runtime import. Make sure to reinstall the package
-after doing so.
+for SCFW's use. The module may then be placed in the same directory as this
+source file for runtime import. Make sure to reinstall the `scfw` package after
+doing so.
 """
 
 import importlib

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -1,5 +1,5 @@
 """
-Configures a logger for sending firewall logs to a local Datadog Agent.
+Configures a logger for sending Supply-Chain Firewall logs to a local Datadog Agent.
 """
 
 import logging
@@ -86,9 +86,9 @@ class DDAgentLogger(DDLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDAgentLogger` for discovery by the firewall.
+    Export `DDAgentLogger` for discovery by Supply-Chain Firewall.
 
     Returns:
-        A `DDAgentLogger` for use in a run of the firewall.
+        A `DDAgentLogger` for use in a run of Supply-Chain Firewall.
     """
     return DDAgentLogger()

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -1,5 +1,5 @@
 """
-Configures a logger for sending firewall logs to Datadog's API over HTTP.
+Configures a logger for sending Supply-Chain Firewall logs to Datadog's API over HTTP.
 """
 
 import logging
@@ -27,10 +27,8 @@ Lorem ipsum dolor sit amet.
 
 class _DDLogHandler(logging.Handler):
     """
-    A log handler for adding tags and forwarding firewall logs of blocked and
-    permitted package installation requests to the Datadog API.
-
-    In addition to USM tags, install targets are tagged with the `target` tag and included.
+    A log handler for adding tags and forwarding logs of blocked and allowed
+    package manager commands to the Datadog API.
     """
     def emit(self, record):
         """
@@ -95,9 +93,9 @@ class DDAPILogger(DDLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDAPILogger` for discovery by the firewall.
+    Export `DDAPILogger` for discovery by Supply-Chain Firewall.
 
     Returns:
-        A `DDAPILogger` for use in a run of the firewall.
+        A `DDAPILogger` for use in a run of Supply-Chain Firewall.
     """
     return DDAPILogger()

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -13,16 +13,11 @@ from datadog_api_client.v2.model.http_log_item import HTTPLogItem
 import datadog_api_client.exceptions as dd_exceptions
 
 import scfw
-from scfw.constants import DD_ENV, DD_SERVICE, DD_SOURCE
+from scfw.constants import DD_API_LOGGER_ENABLED_VAR, DD_ENV, DD_SERVICE, DD_SOURCE
 from scfw.logger import FirewallLogger
 from scfw.loggers.dd_logger import DDLogFormatter, DDLogger
 
 _DD_LOG_NAME = "dd_api_log"
-
-DD_API_LOGGER_ENABLED_VAR = "SCFW_DD_API_LOGGER_ENABLED"
-"""
-Setting this environment variable is required to enable the Datadog API logger.
-"""
 
 
 class _DDLogHandler(logging.Handler):
@@ -60,10 +55,14 @@ class _DDLogHandler(logging.Handler):
                 api_instance.submit_log(content_encoding=ContentEncoding.DEFLATE, body=body)
 
         except dd_exceptions.ApiException as e:
-            if isinstance(e.body, dict):
-                detail = e.body.get("errors", "")
+            if (
+                isinstance(e.body, dict)
+                and (errors := e.body.get("errors", []))
+                and isinstance(errors, list)
+            ):
+                detail = ": ".join(str(error) for error in errors)
             elif e.reason:
-                detail = e.reason
+                detail = str(e.reason)
             else:
                 detail = "Unspecified API error"
 

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -10,13 +10,19 @@ from datadog_api_client.v2.api.logs_api import LogsApi
 from datadog_api_client.v2.model.content_encoding import ContentEncoding
 from datadog_api_client.v2.model.http_log import HTTPLog
 from datadog_api_client.v2.model.http_log_item import HTTPLogItem
+import datadog_api_client.exceptions as dd_exceptions
 
 import scfw
-from scfw.constants import DD_API_KEY_VAR, DD_ENV, DD_SERVICE, DD_SOURCE
+from scfw.constants import DD_ENV, DD_SERVICE, DD_SOURCE
 from scfw.logger import FirewallLogger
 from scfw.loggers.dd_logger import DDLogFormatter, DDLogger
 
 _DD_LOG_NAME = "dd_api_log"
+
+DD_API_LOGGER_ENABLED_VAR = "SCFW_DD_API_LOGGER_ENABLED"
+"""
+Lorem ipsum dolor sit amet.
+"""
 
 
 class _DDLogHandler(logging.Handler):
@@ -38,30 +44,37 @@ class _DDLogHandler(logging.Handler):
             f"version:{scfw.__version__}"
         }
 
-        # TODO(ikretz): Fix this to make it line up with the new format.
-        targets = record.__dict__.get("targets", {})
-        target_tags = set(map(lambda e: f"target:{e}", targets))
-
         body = HTTPLog(
             [
                 HTTPLogItem(
                     ddsource=DD_SOURCE,
-                    ddtags=",".join(usm_tags | target_tags),
+                    ddtags=",".join(usm_tags),
                     message=self.format(record),
                     service=DD_SERVICE,
                 ),
             ]
         )
 
-        configuration = Configuration()
-        with ApiClient(configuration) as api_client:
-            api_instance = LogsApi(api_client)
-            api_instance.submit_log(content_encoding=ContentEncoding.DEFLATE, body=body)
+        try:
+            configuration = Configuration()
+            with ApiClient(configuration) as api_client:
+                api_instance = LogsApi(api_client)
+                api_instance.submit_log(content_encoding=ContentEncoding.DEFLATE, body=body)
+
+        except dd_exceptions.ApiException as e:
+            if isinstance(e.body, dict):
+                detail = e.body.get("errors", "")
+            elif e.reason:
+                detail = e.reason
+            else:
+                detail = "Unspecified API error"
+
+            raise RuntimeError(f"Datadog API returned error: {detail}")
 
 
-# TODO(ikretz): Put this being another opt-in environment variable
+# TODO(ikretz): Update documentation
 # Configure a single logging handle for all `DDAPILogger` instances to share
-_handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
+_handler = _DDLogHandler() if os.getenv(DD_API_LOGGER_ENABLED_VAR) else logging.NullHandler()
 _handler.setFormatter(DDLogFormatter())
 
 _ddlog = logging.getLogger(_DD_LOG_NAME)

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -21,7 +21,7 @@ _DD_LOG_NAME = "dd_api_log"
 
 DD_API_LOGGER_ENABLED_VAR = "SCFW_DD_API_LOGGER_ENABLED"
 """
-Lorem ipsum dolor sit amet.
+Setting this environment variable is required to enable the Datadog API logger.
 """
 
 
@@ -70,7 +70,6 @@ class _DDLogHandler(logging.Handler):
             raise RuntimeError(f"Datadog API returned error: {detail}")
 
 
-# TODO(ikretz): Update documentation
 # Configure a single logging handle for all `DDAPILogger` instances to share
 _handler = _DDLogHandler() if os.getenv(DD_API_LOGGER_ENABLED_VAR) else logging.NullHandler()
 _handler.setFormatter(DDLogFormatter())

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -38,6 +38,7 @@ class _DDLogHandler(logging.Handler):
             f"version:{scfw.__version__}"
         }
 
+        # TODO(ikretz): Fix this to make it line up with the new format.
         targets = record.__dict__.get("targets", {})
         target_tags = set(map(lambda e: f"target:{e}", targets))
 
@@ -58,6 +59,7 @@ class _DDLogHandler(logging.Handler):
             api_instance.submit_log(content_encoding=ContentEncoding.DEFLATE, body=body)
 
 
+# TODO(ikretz): Put this being another opt-in environment variable
 # Configure a single logging handle for all `DDAPILogger` instances to share
 _handler = _DDLogHandler() if os.getenv(DD_API_KEY_VAR) else logging.NullHandler()
 _handler.setFormatter(DDLogFormatter())

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -1,0 +1,196 @@
+"""
+Lorem ipsum dolor sit amet.
+"""
+
+import json
+import logging
+import os
+import socket
+from typing import Any, Type
+import uuid
+
+import requests
+
+from scfw.constants import DD_API_KEY_VAR, DD_APP_KEY_VAR
+from scfw.ecosystem import ECOSYSTEM
+from scfw.logger import FirewallAction, FirewallLogger, FirewallRunSummary
+from scfw.report import Finding, VerificationReport
+
+_log = logging.getLogger(__name__)
+
+_DD_LOG_NAME = "dd_codesec_log"
+
+_STAGING_ENDPOINT = "https://dd.datad0g.com/api/v2/static-analysis-sca/scfw/report"
+
+# Lorem ipsum dolor sit amet.
+DD_CODESEC_LOGGER_ENABLED_VAR = "SCFW_DD_CODESEC_LOGGER_ENABLED"
+
+
+class _DDCodeSecurityLogFormatter(logging.Formatter):
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        def get_or_raise(d: dict, key: str, typ: Type) -> Any:
+            if key not in d:
+                raise ValueError(f"Missing required key: '{key}'")
+
+            value = d[key]
+            if not isinstance(value, typ):
+                raise TypeError(f"Incompatible type for '{key}' value: require {typ}")
+
+            return value
+
+        def get_reports(run_summary: FirewallRunSummary) -> list[dict]:
+            reports = []
+
+            match run_summary.action:
+                case FirewallAction.ALLOW:
+                    reported_packages = run_summary.install_targets or set()
+                case FirewallAction.BLOCK:
+                    reported_packages = set(run_summary.relevant_findings or {})
+
+            for package in reported_packages:
+                findings: set[Finding] = set()
+                if run_summary.relevant_findings:
+                    findings = run_summary.relevant_findings.get(package, set())
+
+                report = {
+                    "ecosystem": str(package.ecosystem),
+                    "package": package.name,
+                    "version": package.version,
+                    "warning": run_summary.warning and len(findings) != 0,
+                    "findings": [
+                        {
+                            "verifier": finding.verifier,
+                            "finding": finding.finding,
+                        }
+                        for finding in findings
+                    ]
+                }
+                reports.append(report)
+
+            return reports
+
+        attributes: dict[str, Any] = {
+            "cwd": os.getcwd(),
+            "hostname": socket.gethostname(),
+        }
+
+        attributes["package_manager"] = get_or_raise(record.__dict__, "package_manager", str)
+        attributes["executable"] = get_or_raise(record.__dict__, "executable", str)
+
+        run_summary: FirewallRunSummary = get_or_raise(record.__dict__, "run_summary", FirewallRunSummary)
+        attributes["command"] = ' '.join(run_summary.command)
+        attributes["outcome"] = str(run_summary.action)
+
+        attributes["reports"] = get_reports(run_summary)
+
+        return json.dumps(
+            {
+                "data": {
+                    "type": "scfw-report-request",
+                    "id": str(uuid.uuid4()),
+                    "attributes": attributes,
+                }
+            }
+        )
+
+
+class _DDCodeSecurityLogHandler(logging.Handler):
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    def emit(self, record: logging.LogRecord):
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        dd_api_key = os.getenv(DD_API_KEY_VAR)
+        dd_app_key = os.getenv(DD_APP_KEY_VAR)
+        if not (dd_api_key and dd_app_key):
+            _log.warning("Lorem ipsum dolor sit amet")
+            return
+
+        try:
+            r = requests.post(
+                _STAGING_ENDPOINT,
+                headers={
+                    "DD-API-KEY": dd_api_key,
+                    "dd-application-key": dd_app_key,
+                },
+                json=json.loads(self.format(record)),
+            )
+            r.raise_for_status()
+
+        except Exception as e:
+            _log.warning(f"Lorem ipsum dolor sit amet: {e}")
+
+
+# Lorem ipsum dolor sit amet
+_handler = _DDCodeSecurityLogHandler() if os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR) else logging.NullHandler()
+_handler.setFormatter(_DDCodeSecurityLogFormatter())
+
+_ddlog = logging.getLogger(_DD_LOG_NAME)
+_ddlog.setLevel(logging.INFO)
+_ddlog.addHandler(_handler)
+
+
+class DDCodeSecurityLogger(FirewallLogger):
+    """
+    Lorem ipsum dolor sit amet.
+    """
+    def __init__(self):
+        """
+        Initialize a new `DDCodeSecurityLogger`.
+        """
+        self._logger = _ddlog
+
+    def log_firewall_run(
+        self,
+        ecosystem: ECOSYSTEM,
+        package_manager: str,
+        executable: str,
+        run_summary: FirewallRunSummary,
+    ):
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        log_data = {
+            "ecosystem": ecosystem,
+            "package_manager": package_manager,
+            "executable": executable,
+            "run_summary": run_summary,
+        }
+
+        self._logger.info(msg=None, extra=log_data)
+
+    def log_audit(
+        self,
+        ecosystem: ECOSYSTEM,
+        package_manager: str,
+        executable: str,
+        report: VerificationReport,
+    ):
+        """
+        Lorem ipsum dolor sit amet.
+        """
+        if (
+            len(self._logger.handlers) == 1
+            and isinstance(self._logger.handlers[0], logging.NullHandler)
+        ):
+            return
+
+        _log.warning("Lorem ipsum dolor sit amet")
+
+
+def load_logger() -> FirewallLogger:
+    """
+    Export `DDCodeSecurityLogger` for discovery by Supply-Chain Firewall.
+
+    Returns:
+        A `DDCodeSecurityLogger` for use in a run of Supply-Chain Firewall.
+    """
+    return DDCodeSecurityLogger()

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -2,11 +2,10 @@
 Provides a `FirewallLogger` for Datadog Code Security's Supply-Chain Firewall API.
 """
 
-import json
 import logging
 import os
 import socket
-from typing import Any, Type
+from typing import Any
 import uuid
 
 import requests
@@ -18,8 +17,6 @@ from scfw.report import Finding, VerificationReport
 
 _log = logging.getLogger(__name__)
 
-_DD_LOG_NAME = "dd_codesec_log"
-
 _CODESEC_LOGGER_API_ENDPOINT = "api/v2/static-analysis-sca/scfw/report"
 
 DD_CODESEC_LOGGER_ENABLED_VAR = "SCFW_DD_CODESEC_LOGGER_ENABLED"
@@ -28,30 +25,89 @@ Setting this environment variable is required to enable the Datadog Code Securit
 """
 
 
-class _DDCodeSecurityLogFormatter(logging.Formatter):
+class DDCodeSecurityLogger(FirewallLogger):
     """
-    A custom log formatter for Datadog Code Security's Supply-Chain Firewall API.
+    An implementation of `FirewallLogger` for sending logs to Datadog Code Security's
+    Supply-Chain Firewall API.
     """
-    def format(self, record: logging.LogRecord) -> str:
+    def __init__(self):
         """
-        Format a log record as JSON in the API's expected format.
+        Lorem ipsum dolor sit amet.
+        """
+        self._enabled = os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR) is not None
+
+    def log_firewall_run(
+        self,
+        ecosystem: ECOSYSTEM,
+        package_manager: str,
+        executable: str,
+        run_summary: FirewallRunSummary,
+    ):
+        """
+        Log the data and action taken in a completed run of Supply-Chain Firewall.
 
         Args:
-            record: The log record to be formatted.
-
-        Returns:
-            A `str` containing the formatted log record.
+            ecosystem: The ecosystem of the inspected package manager command.
+            package_manager: The command-line name of the package manager.
+            executable: The executable used to execute the inspected package manager command.
+            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
         """
-        def get_or_raise(d: dict, key: str, typ: Type) -> Any:
-            if key not in d:
-                raise ValueError(f"Missing required key: '{key}'")
+        if not self._enabled:
+            return
 
-            value = d[key]
-            if not isinstance(value, typ):
-                raise TypeError(f"Incompatible type for '{key}' value: require {typ}")
+        dd_api_key = os.getenv(DD_API_KEY_VAR)
+        dd_app_key = os.getenv(DD_APP_KEY_VAR)
+        if not (dd_api_key and dd_app_key):
+            raise RuntimeError("Missing required Datadog API key or application key")
 
-            return value
+        dd_site = os.getenv(DD_SITE_VAR, "datadoghq.com")
 
+        try:
+            r = requests.post(
+                f"https://api.{dd_site}/{_CODESEC_LOGGER_API_ENDPOINT}",
+                headers={
+                    "dd-api-key": dd_api_key,
+                    "dd-application-key": dd_app_key,
+                },
+                json=self.generate_api_payload(package_manager, executable, run_summary),
+            )
+            r.raise_for_status()
+
+        except Exception as e:
+            raise RuntimeError(f"Code Security API request failed: {e}")
+
+    def log_audit(
+        self,
+        ecosystem: ECOSYSTEM,
+        package_manager: str,
+        executable: str,
+        report: VerificationReport,
+    ):
+        """
+        Log the results of an audit for the given ecosystem and package manager.
+        This function is not currently implemented: calling it will have no effect
+        other than emitting a warning.
+
+        Args:
+            ecosystem: The ecosystem of the audited packages.
+            package_manager: The package manager that manages the audited packages.
+            executable: The package manager executable used to enumerate audited packages.
+            report: The report containing the verification results for the audited packages.
+        """
+        if not self._enabled:
+            return
+
+        _log.warning("`log_audit` is not currently implemented for the Code Security API")
+
+    def generate_api_payload(
+        self,
+        package_manager: str,
+        executable: str,
+        run_summary: FirewallRunSummary,
+    ) -> dict:
+        """
+        Lorem ipsum dolor sit amet.
+        """
         def get_reports(run_summary: FirewallRunSummary) -> list[dict]:
             reports = []
 
@@ -59,6 +115,8 @@ class _DDCodeSecurityLogFormatter(logging.Formatter):
                 case FirewallAction.ALLOW:
                     reported_packages = run_summary.install_targets or set()
                 case FirewallAction.BLOCK:
+                    # When the action is BLOCK due solely to unverifiable packages,
+                    # relevant_findings is None and reports will be empty.
                     reported_packages = set(run_summary.relevant_findings or {})
 
             for package in reported_packages:
@@ -85,137 +143,23 @@ class _DDCodeSecurityLogFormatter(logging.Formatter):
 
         attributes: dict[str, Any] = {
             "cwd": os.getcwd(),
+            "executable": executable,
             "hostname": socket.gethostname(),
+            "package_manager": package_manager,
         }
 
-        attributes["package_manager"] = get_or_raise(record.__dict__, "package_manager", str)
-        attributes["executable"] = get_or_raise(record.__dict__, "executable", str)
-
-        run_summary: FirewallRunSummary = get_or_raise(record.__dict__, "run_summary", FirewallRunSummary)
         attributes["command"] = ' '.join(run_summary.command)
         attributes["outcome"] = str(run_summary.action)
 
         attributes["reports"] = get_reports(run_summary)
 
-        return json.dumps(
-            {
-                "data": {
-                    "type": "scfw-report-request",
-                    "id": str(uuid.uuid4()),
-                    "attributes": attributes,
-                }
+        return {
+            "data": {
+                "type": "scfw-report-request",
+                "id": str(uuid.uuid4()),
+                "attributes": attributes,
             }
-        )
-
-
-class _DDCodeSecurityLogHandler(logging.Handler):
-    """
-    A custom log handler for Datadog Code Security's Supply-Chain Firewall API.
-    """
-    def emit(self, record: logging.LogRecord):
-        """
-        Format and send a log to the Code Security Supply-Chain Firewall API.
-
-        Args:
-            record: The log record to be forwarded.
-
-        Raises:
-            RuntimeError:
-                * Missing required Datadog API key or application key
-                * Code Security API request failed (includes reason)
-        """
-        dd_api_key = os.getenv(DD_API_KEY_VAR)
-        dd_app_key = os.getenv(DD_APP_KEY_VAR)
-        if not (dd_api_key and dd_app_key):
-            raise RuntimeError("Missing required Datadog API key or application key")
-
-        dd_site = os.getenv(DD_SITE_VAR, "datadoghq.com")
-
-        try:
-            r = requests.post(
-                f"https://api.{dd_site}/{_CODESEC_LOGGER_API_ENDPOINT}",
-                headers={
-                    "DD-API-KEY": dd_api_key,
-                    "dd-application-key": dd_app_key,
-                },
-                json=json.loads(self.format(record)),
-            )
-            r.raise_for_status()
-
-        except Exception as e:
-            raise RuntimeError(f"Code Security API request failed: {e}")
-
-
-# Configure a single logging handle for all `DDCodeSecurityLogger` instances to share
-_handler = _DDCodeSecurityLogHandler() if os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR) else logging.NullHandler()
-_handler.setFormatter(_DDCodeSecurityLogFormatter())
-
-_ddlog = logging.getLogger(_DD_LOG_NAME)
-_ddlog.setLevel(logging.INFO)
-_ddlog.addHandler(_handler)
-
-
-class DDCodeSecurityLogger(FirewallLogger):
-    """
-    An implementation of `FirewallLogger` for sending logs to Datadog Code Security's
-    Supply-Chain Firewall API.
-    """
-    def __init__(self):
-        """
-        Initialize a new `DDCodeSecurityLogger`.
-        """
-        self._logger = _ddlog
-
-    def log_firewall_run(
-        self,
-        ecosystem: ECOSYSTEM,
-        package_manager: str,
-        executable: str,
-        run_summary: FirewallRunSummary,
-    ):
-        """
-        Log the data and action taken in a completed run of Supply-Chain Firewall.
-
-        Args:
-            ecosystem: The ecosystem of the inspected package manager command.
-            package_manager: The command-line name of the package manager.
-            executable: The executable used to execute the inspected package manager command.
-            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
-        """
-        log_data = {
-            "ecosystem": ecosystem,
-            "package_manager": package_manager,
-            "executable": executable,
-            "run_summary": run_summary,
         }
-
-        self._logger.info(msg=None, extra=log_data)
-
-    def log_audit(
-        self,
-        ecosystem: ECOSYSTEM,
-        package_manager: str,
-        executable: str,
-        report: VerificationReport,
-    ):
-        """
-        Log the results of an audit for the given ecosystem and package manager.
-        This function is not currently implemented: calling it will have no effect
-        other than emitting a warning.
-
-        Args:
-            ecosystem: The ecosystem of the audited packages.
-            package_manager: The package manager that manages the audited packages.
-            executable: The package manager executable used to enumerate audited packages.
-            report: The report containing the verification results for the audited packages.
-        """
-        if (
-            len(self._logger.handlers) == 1
-            and isinstance(self._logger.handlers[0], logging.NullHandler)
-        ):
-            return
-
-        _log.warning("`log_audit` is not currently implemented for the Code Security API")
 
 
 def load_logger() -> FirewallLogger:

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -32,7 +32,7 @@ class DDCodeSecurityLogger(FirewallLogger):
     """
     def __init__(self):
         """
-        Lorem ipsum dolor sit amet.
+        Initialize a new `DDCodeSecurityLogger`.
         """
         self._enabled = bool(os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR))
 
@@ -107,7 +107,15 @@ class DDCodeSecurityLogger(FirewallLogger):
         run_summary: FirewallRunSummary,
     ) -> dict:
         """
-        Lorem ipsum dolor sit amet.
+        Generate the API payload from the `log_firewall_run()` inputs.
+
+        Args:
+            package_manager: The command-line name of the package manager.
+            executable: The executable used to execute the inspected package manager command.
+            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
+
+        Returns:
+            A `dict` containing the API's JSON payload generated from the inputs.
         """
         def get_reports(run_summary: FirewallRunSummary) -> list[dict]:
             reports = []

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -1,5 +1,5 @@
 """
-Lorem ipsum dolor sit amet.
+Provides a `FirewallLogger` for Datadog Code Security's Supply-Chain Firewall API.
 """
 
 import json
@@ -24,17 +24,23 @@ _CODESEC_LOGGER_API_ENDPOINT = "api/v2/static-analysis-sca/scfw/report"
 
 DD_CODESEC_LOGGER_ENABLED_VAR = "SCFW_DD_CODESEC_LOGGER_ENABLED"
 """
-Lorem ipsum dolor sit amet.
+Setting this environment variable is required to enable the Datadog Code Security logger.
 """
 
 
 class _DDCodeSecurityLogFormatter(logging.Formatter):
     """
-    Lorem ipsum dolor sit amet.
+    A custom log formatter for Datadog Code Security's Supply-Chain Firewall API.
     """
     def format(self, record: logging.LogRecord) -> str:
         """
-        Lorem ipsum dolor sit amet.
+        Format a log record as JSON in the API's expected format.
+
+        Args:
+            record: The log record to be formatted.
+
+        Returns:
+            A `str` containing the formatted log record.
         """
         def get_or_raise(d: dict, key: str, typ: Type) -> Any:
             if key not in d:
@@ -104,17 +110,24 @@ class _DDCodeSecurityLogFormatter(logging.Formatter):
 
 class _DDCodeSecurityLogHandler(logging.Handler):
     """
-    Lorem ipsum dolor sit amet.
+    A custom log handler for Datadog Code Security's Supply-Chain Firewall API.
     """
     def emit(self, record: logging.LogRecord):
         """
-        Lorem ipsum dolor sit amet.
+        Format and send a log to the Code Security Supply-Chain Firewall API.
+
+        Args:
+            record: The log record to be forwarded.
+
+        Raises:
+            RuntimeError:
+                * Missing required Datadog API key or application key
+                * Code Security API request failed (includes reason)
         """
         dd_api_key = os.getenv(DD_API_KEY_VAR)
         dd_app_key = os.getenv(DD_APP_KEY_VAR)
         if not (dd_api_key and dd_app_key):
-            _log.warning("Lorem ipsum dolor sit amet")
-            return
+            raise RuntimeError("Missing required Datadog API key or application key")
 
         dd_site = os.getenv(DD_SITE_VAR, "datadoghq.com")
 
@@ -130,10 +143,10 @@ class _DDCodeSecurityLogHandler(logging.Handler):
             r.raise_for_status()
 
         except Exception as e:
-            _log.warning(f"Lorem ipsum dolor sit amet: {e}")
+            raise RuntimeError(f"Code Security API request failed: {e}")
 
 
-# Lorem ipsum dolor sit amet
+# Configure a single logging handle for all `DDCodeSecurityLogger` instances to share
 _handler = _DDCodeSecurityLogHandler() if os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR) else logging.NullHandler()
 _handler.setFormatter(_DDCodeSecurityLogFormatter())
 
@@ -144,7 +157,8 @@ _ddlog.addHandler(_handler)
 
 class DDCodeSecurityLogger(FirewallLogger):
     """
-    Lorem ipsum dolor sit amet.
+    An implementation of `FirewallLogger` for sending logs to Datadog Code Security's
+    Supply-Chain Firewall API.
     """
     def __init__(self):
         """
@@ -160,7 +174,13 @@ class DDCodeSecurityLogger(FirewallLogger):
         run_summary: FirewallRunSummary,
     ):
         """
-        Lorem ipsum dolor sit amet.
+        Log the data and action taken in a completed run of Supply-Chain Firewall.
+
+        Args:
+            ecosystem: The ecosystem of the inspected package manager command.
+            package_manager: The command-line name of the package manager.
+            executable: The executable used to execute the inspected package manager command.
+            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
         """
         log_data = {
             "ecosystem": ecosystem,
@@ -179,7 +199,15 @@ class DDCodeSecurityLogger(FirewallLogger):
         report: VerificationReport,
     ):
         """
-        Lorem ipsum dolor sit amet.
+        Log the results of an audit for the given ecosystem and package manager.
+        This function is not currently implemented: calling it will have no effect
+        other than emitting a warning.
+
+        Args:
+            ecosystem: The ecosystem of the audited packages.
+            package_manager: The package manager that manages the audited packages.
+            executable: The package manager executable used to enumerate audited packages.
+            report: The report containing the verification results for the audited packages.
         """
         if (
             len(self._logger.handlers) == 1
@@ -187,7 +215,7 @@ class DDCodeSecurityLogger(FirewallLogger):
         ):
             return
 
-        _log.warning("Lorem ipsum dolor sit amet")
+        _log.warning("`log_audit` is not currently implemented for the Code Security API")
 
 
 def load_logger() -> FirewallLogger:

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -34,7 +34,7 @@ class DDCodeSecurityLogger(FirewallLogger):
         """
         Lorem ipsum dolor sit amet.
         """
-        self._enabled = os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR) is not None
+        self._enabled = bool(os.getenv(DD_CODESEC_LOGGER_ENABLED_VAR))
 
     def log_firewall_run(
         self,
@@ -70,6 +70,7 @@ class DDCodeSecurityLogger(FirewallLogger):
                     "dd-application-key": dd_app_key,
                 },
                 json=self.generate_api_payload(package_manager, executable, run_summary),
+                timeout=10,
             )
             r.raise_for_status()
 

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -11,7 +11,7 @@ import uuid
 
 import requests
 
-from scfw.constants import DD_API_KEY_VAR, DD_APP_KEY_VAR
+from scfw.constants import DD_API_KEY_VAR, DD_APP_KEY_VAR, DD_SITE_VAR
 from scfw.ecosystem import ECOSYSTEM
 from scfw.logger import FirewallAction, FirewallLogger, FirewallRunSummary
 from scfw.report import Finding, VerificationReport
@@ -20,10 +20,12 @@ _log = logging.getLogger(__name__)
 
 _DD_LOG_NAME = "dd_codesec_log"
 
-_STAGING_ENDPOINT = "https://dd.datad0g.com/api/v2/static-analysis-sca/scfw/report"
+_CODESEC_LOGGER_API_ENDPOINT = "api/v2/static-analysis-sca/scfw/report"
 
-# Lorem ipsum dolor sit amet.
 DD_CODESEC_LOGGER_ENABLED_VAR = "SCFW_DD_CODESEC_LOGGER_ENABLED"
+"""
+Lorem ipsum dolor sit amet.
+"""
 
 
 class _DDCodeSecurityLogFormatter(logging.Formatter):
@@ -114,9 +116,11 @@ class _DDCodeSecurityLogHandler(logging.Handler):
             _log.warning("Lorem ipsum dolor sit amet")
             return
 
+        dd_site = os.getenv(DD_SITE_VAR, "datadoghq.com")
+
         try:
             r = requests.post(
-                _STAGING_ENDPOINT,
+                f"https://api.{dd_site}/{_CODESEC_LOGGER_API_ENDPOINT}",
                 headers={
                     "DD-API-KEY": dd_api_key,
                     "dd-application-key": dd_app_key,

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -87,6 +87,9 @@ class DDLogFormatter(logging.Formatter):
 
         Args:
             record: The log record to be formatted.
+
+        Returns:
+            A `str` containing the formatted log record.
         """
         def parse_log_attributes(json_str: str) -> dict[str, Any]:
             attributes = json.loads(json_str)

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -79,7 +79,7 @@ dotenv.load_dotenv()
 
 class DDLogFormatter(logging.Formatter):
     """
-    A custom JSON formatter for firewall logs.
+    A custom JSON formatter for Supply-Chain Firewall logs.
     """
     def format(self, record) -> str:
         """

--- a/scfw/main.py
+++ b/scfw/main.py
@@ -1,5 +1,5 @@
 """
-Provides the supply-chain firewall's main routine.
+Provides Supply-Chain Firewall's main routine.
 """
 
 import logging
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 def main() -> int:
     """
-    The supply-chain firewall's main routine.
+    Supply-Chain Firewall's main routine.
 
     Returns:
         An integer status code indicating normal or error exit.


### PR DESCRIPTION
This PR introduces a new custom logger `DDCodeSecurityLogger` that submits SCFW run reports to Datadog Code Security's Supply-Chain Firewall API over HTTPS, currently available as a private beta for Datadog customers.  The logger is enabled by setting `SCFW_DD_CODESEC_LOGGER_ENABLED` and requires both a Datadog API key (`DD_API_KEY`) and application key (`DD_APP_KEY`), with an optional `DD_SITE` parameter for selecting the target Datadog region.

Alongside the new logger, the existing Datadog HTTPS API logger is updated to require explicit opt-in via a new `SCFW_DD_API_LOGGER_ENABLED` environment variable, with the interactive `scfw configure` wizard updated to write this variable to the user's shell config when API logging is enabled.

Finally, the branch updates docstrings and comments throughout the codebase to consistently use "Supply-Chain Firewall" and "SCFW" in place of informal references like "the firewall."