### PR TITLE
[SECRES-5240] Add versioning for Datadog log record format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Supply-Chain Firewall
+# Contributing to Supply Chain Firewall
 
 ## :hammer_and_wrench: Setting up for development
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The principal goal of Supply Chain Firewall is to block 100% of installations of
 
 ---
 ### Interested in SCFW for your business use-case? [Enroll](https://docs.google.com/forms/d/1Xqh5h1n3-jC7au2t30fdTq732dkTJqt_cb7C7T-AkPc/edit) as a design partner.
-### Check out the new Datadog Agent [integration](https://docs.datadoghq.com/integrations/supply-chain-firewall/) and Cloud SIEM [content pack](https://app.datadoghq.com/security/siem/content-packs?query=%22Supply Chain%20Firewall%22) for SCFW.
+### Check out the new Datadog Agent [integration](https://docs.datadoghq.com/integrations/supply-chain-firewall/) and Cloud SIEM [content pack](https://app.datadoghq.com/security/siem/content-packs?query=Supply%20Chain%20Firewall) for SCFW.
 ---
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Supply-Chain Firewall
+# Supply Chain Firewall
 
 ![Test](https://github.com/DataDog/supply-chain-firewall/actions/workflows/test.yaml/badge.svg)
 ![Code quality](https://github.com/DataDog/supply-chain-firewall/actions/workflows/code_quality.yaml/badge.svg)
 
 <p align="center">
-  <img src="https://github.com/DataDog/supply-chain-firewall/blob/main/docs/images/logo.png?raw=true" alt="Supply-Chain Firewall" width="300" />
+  <img src="https://github.com/DataDog/supply-chain-firewall/blob/main/docs/images/logo.png?raw=true" alt="Supply Chain Firewall" width="300" />
 </p>
 
-Supply-Chain Firewall is a command-line tool for preventing the installation of malicious npm and PyPI packages.  It is intended primarily for use by engineers to protect their development workstations from compromise in a supply-chain attack.
+Supply Chain Firewall is a command-line tool for preventing the installation of malicious npm and PyPI packages.  It is intended primarily for use by engineers to protect their development workstations from compromise in a supply-chain attack.
 
 ![scfw demo usage](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/images/demo.gif?raw=true)
 
-Given a command for a supported package manager, Supply-Chain Firewall collects all package targets that would be installed by the command and verifies them against reputable sources of data on open source malware and vulnerabilities.  The command is automatically blocked from running when any verifier returns critical findings for any target, generally indicating that the target in question is malicious.  In cases where a verifier reports warnings for a target, they are presented to the user along with a prompt confirming intent to proceed with the installation.
+Given a command for a supported package manager, Supply Chain Firewall collects all package targets that would be installed by the command and verifies them against reputable sources of data on open source malware and vulnerabilities.  The command is automatically blocked from running when any verifier returns critical findings for any target, generally indicating that the target in question is malicious.  In cases where a verifier reports warnings for a target, they are presented to the user along with a prompt confirming intent to proceed with the installation.
 
-Supply-Chain Firewall includes default verifiers for the following data sources:
+Supply Chain Firewall includes default verifiers for the following data sources:
 
 - Datadog Security Research's public [malicious packages dataset](https://github.com/DataDog/malicious-software-packages-dataset)
 - [OSV.dev](https://osv.dev) advisories, both for malicious packages as well as vulnerabilities
@@ -24,18 +24,18 @@ Documentation specific to each default verifier and the configurable options the
 
 Users may also implement their own custom verifiers for alternative data sources. A template for implementating a custom verifier may be found in `examples/verifier.py`. Details may also be found in the API documentation.
 
-The principal goal of Supply-Chain Firewall is to block 100% of installations of known-malicious packages within the purview of its data sources.
+The principal goal of Supply Chain Firewall is to block 100% of installations of known-malicious packages within the purview of its data sources.
 
 ---
 ### Interested in SCFW for your business use-case? [Enroll](https://docs.google.com/forms/d/1Xqh5h1n3-jC7au2t30fdTq732dkTJqt_cb7C7T-AkPc/edit) as a design partner.
-### Check out the new Datadog Agent [integration](https://docs.datadoghq.com/integrations/supply-chain-firewall/) and Cloud SIEM [content pack](https://app.datadoghq.com/security/siem/content-packs?query=%22Supply-Chain%20Firewall%22) for SCFW.
+### Check out the new Datadog Agent [integration](https://docs.datadoghq.com/integrations/supply-chain-firewall/) and Cloud SIEM [content pack](https://app.datadoghq.com/security/siem/content-packs?query=%22Supply Chain%20Firewall%22) for SCFW.
 ---
 
 ## Getting started
 
 ### Installation
 
-The recommended way to install Supply-Chain Firewall is via [`pipx`](https://pipx.pypa.io/):
+The recommended way to install Supply Chain Firewall is via [`pipx`](https://pipx.pypa.io/):
 
 ```bash
 $ pipx install scfw
@@ -43,7 +43,7 @@ $ pipx install scfw
 
 This will install the `scfw` command-line program into an isolated Python environment on your system and make it available in any other Python environment, including ephemeral ones created with `venv` or `virtualenv`.  `pipx` may be installed via Homebrew on macOS or via the system package manager on major Linux distributions.  Be sure to run `pipx ensurepath` after installation to properly configure your `PATH`.
 
-Supply-Chain Firewall can also be installed via `pip install scfw` directly into the active Python environment.
+Supply Chain Firewall can also be installed via `pip install scfw` directly into the active Python environment.
 
 To check whether the installation succeeded, run the following command and verify that you see output similar to the following.
 
@@ -54,7 +54,7 @@ $ scfw --version
 
 ### Post-installation steps
 
-To get the most out of Supply-Chain Firewall, it is recommended to run the `scfw configure` command after installation.  This script will walk you through configuring your environment so that all commands for supported package managers are passively run through `scfw` as well as enabling Datadog logging, described in more detail below.
+To get the most out of Supply Chain Firewall, it is recommended to run the `scfw configure` command after installation.  This script will walk you through configuring your environment so that all commands for supported package managers are passively run through `scfw` as well as enabling Datadog logging, described in more detail below.
 
 ```bash
 $ scfw configure
@@ -71,15 +71,15 @@ See the `configure` command [documentation](https://github.com/DataDog/supply-ch
 | pip               | >= 22.2               | `install`                          |
 | poetry            | >= 1.7                | `add`, `install`, `sync`, `update` |
 
-Supply-Chain Firewall may only know how to inspect some of the "installish" subcommands for its supported package managers.  These are shown in the above table.  Any other subcommands are always allowed to run.
+Supply Chain Firewall may only know how to inspect some of the "installish" subcommands for its supported package managers.  These are shown in the above table.  Any other subcommands are always allowed to run.
 
 By default, `scfw` will refuse to run inspected subcommands with an unsupported version of a supported package manager.  This is in keeping with its goal of blocking 100% of known-malicious package installations.  In order to get the most out of `scfw`, please verify that you are running a supported version of your package manager and upgrade accordingly before using this tool.
 
-Currently, Supply-Chain Firewall is only fully supported on macOS systems, though it should run as intended on common Linux distributions.  It is currently not supported on Windows.
+Currently, Supply Chain Firewall is only fully supported on macOS systems, though it should run as intended on common Linux distributions.  It is currently not supported on Windows.
 
-### Uninstalling Supply-Chain Firewall
+### Uninstalling Supply Chain Firewall
 
-Supply-Chain Firewall may be uninstalled via `pip(x) uninstall scfw`.  Before doing so, be sure to run the command `scfw configure --remove` to remove any Supply-Chain Firewall-managed configuration you may have previously added to your environment.
+Supply Chain Firewall may be uninstalled via `pip(x) uninstall scfw`.  Before doing so, be sure to run the command `scfw configure --remove` to remove any Supply Chain Firewall-managed configuration you may have previously added to your environment.
 
 ```bash
 $ scfw configure --remove
@@ -105,7 +105,7 @@ options:
 
 ### Inspect package manager commands
 
-To use Supply-Chain Firewall to inspect a package manager command, simply prepend `scfw run` to the command you intend to run:
+To use Supply Chain Firewall to inspect a package manager command, simply prepend `scfw run` to the command you intend to run:
 
 ```
 $ scfw run npm install react
@@ -123,7 +123,7 @@ See the `run` command [documentation](https://github.com/DataDog/supply-chain-fi
 
 ### Audit installed packages
 
-Supply-Chain Firewall can also use its verifiers to audit installed packages:
+Supply Chain Firewall can also use its verifiers to audit installed packages:
 
 ```
 $ scfw audit npm
@@ -150,19 +150,19 @@ See the `audit` command [documentation](https://github.com/DataDog/supply-chain-
 
 ## Datadog Log Management integration
 
-Supply-Chain Firewall can optionally send logs of blocked and successful installations to Datadog.
+Supply Chain Firewall can optionally send logs of blocked and successful installations to Datadog.
 
 ![scfw datadog log](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/images/datadog_log.png?raw=true)
 
 Logs may be forwarded to Datadog via the HTTP API or a local Datadog Agent process.  A Datadog API key is required to enable log forwarding.  Documentation on how to enable and configure these loggers may be found [here](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md).
 
-Supply-Chain Firewall can maintain a local JSON Lines log file that records all completed `run` and `audit` executions.  Users are strongly encouraged to [enable](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md#local-file-logger) this logger, as having a centralized record of executed package manager commands, their outcomes, and installed packages over time can be useful in incident response scenarios.  Once file logging has been enabled, users may separately [configure](https://docs.datadoghq.com/agent/logs/?tab=tailfiles#custom-log-collection) the local Datadog Agent to tail this file and thereby ingest logs from SCFW with no additional overhead.
+Supply Chain Firewall can maintain a local JSON Lines log file that records all completed `run` and `audit` executions.  Users are strongly encouraged to [enable](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/loggers.md#local-file-logger) this logger, as having a centralized record of executed package manager commands, their outcomes, and installed packages over time can be useful in incident response scenarios.  Once file logging has been enabled, users may separately [configure](https://docs.datadoghq.com/agent/logs/?tab=tailfiles#custom-log-collection) the local Datadog Agent to tail this file and thereby ingest logs from SCFW with no additional overhead.
 
-Supply-Chain Firewall can also integrate with user-supplied loggers.  A template for implementating a custom logger may be found in `examples/logger.py`. Refer to the API documentation for details.
+Supply Chain Firewall can also integrate with user-supplied loggers.  A template for implementating a custom logger may be found in `examples/logger.py`. Refer to the API documentation for details.
 
 ## Development
 
-We welcome community contributions to Supply-Chain Firewall.  Refer to the [CONTRIBUTING](https://github.com/DataDog/supply-chain-firewall/blob/main/CONTRIBUTING.md) guide for instructions on building the API documentation and setting up for development.
+We welcome community contributions to Supply Chain Firewall.  Refer to the [CONTRIBUTING](https://github.com/DataDog/supply-chain-firewall/blob/main/CONTRIBUTING.md) guide for instructions on building the API documentation and setting up for development.
 
 ## Maintainers
 

--- a/docs/loggers.md
+++ b/docs/loggers.md
@@ -16,7 +16,7 @@ Users may configure the behavior of this logger via the following environment va
 * `DD_ENV`:
     Takes a string identifying the environment where Supply Chain Firewall is running.  Defaults to `dev` if not set.
 
-* `DD_LOG_LEVEL`:
+* `SCFW_DD_LOG_LEVEL`:
     Takes one of the strings `ALLOW` or `BLOCK`.
 
     This value controls which `run` actions are forwarded to Datadog as follows:
@@ -62,7 +62,7 @@ Users may configure the behavior of this logger via the following environment va
 * `DD_ENV`:
     Takes a string identifying the environment where Supply Chain Firewall is running.  Defaults to `dev` if not set.
 
-* `DD_LOG_LEVEL`:
+* `SCFW_DD_LOG_LEVEL`:
     Takes one of the strings `ALLOW` or `BLOCK`.
 
     This value controls which `run` actions are forwarded to Datadog as follows:

--- a/docs/loggers.md
+++ b/docs/loggers.md
@@ -1,20 +1,20 @@
-# Supply-Chain Firewall default loggers
+# Supply Chain Firewall default loggers
 
 ## Datadog Agent logger
 
-The Datadog Agent logger submits JSON logs of successful `run` and `audit` actions taken by Supply-Chain Firewall to a properly configured local Datadog Agent process over ad hoc TCP connections.
+The Datadog Agent logger submits JSON logs of successful `run` and `audit` actions taken by Supply Chain Firewall to a properly configured local Datadog Agent process over ad hoc TCP connections.
 
 Note that the Datadog Agent must already be separately [configured](https://docs.datadoghq.com/agent/logs/#activate-log-collection) for log collection in order to use this logger.
 
 Users may configure the behavior of this logger via the following environment variables:
 
 * `SCFW_DD_AGENT_LOG_PORT`:
-    Takes a TCP port number on which the local Datadog Agent has been configured to receive logs from Supply-Chain Firewall.  Required to enable this logger.
+    Takes a TCP port number on which the local Datadog Agent has been configured to receive logs from Supply Chain Firewall.  Required to enable this logger.
 
     The `scfw configure` [subcommand](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/subcommands.md#scfw-configure) should be used in order to simultaneously configure the Datadog Agent to receive SCFW logs and write this environment variable into the user's `~/.bashrc` and `~/.zshrc` files.
 
 * `DD_ENV`:
-    Takes a string identifying the environment where Supply-Chain Firewall is running.  Defaults to `dev` if not set.
+    Takes a string identifying the environment where Supply Chain Firewall is running.  Defaults to `dev` if not set.
 
 * `DD_LOG_LEVEL`:
     Takes one of the strings `ALLOW` or `BLOCK`.
@@ -44,7 +44,7 @@ Users may configure the behavior of this logger via the following environment va
 
 ## Datadog API logger
 
-The Datadog API logger submits JSON logs of successful `run` and `audit` actions taken by Supply-Chain Firewall to the Datadog HTTP API.
+The Datadog API logger submits JSON logs of successful `run` and `audit` actions taken by Supply Chain Firewall to the Datadog HTTP API.
 
 Users may configure the behavior of this logger via the following environment variables:
 
@@ -60,7 +60,7 @@ Users may configure the behavior of this logger via the following environment va
     Takes a [Datadog site parameter](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) for setting the region where the target Datadog organization is hosted.  Defaults to `US1` if not set.
 
 * `DD_ENV`:
-    Takes a string identifying the environment where Supply-Chain Firewall is running.  Defaults to `dev` if not set.
+    Takes a string identifying the environment where Supply Chain Firewall is running.  Defaults to `dev` if not set.
 
 * `DD_LOG_LEVEL`:
     Takes one of the strings `ALLOW` or `BLOCK`.
@@ -92,7 +92,7 @@ Users may configure the behavior of this logger via the following environment va
 
 > **Preview:** The Datadog Code Security API logger is currently available only as a preview for Datadog customers and upon request.
 
-This logger submits reports of `run` actions taken by Supply-Chain Firewall to Datadog Code Security's Supply-Chain Firewall API over HTTPS.  Note that `audit` actions are not currently supported by this logger.
+This logger submits reports of `run` actions taken by Supply Chain Firewall to Datadog Code Security's Supply Chain Firewall API over HTTPS.  Note that `audit` actions are not currently supported by this logger.
 
 Users may configure the behavior of this logger via the following environment variables:
 
@@ -110,7 +110,7 @@ Users may configure the behavior of this logger via the following environment va
 
 ## Local file logger
 
-The local file logger writes JSON Lines logs of all `run` and `audit` actions taken by Supply-Chain Firewall to a specified local log file.  Users are strongly encouraged to enable this logger, as having a centralized record of executed package manager commands, their outcomes, and installed packages over time can be useful in incident response scenarios.
+The local file logger writes JSON Lines logs of all `run` and `audit` actions taken by Supply Chain Firewall to a specified local log file.  Users are strongly encouraged to enable this logger, as having a centralized record of executed package manager commands, their outcomes, and installed packages over time can be useful in incident response scenarios.
 
 ```json
 {"source": "scfw", "service": "scfw", "version": "2.5.0", "env": "dev", "hostname": "bitshq", "username": "bits", "package_manager": "poetry", "executable": "~/.local/bin/poetry", "ecosystem": "PyPI", "msg": "Command 'poetry add git+https://github.com/tree-sitter/py-tree-sitter' was allowed", "action": "ALLOW", "created": 1768396428.952134, "targets": ["tree-sitter-0.25.2"], "verified": true, "warned": false}

--- a/docs/loggers.md
+++ b/docs/loggers.md
@@ -102,13 +102,11 @@ Users may configure the behavior of this logger via the following environment va
 * `DD_API_KEY`:
     Takes a Datadog API key.  Required to successfully use this logger.
 
-    The `scfw configure` [subcommand](https://github.com/DataDog/supply-chain-firewall/blob/main/docs/subcommands.md#scfw-configure) can be used to write this environment variable into the user's `~/.bashrc` and `~/.zshrc` files.
-
 * `DD_APP_KEY`:
     Takes a Datadog application key.  Required to successfully use this logger.
 
 * `DD_SITE`:
-    Takes a [Datadog site parameter](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) for setting the region where the target Datadog organization is hosted.  Defaults to `datadoghq.com` if not set.
+    Takes a [Datadog site parameter](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) for setting the region where the target Datadog organization is hosted.  Defaults to `US1` if not set.
 
 ## Local file logger
 

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -1,10 +1,10 @@
-# Supply-Chain Firewall subcommands
+# Supply Chain Firewall subcommands
 
 ## `scfw audit`
 
 The `audit` subcommand is used to verify all currently installed packages managed by a given supported package manager.
 
-Supply-Chain Firewall audits all installed packages visible to the package manager in the invoking environment.  The user may specify the package manager executable they wish to use on the command line.  For `npm` and `poetry` audits, Supply-Chain Firewall assumes the project of interest is in the current working directory.
+Supply Chain Firewall audits all installed packages visible to the package manager in the invoking environment.  The user may specify the package manager executable they wish to use on the command line.  For `npm` and `poetry` audits, Supply Chain Firewall assumes the project of interest is in the current working directory.
 
 Currently, `npm` audits do not take globally installed packages into consideration.  To audit a globally installed `npm` package, first `cd` into the package's directory (inside the global `node_modules/`) and perform a local audit there.
 
@@ -12,7 +12,7 @@ Currently, `npm` audits do not take globally installed packages into considerati
 $ scfw audit --help
 usage: scfw audit [-h] [--executable PATH] {npm,pip,poetry}
 
-Audit installed packages using Supply-Chain Firewall's verifiers.
+Audit installed packages using Supply Chain Firewall's verifiers.
 
 positional arguments:
   {npm,pip,poetry}   The package manager whose installed packages should be verified
@@ -24,9 +24,9 @@ options:
 
 ## `scfw configure`
 
-The `configure` subcommand may be used to configure the environment with shell aliases and environment variables in order to get the most out of Supply-Chain Firewall.  It may be run repeatedly to update desired configuration settings.
+The `configure` subcommand may be used to configure the environment with shell aliases and environment variables in order to get the most out of Supply Chain Firewall.  It may be run repeatedly to update desired configuration settings.
 
-Selected configuration options are written to the user's pre-existing `~/.bashrc` and `~/.zshrc` files in a clearly delimited block that Supply-Chain Firewall manages.  This block should never be manually edited, at the risk of breaking SCFW's ability to maintain these files and its own options successfully.
+Selected configuration options are written to the user's pre-existing `~/.bashrc` and `~/.zshrc` files in a clearly delimited block that Supply Chain Firewall manages.  This block should never be manually edited, at the risk of breaking SCFW's ability to maintain these files and its own options successfully.
 
 When run with no command-line arguments, the `configure` subcommand launches an interactive configurator that walks the user through the available set of supported options.  Otherwise, it may be run non-interactively by passing the desired options on the command line.
 
@@ -35,23 +35,23 @@ The `--remove` option may be used to remove all saved SCFW-managed configuration
 ```bash
 usage: scfw configure [-h] [-r] [--alias-npm] [--alias-pip] [--alias-poetry] [--dd-agent-port PORT] [--dd-api-key KEY] [--dd-log-level LEVEL] [--scfw-home PATH]
 
-Configure the environment for using Supply-Chain Firewall.
+Configure the environment for using Supply Chain Firewall.
 
 options:
   -h, --help            show this help message and exit
-  -r, --remove          Remove all Supply-Chain Firewall-managed configuration
-  --alias-npm           Add shell aliases to always run npm commands through Supply-Chain Firewall
-  --alias-pip           Add shell aliases to always run pip commands through Supply-Chain Firewall
-  --alias-poetry        Add shell aliases to always run Poetry commands through Supply-Chain Firewall
+  -r, --remove          Remove all Supply Chain Firewall-managed configuration
+  --alias-npm           Add shell aliases to always run npm commands through Supply Chain Firewall
+  --alias-pip           Add shell aliases to always run pip commands through Supply Chain Firewall
+  --alias-poetry        Add shell aliases to always run Poetry commands through Supply Chain Firewall
   --dd-agent-port PORT  Configure log forwarding to the local Datadog Agent on the given port
   --dd-api-key KEY      API key to use when forwarding logs via the Datadog API
   --dd-log-level LEVEL  Desired logging level for Datadog log forwarding (options: ALLOW, BLOCK)
-  --scfw-home PATH      Directory that Supply-Chain Firewall can use as a local cache
+  --scfw-home PATH      Directory that Supply Chain Firewall can use as a local cache
 ```
 
 ## `scfw run`
 
-The `run` subcommand is used to run a package manager command through Supply-Chain Firewall while verifying installation targets.
+The `run` subcommand is used to run a package manager command through Supply Chain Firewall while verifying installation targets.
 
 All package targets that would be installed by running the given package manager command are verified against the set of verifiers that SCFW was able to discover at the time of invocation.  The command is automatically blocked from running when any verifier returns critical findings for any target, generally indicating that the target in question is malicious.  In cases where a verifier reports warnings for a target, they are presented to the user along with a prompt confirming intent to proceed with the installation.  Otherwise, the command is allowed to run as if SCFW were not present.
 
@@ -61,7 +61,7 @@ For `pip install` commands, packages will be installed in the same environment (
 $ scfw run --help
 usage: scfw run [options] COMMAND
 
-Run a package manager command through Supply-Chain Firewall.
+Run a package manager command through Supply Chain Firewall.
 
 options:
   -h, --help           show this help message and exit

--- a/docs/verifiers.md
+++ b/docs/verifiers.md
@@ -1,4 +1,4 @@
-# Supply-Chain Firewall default verifiers
+# Supply Chain Firewall default verifiers
 
 ## Package minimum age verifier
 

--- a/examples/findings_list.yaml
+++ b/examples/findings_list.yaml
@@ -1,5 +1,5 @@
 findings:
-  # CRITICAL severity findings cause Supply-Chain Firewall to block automatically
+  # CRITICAL severity findings cause Supply Chain Firewall to block automatically
   - severity: CRITICAL
     finding: "This package is licensed under an incompatible open source license and must not be used"
     packages:
@@ -13,7 +13,7 @@ findings:
           - 1.0.1
           - 1.0.2
 
-  # WARNING severity findings cause Supply-Chain Firewall to warn while providing the option to continue
+  # WARNING severity findings cause Supply Chain Firewall to warn while providing the option to continue
   - severity: WARNING
     finding: "A more optimized internal version of this package exists: please consider using it"
     packages:

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -1,8 +1,8 @@
 """
-Users of Supply-Chain Firewall may want to use custom loggers according to their
+Users of Supply Chain Firewall may want to use custom loggers according to their
 own logging needs.  This module contains a template for writing a custom logger.
 
-Supply-Chain Firewall discovers loggers at runtime via the following simple protocol.
+Supply Chain Firewall discovers loggers at runtime via the following simple protocol.
 The module implementing the custom logger must contain a function with the following
 name and signature:
 
@@ -11,7 +11,7 @@ def load_logger() -> FirewallLogger
 ```
 
 This `load_logger` function should return an instance of the custom logger for
-Supply-Chain Firewall's use. The module may then be placed in the `scfw/loggers`
+Supply Chain Firewall's use. The module may then be placed in the `scfw/loggers`
 directory for runtime import, no further modification required. Make sure to reinstall
 the `scfw` package after doing so.
 """

--- a/examples/verifier.py
+++ b/examples/verifier.py
@@ -1,9 +1,9 @@
 """
-Users of Supply-Chain Firewall may provide custom package verifiers representing
+Users of Supply Chain Firewall may provide custom package verifiers representing
 alternative sources of truth for SCFW to use. This module contains a template for
 writing such a custom verifier.
 
-Supply-Chain Firewall discovers verifiers at runtime via the following simple protocol.
+Supply Chain Firewall discovers verifiers at runtime via the following simple protocol.
 The module implementing the custom verifier must contain a function with the following
 name and signature:
 
@@ -12,7 +12,7 @@ def load_verifier() -> PackageVerifier
 ```
 
 This `load_verifier` function should return an instance of the custom verifier
-for Supply-Chain Firewall's use. The module may then be placed in the scfw/verifiers
+for Supply Chain Firewall's use. The module may then be placed in the scfw/verifiers
 directory for runtime import without further modifications. Make sure to reinstall
 the `scfw` package after doing so.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 maintainers = [
     {name = "Ian Kretz", email = "ian.kretz@datadoghq.com"},
 ]
-description = "A tool for preventing the installation of malicious open-source packages"
+description = "A tool for preventing the installation of malicious npm and PyPI packages"
 readme = "README.md"
 
 [project.scripts]

--- a/scfw/__init__.py
+++ b/scfw/__init__.py
@@ -1,5 +1,5 @@
 """
-Supply-Chain Firewall (SCFW) is a tool for preventing the installation of malicious npm and PyPI packages.
+Supply Chain Firewall (SCFW) is a tool for preventing the installation of malicious npm and PyPI packages.
 """
 
 __version__ = "2.6.1"

--- a/scfw/audit.py
+++ b/scfw/audit.py
@@ -1,5 +1,5 @@
 """
-Implements Supply-Chain Firewall's `audit` subcommand.
+Implements Supply Chain Firewall's `audit` subcommand.
 """
 
 from argparse import Namespace
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 def run_audit(args: Namespace) -> int:
     """
-    Audit installed packages using Supply-Chain Firewall's verifiers.
+    Audit installed packages using Supply Chain Firewall's verifiers.
 
     Args:
         args: A `Namespace` containing the parsed `audit` subcommand command line.

--- a/scfw/cli/__init__.py
+++ b/scfw/cli/__init__.py
@@ -1,5 +1,5 @@
 """
-Defines Supply-Chain Firewall's command-line interface and performs argument parsing.
+Defines Supply Chain Firewall's command-line interface and performs argument parsing.
 """
 
 from argparse import ArgumentError, Namespace, SUPPRESS
@@ -24,7 +24,7 @@ _DEFAULT_LOG_LEVEL = logging.getLevelName(logging.WARNING)
 
 def _add_audit_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for Supply-Chain Firewall's `audit` subcommand.
+    Defines the command-line interface for Supply Chain Firewall's `audit` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `audit` command line will be added.
@@ -47,7 +47,7 @@ def _add_audit_cli(parser: ArgumentParser):
 
 def _add_configure_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for Supply-Chain Firewall's `configure` subcommand.
+    Defines the command-line interface for Supply Chain Firewall's `configure` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `configure` command line will be added.
@@ -56,25 +56,25 @@ def _add_configure_cli(parser: ArgumentParser):
         "-r",
         "--remove",
         action="store_true",
-        help="Remove all Supply-Chain Firewall-managed configuration"
+        help="Remove all Supply Chain Firewall-managed configuration"
     )
 
     parser.add_argument(
         "--alias-npm",
         action="store_true",
-        help="Add shell aliases to always run npm commands through Supply-Chain Firewall"
+        help="Add shell aliases to always run npm commands through Supply Chain Firewall"
     )
 
     parser.add_argument(
         "--alias-pip",
         action="store_true",
-        help="Add shell aliases to always run pip commands through Supply-Chain Firewall"
+        help="Add shell aliases to always run pip commands through Supply Chain Firewall"
     )
 
     parser.add_argument(
         "--alias-poetry",
         action="store_true",
-        help="Add shell aliases to always run Poetry commands through Supply-Chain Firewall"
+        help="Add shell aliases to always run Poetry commands through Supply Chain Firewall"
     )
 
     parser.add_argument(
@@ -107,13 +107,13 @@ def _add_configure_cli(parser: ArgumentParser):
         type=str,
         default=None,
         metavar="PATH",
-        help="Directory that Supply-Chain Firewall can use as a local cache"
+        help="Directory that Supply Chain Firewall can use as a local cache"
     )
 
 
 def _add_run_cli(parser: ArgumentParser):
     """
-    Defines the command-line interface for Supply-Chain Firewall's `run` subcommand.
+    Defines the command-line interface for Supply Chain Firewall's `run` subcommand.
 
     Args:
         parser: The `ArgumentParser` to which the `run` command line will be added.
@@ -168,7 +168,7 @@ def _add_run_cli(parser: ArgumentParser):
 
 class Subcommand(Enum):
     """
-    The set of subcommands that comprise Supply-Chain Firewall's command line.
+    The set of subcommands that comprise Supply Chain Firewall's command line.
     """
     Audit = "audit"
     Configure = "configure"
@@ -195,18 +195,18 @@ class Subcommand(Enum):
             case Subcommand.Audit:
                 return {
                     "exit_on_error": False,
-                    "description": "Audit installed packages using Supply-Chain Firewall's verifiers."
+                    "description": "Audit installed packages using Supply Chain Firewall's verifiers."
                 }
             case Subcommand.Configure:
                 return {
                     "exit_on_error": False,
-                    "description": "Configure the environment for using Supply-Chain Firewall."
+                    "description": "Configure the environment for using Supply Chain Firewall."
                 }
             case Subcommand.Run:
                 return {
                     "usage": "%(prog)s [options] COMMAND",
                     "exit_on_error": False,
-                    "description": "Run a package manager command through Supply-Chain Firewall."
+                    "description": "Run a package manager command through Supply Chain Firewall."
                 }
 
     def _cli_spec(self) -> Callable[[ArgumentParser], None]:
@@ -230,10 +230,10 @@ class Subcommand(Enum):
 
 def _cli() -> ArgumentParser:
     """
-    Defines the command-line interface for Supply-Chain Firewall.
+    Defines the command-line interface for Supply Chain Firewall.
 
     Returns:
-        A parser for Supply-Chain Firewall's command line.
+        A parser for Supply Chain Firewall's command line.
 
         This parser only handles SCFW's own optional arguments and subcommands.
         It does not parse the package manager commands being run through it.
@@ -271,7 +271,7 @@ def _cli() -> ArgumentParser:
 
 def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
     """
-    Parse Supply-Chain Firewall's command line from a given argument vector.
+    Parse Supply Chain Firewall's command line from a given argument vector.
 
     Args:
         argv: The argument vector to be parsed.
@@ -328,7 +328,7 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
 
 def parse_command_line() -> tuple[Optional[Namespace], str]:
     """
-    Parse Supply-Chain Firewall's command line.
+    Parse Supply Chain Firewall's command line.
 
     Returns:
         A `tuple` of a `Namespace` object containing the results of parsing SCFW's

--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -1,5 +1,5 @@
 """
-Implements Supply-Chain Firewall's `configure` subcommand.
+Implements Supply Chain Firewall's `configure` subcommand.
 """
 
 from argparse import Namespace
@@ -15,7 +15,7 @@ _log = logging.getLogger(__name__)
 
 def run_configure(args: Namespace) -> int:
     """
-    Configure the environment for using Supply-Chain Firewall.
+    Configure the environment for using Supply Chain Firewall.
 
     Args:
         args: A `Namespace` containing the parsed `configure` subcommand command line.
@@ -36,7 +36,7 @@ def run_configure(args: Namespace) -> int:
         env_status = env.remove_config()
 
         print(
-            "All Supply-Chain Firewall-managed configuration has been removed from your environment."
+            "All Supply Chain Firewall-managed configuration has been removed from your environment."
             "\n\nPost-removal tasks:"
             "\n* Update your current shell environment by sourcing from your .bashrc/.zshrc file."
             "\n* If you had previously configured Datadog Agent log forwarding, restart the Agent."
@@ -67,7 +67,7 @@ def run_configure(args: Namespace) -> int:
         try:
             dd_agent.configure_agent_logging(port)
         except Exception as e:
-            _log.warning(f"Failed to configure Datadog Agent for Supply-Chain Firewall: {e}")
+            _log.warning(f"Failed to configure Datadog Agent for Supply Chain Firewall: {e}")
             dd_agent_status = 1
             # Don't set the Agent port environment variable if Agent configuration failed
             answers["dd_agent_port"] = None

--- a/scfw/configure/dd_agent.py
+++ b/scfw/configure/dd_agent.py
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 def configure_agent_logging(port: str):
     """
-    Configure a local Datadog Agent for accepting logs from Supply-Chain Firewall.
+    Configure a local Datadog Agent for accepting logs from Supply Chain Firewall.
 
     Args:
         port: The local port number where logs will be sent to the Agent.
@@ -52,7 +52,7 @@ def configure_agent_logging(port: str):
 
 def remove_agent_logging():
     """
-    Remove Datadog Agent configuration for Supply-Chain Firewall, if it exists.
+    Remove Datadog Agent configuration for Supply Chain Firewall, if it exists.
     """
     scfw_config_dir = _dd_agent_scfw_config_dir()
     if not (scfw_config_dir and scfw_config_dir.is_dir()):
@@ -70,16 +70,16 @@ def remove_agent_logging():
 
 def _dd_agent_scfw_config_dir() -> Optional[Path]:
     """
-    Return the filesystem path to Supply-Chain Firewall's configuration directory
+    Return the filesystem path to Supply Chain Firewall's configuration directory
     for Datadog Agent log forwarding.
 
     Returns:
-        A `Path` containing the local filesystem path to Supply-Chain Firewall's
+        A `Path` containing the local filesystem path to Supply Chain Firewall's
         configuration directory for the Datadog Agent or `None` if the Agent binary
         is inaccessible or the Agent's global configuration directory (always the
         returned directory's parent) does not exist.
 
-        The returned path is what Supply-Chain Firewall's configuration directory
+        The returned path is what Supply Chain Firewall's configuration directory
         would be if it existed, but this function does not check that this directory
         actually exists. It is the caller's responsibility to do so.
 

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -1,5 +1,5 @@
 """
-Provides utilities for configuring the environment (via `.rc` files) for using Supply-Chain Firewall.
+Provides utilities for configuring the environment (via `.rc` files) for using Supply Chain Firewall.
 """
 
 import logging
@@ -18,7 +18,7 @@ _BLOCK_END = "# END SCFW MANAGED BLOCK"
 
 def remove_config() -> int:
     """
-    Remove Supply-Chain Firewall configuration from all supported files.
+    Remove Supply Chain Firewall configuration from all supported files.
 
     Returns:
         An integer status code indicating normal or error exit.
@@ -37,7 +37,7 @@ def remove_config() -> int:
 
 def update_config_files(answers: dict) -> int:
     """
-    Update the Supply-Chain Firewall configuration in all supported files.
+    Update the Supply Chain Firewall configuration in all supported files.
 
     Args:
         answers: A `dict` of configuration options to format and write to each file.
@@ -66,7 +66,7 @@ def update_config_files(answers: dict) -> int:
 
 def _update_config_file(config_file: Path, scfw_config: str):
     """
-    Update the Supply-Chain Firewall configuration in the given file.
+    Update the Supply Chain Firewall configuration in the given file.
 
     Args:
         config_file: A `Path` to the configuration file to update.

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -13,8 +13,8 @@ from scfw.constants import DD_API_KEY_VAR
 from scfw.logger import FirewallAction
 
 GREETING = (
-    "Thank you for using scfw, the Supply-Chain Firewall by Datadog!\n\n"
-    "Supply-Chain Firewall is a tool for preventing the installation of malicious npm and PyPI packages.\n\n"
+    "Thank you for using scfw, the Supply Chain Firewall by Datadog!\n\n"
+    "Supply Chain Firewall is a tool for preventing the installation of malicious npm and PyPI packages.\n\n"
     "This script will walk you through setting up your environment to get the most out of scfw.\n"
     "You can rerun this script at any time to update your configuration settings.\n"
 )
@@ -38,7 +38,7 @@ def get_answers() -> dict:
         inquirer.Text(
             name="scfw_home",
             message=(
-                "Enter a directory that Supply-Chain Firewall can use as a local cache"
+                "Enter a directory that Supply Chain Firewall can use as a local cache"
                 f" (default: {home_dir_default})" if home_dir_default else ""
             )
         ),
@@ -114,7 +114,7 @@ def get_farewell(answers: dict) -> str:
         A `str` farewell message to print in interactive mode.
     """
     farewell = (
-        "The environment was successfully configured for Supply-Chain Firewall."
+        "The environment was successfully configured for Supply Chain Firewall."
         "\n\nPost-configuration tasks:"
         "\n* Update your current shell environment by sourcing from your .bashrc/.zshrc file."
     )

--- a/scfw/ecosystem.py
+++ b/scfw/ecosystem.py
@@ -1,5 +1,5 @@
 """
-A representation of package ecosystems supported by Supply-Chain Firewall.
+A representation of package ecosystems supported by Supply Chain Firewall.
 """
 
 from enum import Enum
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 class ECOSYSTEM(Enum):
     """
-    Package ecosystems supported by Supply-Chain Firewall.
+    Package ecosystems supported by Supply Chain Firewall.
     """
     Npm = "npm"
     PyPI = "PyPI"

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -1,5 +1,5 @@
 """
-Implements Supply-Chain Firewall's core `run` subcommand.
+Implements Supply Chain Firewall's core `run` subcommand.
 """
 
 from argparse import Namespace
@@ -23,12 +23,12 @@ _log = logging.getLogger(__name__)
 
 def run_firewall(args: Namespace) -> int:
     """
-    Run a package manager command through Supply-Chain Firewall.
+    Run a package manager command through Supply Chain Firewall.
 
     Args:
         args:
             A `Namespace` parsed from a `run` subcommand command line containing a
-            package manager command to inspect with Supply-Chain Firewall.
+            package manager command to inspect with Supply Chain Firewall.
 
     Returns:
         An integer status code indicating normal or error exit.
@@ -139,14 +139,14 @@ def _determine_firewall_action(
 
     Returns:
         A triple of an `Optional[FirewallAction]` representing the action that
-        Supply-Chain Firewall should take given `report` and `warning_action`, an
+        Supply Chain Firewall should take given `report` and `warning_action`, an
         `Optional[FindingSeverity]` indicating the highest severity level present in
         `report` (where `FindingSeverity.WARNING` also covers unverifiable packages),
         and an `Optional[FindingsReport]` containing any findings that were relevant
         to the returned action.
 
         Note that on warning, the returned action is always equal to `warning_action`.
-        In the case that Supply-Chain Firewall was unable to determine this action
+        In the case that Supply Chain Firewall was unable to determine this action
         from the environment or the command line, `run_firewall()` is required to
         interactively prompt the user to select an action.
     """

--- a/scfw/logger.py
+++ b/scfw/logger.py
@@ -1,6 +1,6 @@
 """
 Provides an interface for client loggers to receive data from completed runs
-of Supply-Chain Firewall.
+of Supply Chain Firewall.
 """
 
 from abc import (ABCMeta, abstractmethod)
@@ -74,7 +74,7 @@ class FirewallAction(Enum):
 @dataclass(eq=True)
 class FirewallRunSummary:
     """
-    A structured summary of a run of Supply-Chain Firewall used for logging.
+    A structured summary of a run of Supply Chain Firewall used for logging.
     """
     command: list[str]
     install_targets: Optional[set[Package]]
@@ -97,13 +97,13 @@ class FirewallLogger(metaclass=ABCMeta):
         run_summary: FirewallRunSummary,
     ):
         """
-        Log the data and action taken in a completed run of Supply-Chain Firewall.
+        Log the data and action taken in a completed run of Supply Chain Firewall.
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
+            run_summary: The summary of the completed run of Supply Chain Firewall to be logged.
         """
         pass
 

--- a/scfw/loggers/__init__.py
+++ b/scfw/loggers/__init__.py
@@ -61,7 +61,7 @@ class FirewallLoggers(FirewallLogger):
         run_summary: FirewallRunSummary,
     ):
         """
-        Log the data and action taken in a completed run of Supply-Chain Firewall to
+        Log the data and action taken in a completed run of Supply Chain Firewall to
         all client loggers.
         """
         for logger in self._loggers:

--- a/scfw/loggers/dd_agent_logger.py
+++ b/scfw/loggers/dd_agent_logger.py
@@ -1,5 +1,5 @@
 """
-Configures a logger for sending Supply-Chain Firewall logs to a local Datadog Agent.
+Configures a logger for sending Supply Chain Firewall logs to a local Datadog Agent.
 """
 
 import logging
@@ -23,7 +23,7 @@ class _DDLogHandler(logging.Handler):
         Args:
             agent_port:
                 The port number where the Datadog Agent has been independently configured
-                to receive logs from Supply-Chain Firewall.
+                to receive logs from Supply Chain Firewall.
 
         Raises:
             ValueError: An invalid port number was given.
@@ -86,9 +86,9 @@ class DDAgentLogger(DDLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDAgentLogger` for discovery by Supply-Chain Firewall.
+    Export `DDAgentLogger` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `DDAgentLogger` for use in a run of Supply-Chain Firewall.
+        A `DDAgentLogger` for use in a run of Supply Chain Firewall.
     """
     return DDAgentLogger()

--- a/scfw/loggers/dd_api_logger.py
+++ b/scfw/loggers/dd_api_logger.py
@@ -1,5 +1,5 @@
 """
-Configures a logger for sending Supply-Chain Firewall logs to Datadog's API over HTTP.
+Configures a logger for sending Supply Chain Firewall logs to Datadog's API over HTTP.
 """
 
 import logging
@@ -91,9 +91,9 @@ class DDAPILogger(DDLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDAPILogger` for discovery by Supply-Chain Firewall.
+    Export `DDAPILogger` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `DDAPILogger` for use in a run of Supply-Chain Firewall.
+        A `DDAPILogger` for use in a run of Supply Chain Firewall.
     """
     return DDAPILogger()

--- a/scfw/loggers/dd_codesec_logger.py
+++ b/scfw/loggers/dd_codesec_logger.py
@@ -1,5 +1,5 @@
 """
-Provides a `FirewallLogger` for Datadog Code Security's Supply-Chain Firewall API.
+Provides a `FirewallLogger` for Datadog Code Security's Supply Chain Firewall API.
 """
 
 import logging
@@ -28,7 +28,7 @@ Setting this environment variable is required to enable the Datadog Code Securit
 class DDCodeSecurityLogger(FirewallLogger):
     """
     An implementation of `FirewallLogger` for sending logs to Datadog Code Security's
-    Supply-Chain Firewall API.
+    Supply Chain Firewall API.
     """
     def __init__(self):
         """
@@ -44,13 +44,13 @@ class DDCodeSecurityLogger(FirewallLogger):
         run_summary: FirewallRunSummary,
     ):
         """
-        Log the data and action taken in a completed run of Supply-Chain Firewall.
+        Log the data and action taken in a completed run of Supply Chain Firewall.
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
+            run_summary: The summary of the completed run of Supply Chain Firewall to be logged.
         """
         if not self._enabled:
             return
@@ -112,7 +112,7 @@ class DDCodeSecurityLogger(FirewallLogger):
         Args:
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
+            run_summary: The summary of the completed run of Supply Chain Firewall to be logged.
 
         Returns:
             A `dict` containing the API's JSON payload generated from the inputs.
@@ -173,9 +173,9 @@ class DDCodeSecurityLogger(FirewallLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `DDCodeSecurityLogger` for discovery by Supply-Chain Firewall.
+    Export `DDCodeSecurityLogger` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `DDCodeSecurityLogger` for use in a run of Supply-Chain Firewall.
+        A `DDCodeSecurityLogger` for use in a run of Supply Chain Firewall.
     """
     return DDCodeSecurityLogger()

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -51,6 +51,11 @@ _ALL_LOG_ATTRIBUTES = _AUDIT_ATTRIBUTES | _FIREWALL_ACTION_ATTRIBUTES
 
 _DD_LOG_LEVEL_DEFAULT = FirewallAction.BLOCK
 
+DD_LOG_VERSION = 1
+"""
+A version number for the log record format.
+"""
+
 DD_LOGGER_HOME = Path("dd_logger/")
 """
 The Datadog logger home directory, realtive to `SCFW_HOME`.
@@ -129,12 +134,13 @@ class DDLogFormatter(logging.Formatter):
             return attributes
 
         log_record = {
-            "source": DD_SOURCE,
-            "service": DD_SERVICE,
-            "version": scfw.__version__,
+            "cwd": os.getcwd(),
             "env": os.getenv("DD_ENV", DD_ENV),
             "hostname": socket.gethostname(),
-            "cwd": os.getcwd(),
+            "log_version": DD_LOG_VERSION,
+            "service": DD_SERVICE,
+            "source": DD_SOURCE,
+            "version": scfw.__version__,
         }
 
         try:

--- a/scfw/loggers/dd_logger.py
+++ b/scfw/loggers/dd_logger.py
@@ -84,7 +84,7 @@ dotenv.load_dotenv()
 
 class DDLogFormatter(logging.Formatter):
     """
-    A custom JSON formatter for Supply-Chain Firewall logs.
+    A custom JSON formatter for Supply Chain Firewall logs.
     """
     def format(self, record) -> str:
         """
@@ -199,13 +199,13 @@ class DDLogger(FirewallLogger):
         run_summary: FirewallRunSummary,
     ):
         """
-        Log the data and action taken in a completed run of Supply-Chain Firewall.
+        Log the data and action taken in a completed run of Supply Chain Firewall.
 
         Args:
             ecosystem: The ecosystem of the inspected package manager command.
             package_manager: The command-line name of the package manager.
             executable: The executable used to execute the inspected package manager command.
-            run_summary: The summary of the completed run of Supply-Chain Firewall to be logged.
+            run_summary: The summary of the completed run of Supply Chain Firewall to be logged.
         """
         if run_summary.action < self._level:
             return

--- a/scfw/loggers/file_logger.py
+++ b/scfw/loggers/file_logger.py
@@ -57,9 +57,9 @@ class FileLogger(DDLogger):
 
 def load_logger() -> FirewallLogger:
     """
-    Export `FileLogger` for discovery by Supply-Chain Firewall.
+    Export `FileLogger` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `FileLogger` for use in a run of Supply-Chain Firewall.
+        A `FileLogger` for use in a run of Supply Chain Firewall.
     """
     return FileLogger()

--- a/scfw/main.py
+++ b/scfw/main.py
@@ -1,5 +1,5 @@
 """
-Provides Supply-Chain Firewall's main routine.
+Provides Supply Chain Firewall's main routine.
 """
 
 import logging
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 def main() -> int:
     """
-    Supply-Chain Firewall's main routine.
+    Supply Chain Firewall's main routine.
 
     Returns:
         An integer status code indicating normal or error exit.
@@ -29,7 +29,7 @@ def main() -> int:
 
     _configure_logging(args.log_level)
 
-    _log.info(f"Starting Supply-Chain Firewall on {time.asctime(time.localtime())}")
+    _log.info(f"Starting Supply Chain Firewall on {time.asctime(time.localtime())}")
     _log.debug(f"Command line: {vars(args)}")
 
     try:

--- a/scfw/package_manager.py
+++ b/scfw/package_manager.py
@@ -93,7 +93,7 @@ class UnsupportedVersionError(Exception):
     """
     An exception that occurs when an attempt is made to initialize a `PackageManager`
     or execute one of its key methods with an unsupported version of the underlying
-    executable. Supply-Chain Firewall handles this exception gracefully by alerting
+    executable. Supply Chain Firewall handles this exception gracefully by alerting
     the user to the issue. In firewall mode, the user can optionally disable verification
     and run commands with unsupported versions of supported package managers.
     """

--- a/scfw/package_managers/__init__.py
+++ b/scfw/package_managers/__init__.py
@@ -1,6 +1,6 @@
 """
 Provides an interface for obtaining `PackageManager` instances needed for runs
-of Supply-Chain Firewall.
+of Supply Chain Firewall.
 """
 
 from typing import Optional

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -158,7 +158,7 @@ def show_reports(
 
     Returns:
         A pretty-printed `str` representation of the given reports suitable for displaying
-        to the user during a run of Supply-Chain Firewall.
+        to the user during a run of Supply Chain Firewall.
     """
     def show_line(linenum: int, line: str) -> str:
         return (f"  - {line}" if linenum == 0 else f"    {line}")

--- a/scfw/verifier.py
+++ b/scfw/verifier.py
@@ -16,10 +16,10 @@ class FindingSeverity(Enum):
     A hierarchy of severity levels for package verifier findings.
 
     Package verifiers attach severity levels to their findings in order to direct
-    Supply-Chain Firewall to take the correct action with respect to blocking or
+    Supply Chain Firewall to take the correct action with respect to blocking or
     warning on a package manager command.
 
-    A `CRITICAL` finding causes Supply-Chain Firewall to block. A `WARNING` finding
+    A `CRITICAL` finding causes Supply Chain Firewall to block. A `WARNING` finding
     prompts it to seek confirmation from the user before running the command.
     """
     CRITICAL = "CRITICAL"
@@ -146,7 +146,7 @@ class UnverifiablePackage(Exception):
     a private package registry would not be within the purview of a verifier that only
     covers packages sourced from an ecosystem's main public registry.
 
-    Supply-Chain Firewall handles this exception gracefully by separately collecting,
+    Supply Chain Firewall handles this exception gracefully by separately collecting,
     logging and reporting any packages that were unable to be verified.
     """
     pass

--- a/scfw/verifiers/__init__.py
+++ b/scfw/verifiers/__init__.py
@@ -1,13 +1,13 @@
 """
 Exports the currently discoverable set of package verifiers for use in
-Supply-Chain Firewall.
+Supply Chain Firewall.
 
-Two package verifiers ship with Supply-Chain Firewall by default: one for
+Two package verifiers ship with Supply Chain Firewall by default: one for
 Datadog Security Research's malicious packages dataset and one for OSV.dev's
-advisory database. Users of Supply-Chain Firewall may additionally provide
+advisory database. Users of Supply Chain Firewall may additionally provide
 custom verifiers representing alternative sources of truth.
 
-Supply-Chain Firewall discovers verifiers at runtime via the following protocol.
+Supply Chain Firewall discovers verifiers at runtime via the following protocol.
 The module implementing the custom verifier must contain a function with the
 following name and signature:
 
@@ -17,7 +17,7 @@ def load_verifier() -> PackageVerifier
 
 This `load_verifier` function should return an instance of the custom verifier.
 The module may then be placed in the same directory as this source file for
-runtime import. Make sure to reinstall Supply-Chain Firewall after doing so.
+runtime import. Make sure to reinstall Supply Chain Firewall after doing so.
 """
 
 import concurrent.futures as cf

--- a/scfw/verifiers/age_verifier/__init__.py
+++ b/scfw/verifiers/age_verifier/__init__.py
@@ -131,9 +131,9 @@ class PackageAgeVerifier(PackageVerifier):
 
 def load_verifier() -> PackageVerifier:
     """
-    Export `PackageAgeVerifier` for discovery by Supply-Chain Firewall.
+    Export `PackageAgeVerifier` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `PackageAgeVerifier` for use in a run of Supply-Chain Firewall.
+        A `PackageAgeVerifier` for use in a run of Supply Chain Firewall.
     """
     return PackageAgeVerifier()

--- a/scfw/verifiers/dd_verifier/__init__.py
+++ b/scfw/verifiers/dd_verifier/__init__.py
@@ -112,9 +112,9 @@ class DatadogMaliciousPackagesVerifier(PackageVerifier):
 
 def load_verifier() -> PackageVerifier:
     """
-    Export `DatadogMaliciousPackagesVerifier` for discovery by Supply-Chain Firewall.
+    Export `DatadogMaliciousPackagesVerifier` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `DatadogMaliciousPackagesVerifier` for use in a run of Supply-Chain Firewall.
+        A `DatadogMaliciousPackagesVerifier` for use in a run of Supply Chain Firewall.
     """
     return DatadogMaliciousPackagesVerifier()

--- a/scfw/verifiers/list_verifier/__init__.py
+++ b/scfw/verifiers/list_verifier/__init__.py
@@ -104,9 +104,9 @@ class FindingsListVerifier(PackageVerifier):
 
 def load_verifier() -> PackageVerifier:
     """
-    Export `FindingsListVerifier` for discovery by Supply-Chain Firewall.
+    Export `FindingsListVerifier` for discovery by Supply Chain Firewall.
 
     Returns:
-        A `FindingsListVerifier` for use in a run of Supply-Chain Firewall.
+        A `FindingsListVerifier` for use in a run of Supply Chain Firewall.
     """
     return FindingsListVerifier()

--- a/scfw/verifiers/osv_verifier/__init__.py
+++ b/scfw/verifiers/osv_verifier/__init__.py
@@ -208,9 +208,9 @@ class OsvVerifier(PackageVerifier):
 
 def load_verifier() -> PackageVerifier:
     """
-    Export `OsvVerifier` for discovery by Supply-Chain Firewall.
+    Export `OsvVerifier` for discovery by Supply Chain Firewall.
 
     Returns:
-        An `OsvVerifier` for use in a run of Supply-Chain Firewall.
+        An `OsvVerifier` for use in a run of Supply Chain Firewall.
     """
     return OsvVerifier()

--- a/tests/package_managers/test_npm.py
+++ b/tests/package_managers/test_npm.py
@@ -1,5 +1,5 @@
 """
-Tests establishing the validity of Supply-Chain Firewall's assumptions about
+Tests establishing the validity of Supply Chain Firewall's assumptions about
 npm's command-line options and behavior.
 """
 

--- a/tests/package_managers/test_poetry.py
+++ b/tests/package_managers/test_poetry.py
@@ -23,7 +23,7 @@ def test_poetry_version_output():
 
 def test_poetry_add_no_change(new_poetry_project):
     """
-    Test that certain `poetry add` commands relied on by Supply-Chain Firewall not
+    Test that certain `poetry add` commands relied on by Supply Chain Firewall not
     to error or modify the local installation state indeed have these properties.
     """
     test_cases = [
@@ -51,7 +51,7 @@ def test_poetry_add_no_change(new_poetry_project):
 
 def test_poetry_install_no_change(new_poetry_project):
     """
-    Test that certain `poetry install` commands relied on by Supply-Chain Firewall
+    Test that certain `poetry install` commands relied on by Supply Chain Firewall
     not to error or modify the local installation state indeed have these properties.
     """
     test_cases = [
@@ -74,7 +74,7 @@ def test_poetry_install_no_change(new_poetry_project):
 
 def test_poetry_sync_no_change(new_poetry_project):
     """
-    Test that certain `poetry sync` commands relied on by Supply-Chain Firewall
+    Test that certain `poetry sync` commands relied on by Supply Chain Firewall
     not to error or modify the local installation state indeed have these properties.
     """
     version = poetry_version()
@@ -103,7 +103,7 @@ def test_poetry_sync_no_change(new_poetry_project):
 
 def test_poetry_update_no_change(new_poetry_project):
     """
-    Test that certain `poetry update` commands relied on by Supply-Chain Firewall
+    Test that certain `poetry update` commands relied on by Supply Chain Firewall
     not to error or modify the local installation state indeed have these properties.
     """
     test_cases = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
 """
-Tests of the Supply-Chain Firewall command-line interface.
+Tests of the Supply Chain Firewall command-line interface.
 """
 
 import pytest

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,5 +1,5 @@
 """
-Tests of utilities for writing Supply-Chain Firewall configuration to supported files.
+Tests of utilities for writing Supply Chain Firewall configuration to supported files.
 """
 
 from pathlib import Path


### PR DESCRIPTION
This PR adds versioning for the (non-Code Security) Datadog log record format.  This is being done to support future schema evolution.

It also drops the hyphen from the project name: this is now "Supply Chain Firewall".