### PR TITLE
Add CI checks on push to v4 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - v4
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - v4
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
             npm-version: "11.18"
           - node-version: "22.9.0"
             npm-version: "11.19"
-          - node-version: "24.0.0"
+          - node-version: "26.0.0"
             npm-version: "12.0"
     steps:
       - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - v4
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,6 +212,12 @@ jobs:
             npm-version: "11.16"
           - node-version: "22.9.0"
             npm-version: "11.17"
+          - node-version: "22.9.0"
+            npm-version: "11.18"
+          - node-version: "22.9.0"
+            npm-version: "11.19"
+          - node-version: "24.0.0"
+            npm-version: "12.0"
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -275,6 +281,8 @@ jobs:
           - pip-version: "26.0"
             python-version: "3.14"
           - pip-version: "26.1"
+            python-version: "3.14"
+          - pip-version: "26.2"
             python-version: "3.14"
     steps:
       - name: Check out code

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Datadog scfw
+Datadog supply-chain-firewall
 Copyright 2024-Present Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Latest released major version.
 
 To report a vulnerability, please use GitHub's built-in "Report a
 vulnerability" feature:
-https://github.com/DataDog/scfw/security/advisories/new.
+https://github.com/DataDog/supply-chain-firewall/security/advisories/new.
 
 Your report will be private and only accessible to maintainers.  You
 can expect to hear back within 1 week, on a best-effort basis.


### PR DESCRIPTION
This PR ensures the CI checks run on push to the `v4` branch, serving currently as the main branch for the Go project.

It also adds additional tests corresponding to the most recent releases of pip and npm.