### PR TITLE
Add PyPI compliance and metadata fixes to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 ]
 requires-python = ">=3.10"
 authors = [
+    {name = "Datadog Inc.", email = "package@datadoghq.com"},
     {name = "Ian Kretz", email = "ian.kretz@datadoghq.com"},
 ]
 maintainers = [
@@ -20,6 +21,22 @@ maintainers = [
 ]
 description = "A tool for preventing the installation of malicious npm and PyPI packages"
 readme = "README.md"
+license = "Apache-2.0"
+keywords = [
+    "supply-chain-security",
+    "malware",
+    "npm",
+    "pypi",
+    "firewall",
+    "package-security",
+    "datadog",
+]
+
+[project.urls]
+Homepage = "https://www.datadoghq.com"
+Repository = "https://github.com/DataDog/supply-chain-firewall"
+"Bug Tracker" = "https://github.com/DataDog/supply-chain-firewall/issues"
+Changelog = "https://github.com/DataDog/supply-chain-firewall/releases"
 
 [project.scripts]
 scfw = "scfw.main:main"


### PR DESCRIPTION
## Summary
Small compliance and metadata fixes to `pyproject.toml`. No runtime,
API, or build-backend changes.

## Changes
### `pyproject.toml`
- Added `[project.urls]` with `Homepage` (https://www.datadoghq.com),
  `Repository`, `Bug Tracker`, and `Changelog`, all pointing to the
  correct `DataDog/supply-chain-firewall` repository.
- Added `Datadog Inc. <package@datadoghq.com>` as the first author;
  the original author (Ian Kretz) is retained as a second author and
  as a `maintainer`.
- Added `license = "Apache-2.0"` (SPDX string form, matching the
  repository's Apache 2.0 `LICENSE`).
- Added discoverability `keywords`.

## Testing
Metadata-only change. Verified that `pyproject.toml` parses as valid
TOML and that `python -m build` produces a wheel whose `METADATA`
renders the new `Project-URL`, `License-Expression`, `Author-email`,
and `Keywords` fields correctly.
