### PR TITLE
🔐 Add Chainguard policy for CLI releases

### DIFF
--- a/.github/chainguard/self.github.release.tags.sts.yaml
+++ b/.github/chainguard/self.github.release.tags.sts.yaml
@@ -1,0 +1,12 @@
+# Policy for: .github/workflows/release.yml
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:DataDog/supply-chain-firewall:ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/supply-chain-firewall/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
+  ref: refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
+  repository: DataDog/supply-chain-firewall
+
+permissions:
+  contents: write

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -3,7 +3,7 @@ name: Release to PyPI
 on:
   push:
     tags:
-      - "v*"
+      - "v3.*"
 
 permissions:
   contents: read

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,7 +3,7 @@ name: Release standalone binaries
 on:
   push:
     tags:
-      - "v*"
+      - "v3.*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🚀 Motivation

The Chainguard identity policy must be present on `main` to authorize release tags produced from the v4 branch for the new CLI version.

## 📝 Summary

Add a Chainguard policy for the release workflow that permits version-tag pushes and grants the required contents write permission.

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
