### PR TITLE
📦 Add GitHub workflow to build standalone SCFW binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,106 @@
+name: Release standalone binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: x86_64
+            runs-on: ubuntu-latest
+          - os: linux
+            arch: arm64
+            runs-on: ubuntu-24.04-arm
+          - os: macos
+            arch: x86_64
+            runs-on: macos-13
+          - os: macos
+            arch: arm64
+            runs-on: macos-latest
+          - os: windows
+            arch: x86_64
+            runs-on: windows-latest
+          - os: windows
+            arch: arm64
+            runs-on: windows-11-arm
+    runs-on: ${{ matrix.runs-on }}
+    env:
+      ASSET_NAME: scfw-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller==6.21.0
+
+      - name: Install Supply-Chain Firewall
+        run: pip install -r requirements.txt
+
+      - name: Write PyInstaller entry point
+        shell: bash
+        run: |
+          printf 'import sys\nfrom scfw.main import main\nsys.exit(main())\n' > entrypoint.py
+
+      - name: Build standalone binary
+        shell: bash
+        run: |
+          pyinstaller --onefile --name scfw \
+            --collect-submodules scfw.verifiers \
+            --collect-submodules scfw.loggers \
+            --copy-metadata readchar \
+            entrypoint.py
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          if [ "${{ matrix.os }}" = "windows" ]; then
+            mv dist/scfw.exe "dist/${{ env.ASSET_NAME }}"
+          else
+            mv dist/scfw "dist/${{ env.ASSET_NAME }}"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ env.ASSET_NAME }}
+          path: dist/${{ env.ASSET_NAME }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Compute checksums
+        working-directory: dist
+        run: sha256sum * > scfw_SHA256SUMS
+
+      - name: Create or update release with binaries
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          files: dist/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -22,7 +22,7 @@ jobs:
             runs-on: ubuntu-24.04-arm
           - os: macos
             arch: x86_64
-            runs-on: macos-13
+            runs-on: macos-26-intel
           - os: macos
             arch: arm64
             runs-on: macos-latest

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -45,7 +45,7 @@ jobs:
           pip install pyinstaller==6.21.0
 
       - name: Install Supply Chain Firewall
-        run: pip install -r requirements.txt
+        run: pip install .
 
       - name: Write PyInstaller entry point
         shell: bash

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install -r requirements.txt
           pip install pyinstaller==6.21.0
 
       - name: Install Supply Chain Firewall

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -26,15 +26,9 @@ jobs:
           - os: macos
             arch: arm64
             runs-on: macos-latest
-          - os: windows
-            arch: x86_64
-            runs-on: windows-latest
-          - os: windows
-            arch: arm64
-            runs-on: windows-11-arm
     runs-on: ${{ matrix.runs-on }}
     env:
-      ASSET_NAME: scfw-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
+      ASSET_NAME: scfw-${{ matrix.os }}-${{ matrix.arch }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -69,12 +63,7 @@ jobs:
 
       - name: Rename binary
         shell: bash
-        run: |
-          if [ "${{ matrix.os }}" = "windows" ]; then
-            mv dist/scfw.exe "dist/${{ env.ASSET_NAME }}"
-          else
-            mv dist/scfw "dist/${{ env.ASSET_NAME }}"
-          fi
+        run: mv dist/scfw "dist/${{ env.ASSET_NAME }}"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install .
           pip install pyinstaller==6.21.0
 
-      - name: Install Supply-Chain Firewall
+      - name: Install Supply Chain Firewall
         run: pip install -r requirements.txt
 
       - name: Write PyInstaller entry point


### PR DESCRIPTION
## 🚀 Motivation 
Today, installing SCFW requires Python 3, pipx, and `pipx install scfw` — meaning users must run the very package-install command SCFW is designed to protect, and developers without a Python setup can't easily install it at all. This ticket adds a release workflow that builds standalone binaries for all major platforms/architectures with checksums, so users can install and verify SCFW without a Python toolchain.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [K9CODESEC-2833](https://datadoghq.atlassian.net/browse/K9CODESEC-2833)

## 📝 Summary
- Added `.github/workflows/release-binaries.yml`, triggered on `v*` tag pushes, that builds standalone `scfw` binaries for Linux, macOS, and Windows (x86_64 and arm64) using PyInstaller.
- Each matrix job sets up Python, installs project dependencies and PyInstaller, generates a small entry point script, and packages a single-file executable named per OS/arch.
- A follow-up `release` job downloads all built artifacts, computes a `scfw_SHA256SUMS` checksum file, and publishes everything to the GitHub release for that tag, giving users a way to verify binary integrity.

```
Tag push (v*) → build (matrix: linux/macos/windows × x86_64/arm64)
                   │  PyInstaller → onefile binary → upload-artifact
                   ▼
                release job → download all artifacts → sha256sum → attach to GitHub Release
```

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9CODESEC-2833]: https://datadoghq.atlassian.net/browse/K9CODESEC-2833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ