### PR TITLE
feat: add ignore option to bypass false-positive findings for specific package

### DIFF
--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -78,7 +78,18 @@ options:
   --block-on-warning   Non-interactively block commands with only warning-level findings
   --error-on-block     Treat blocked commands as errors (useful for scripting)
   --executable PATH    Package manager executable to use for running commands (default: environmentally determined)
+  --ignore PACKAGE     Suppress findings for the given package, e.g. to bypass a false positive (may be given multiple
+                       times; matches a package name or a name-version string)
 ```
+
+The `--ignore` option may be used to temporarily suppress all findings (including critical ones) for a specific package, which is useful for bypassing a false positive without disabling verification entirely.  It may be given multiple times to ignore several packages in a single command.
+
+A value passed to `--ignore` matches a package in one of two ways:
+
+* A bare package name (e.g. `dotenv-expand`) suppresses findings for that package regardless of version.
+* A full name-version string in the ecosystem's own formatting (e.g. `dotenv-expand@5.1.0` for npm or `requests-2.31.0` for PyPI, matching how SCFW prints packages) suppresses findings only for that specific version.
+
+Because it bypasses SCFW's protections, `--ignore` applies only to the single command it is passed to and should be used with caution.  Ignored packages are noted in SCFW's output for the run.
 
 Users may configure the behavior of this subcommand via the following environment variables:
 

--- a/scfw/cli/__init__.py
+++ b/scfw/cli/__init__.py
@@ -193,6 +193,17 @@ def _add_run_cli(parser: ArgumentParser):
         help="Package manager executable to use for running commands (default: environmentally determined)"
     )
 
+    parser.add_argument(
+        "--ignore",
+        action="append",
+        default=None,
+        metavar="PACKAGE",
+        help=(
+            "Suppress findings for the given package, e.g. to bypass a false positive "
+            "(may be given multiple times; matches a package name or a name-version string)"
+        )
+    )
+
 
 class Subcommand(Enum):
     """

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -13,6 +13,7 @@ from typing import Optional
 from scfw.constants import ON_WARNING_VAR
 from scfw.logger import FirewallAction, FirewallRunSummary
 from scfw.loggers import FirewallLoggers
+from scfw.package import Package
 from scfw.package_manager import UnsupportedVersionError
 import scfw.package_managers as package_managers
 from scfw.report import FindingsReport, VerificationReport, show_reports
@@ -53,6 +54,10 @@ def run_firewall(args: Namespace) -> int:
             report = verifiers.verify_packages(install_targets)
         else:
             report = VerificationReport()
+
+        if (ignored := _apply_ignores(report, args.ignore)):
+            _log.warning(f"Ignoring findings for user-specified packages: [{', '.join(map(str, ignored))}]")
+            print(f"Ignoring findings for: {', '.join(sorted(map(str, ignored)))}")
 
         warning_action = _get_warning_action(args.allow_on_warning, args.block_on_warning)
         action, severity, relevant_findings = _determine_firewall_action(report, warning_action)
@@ -126,6 +131,41 @@ def run_firewall(args: Namespace) -> int:
             ),
         )
         return package_manager.run_command(args.command)
+
+
+def _apply_ignores(report: VerificationReport, ignore: Optional[list[str]]) -> set[Package]:
+    """
+    Suppress findings for any package in a report that the user has chosen to ignore.
+
+    Args:
+        report:
+            The `VerificationReport` to filter. Matching packages are reclassified as
+            clean in place so that their findings no longer drive the firewall action.
+        ignore:
+            The (possibly undefined) list of user-provided ignore specifications. A
+            package matches a specification when the latter equals either the package's
+            name (ignoring all versions of the package) or the package's full
+            ecosystem-formatted string, e.g. `dotenv-expand@5.1.0` for npm or
+            `requests-2.31.0` for PyPI (ignoring only that specific version).
+
+    Returns:
+        The `set[Package]` whose findings were suppressed. This is empty when no ignore
+        specifications were provided or none of them matched a package with findings.
+    """
+    if not ignore:
+        return set()
+
+    ignore_specs = set(ignore)
+    candidates = set(report.get_findings()) | set(report.get_unverifiable())
+
+    ignored = {
+        package for package in candidates
+        if package.name in ignore_specs or str(package) in ignore_specs
+    }
+    for package in ignored:
+        report.ignore(package)
+
+    return ignored
 
 
 def _determine_firewall_action(

--- a/scfw/report.py
+++ b/scfw/report.py
@@ -135,6 +135,24 @@ class VerificationReport:
         if package in self._clean:
             self._clean.remove(package)
 
+    def ignore(self, package: Package) -> None:
+        """
+        Suppress any findings or unverifiable results for a given package by
+        reclassifying it as clean.
+
+        Args:
+            package:
+                The `Package` whose findings should be suppressed.
+
+                This is intended to support temporarily ignoring a package the
+                user has explicitly chosen to trust, e.g. to bypass a false positive.
+                After this call, `package` is treated as clean regardless of any
+                findings or unverifiable results it previously had in the report.
+        """
+        self._findings.pop(package, None)
+        self._unverifiable.pop(package, None)
+        self._clean.add(package)
+
     def packages(self) -> set[Package]:
         """
         Return the set of packages contained in the report.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -175,6 +175,7 @@ def test_cli_run_basic_usage(command: list[str]):
     assert not args.allow_unsupported
     assert not args.dry_run
     assert not args.executable
+    assert args.ignore is None
 
 
 def test_cli_run_all_options_no_command():
@@ -182,7 +183,7 @@ def test_cli_run_all_options_no_command():
     Invocation with all options and no arguments.
     """
     executable = "/usr/bin/python"
-    argv = ["scfw", "run", "--executable", executable, "--dry-run", "--allow-unsupported"]
+    argv = ["scfw", "run", "--executable", executable, "--dry-run", "--allow-unsupported", "--ignore", "react"]
     args, _ = _parse_command_line(argv)
     assert args is None
 
@@ -200,18 +201,42 @@ def test_cli_run_all_options_command(command: list[str]):
     Invocation of a run command with all options and the given `command`.
     """
     executable = "/path/to/executable"
-    argv = ["scfw", "run", "--executable", executable, "--dry-run", "--allow-unsupported"] + command
+    options = ["--executable", executable, "--dry-run", "--allow-unsupported", "--ignore", "foo"]
+    argv = ["scfw", "run"] + options + command
     args, _ = _parse_command_line(argv)
     assert args is not None
 
     assert args.subcommand == Subcommand.Run
     assert args.log_level == _DEFAULT_LOG_LEVEL
 
-    assert args.package_manager == argv[6]
-    assert args.command == argv[6:]
+    assert args.package_manager == command[0]
+    assert args.command == command
     assert args.allow_unsupported
     assert args.dry_run
     assert args.executable == executable
+    assert args.ignore == ["foo"]
+
+
+@pytest.mark.parametrize(
+        "command",
+        [
+            ["npm", "install", "react"],
+            ["pip", "install", "requests"],
+            ["poetry", "add", "requests"],
+        ]
+)
+def test_cli_run_ignore_repeatable(command: list[str]):
+    """
+    The `--ignore` option accumulates each occurrence into a list, in order.
+    """
+    argv = ["scfw", "run", "--ignore", "foo", "--ignore", "bar-1.0.0"] + command
+    args, _ = _parse_command_line(argv)
+    assert args is not None
+
+    assert args.subcommand == Subcommand.Run
+    assert args.package_manager == command[0]
+    assert args.command == command
+    assert args.ignore == ["foo", "bar-1.0.0"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 from scfw.constants import ON_WARNING_VAR
 from scfw.ecosystem import ECOSYSTEM
-from scfw.firewall import _determine_firewall_action, _get_warning_action
+from scfw.firewall import _apply_ignores, _determine_firewall_action, _get_warning_action
 from scfw.logger import FirewallAction
 from scfw.report import VerificationReport, VerifierErrorMessage
 from scfw.verifier import Finding, FindingSeverity
@@ -20,6 +20,7 @@ from tests.utils import build_registry_package
 
 _PKG_A = build_registry_package(ECOSYSTEM.PyPI, "requests", "2.31.0")
 _PKG_B = build_registry_package(ECOSYSTEM.PyPI, "numpy", "1.24.0")
+_PKG_C = build_registry_package(ECOSYSTEM.Npm, "dotenv-expand", "5.1.0")
 
 _CRITICAL_FINDING = Finding("foo", FindingSeverity.CRITICAL, "critical finding")
 _WARNING_FINDING = Finding("foo", FindingSeverity.WARNING, "warning finding")
@@ -132,6 +133,137 @@ def test_warning_and_unverifiable_merged(warning_action: Optional[FirewallAction
     assert action == warning_action
     assert severity == FindingSeverity.WARNING
     assert relevant == report.get_findings(FindingSeverity.WARNING)
+
+
+@pytest.mark.parametrize("ignore", [None, []])
+def test_apply_ignores_no_specs(ignore):
+    """
+    With no ignore specifications, `_apply_ignores` is a no-op and returns no packages.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    ignored = _apply_ignores(report, ignore)
+
+    assert ignored == set()
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}}
+
+
+def test_apply_ignores_by_name():
+    """
+    An ignore specification matching a package name suppresses that package's findings.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    ignored = _apply_ignores(report, [_PKG_A.name])
+
+    assert ignored == {_PKG_A}
+    assert report.get_findings() == {}
+    assert _PKG_A in report.get_clean()
+
+
+@pytest.mark.parametrize("package", [_PKG_A, _PKG_C])
+def test_apply_ignores_by_name_version_string(package):
+    """
+    An ignore specification matching a package's full ecosystem-formatted string suppresses
+    that package's findings, for both PyPI (`name-version`) and npm (`name@version`) formats.
+    """
+    report = VerificationReport()
+    report.insert_finding(package, _CRITICAL_FINDING)
+
+    ignored = _apply_ignores(report, [str(package)])
+
+    assert ignored == {package}
+    assert report.get_findings() == {}
+    assert package in report.get_clean()
+
+
+def test_apply_ignores_suppresses_unverifiable():
+    """
+    `_apply_ignores` also suppresses unverifiable results for a matching package.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_A, _UNVERIFIABLE)
+
+    ignored = _apply_ignores(report, [_PKG_A.name])
+
+    assert ignored == {_PKG_A}
+    assert report.get_unverifiable() == {}
+    assert _PKG_A in report.get_clean()
+
+
+def test_apply_ignores_only_affects_matching_packages():
+    """
+    `_apply_ignores` leaves the findings of non-matching packages untouched.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_B, _WARNING_FINDING)
+
+    ignored = _apply_ignores(report, [_PKG_A.name])
+
+    assert ignored == {_PKG_A}
+    assert report.get_findings() == {_PKG_B: {_WARNING_FINDING}}
+
+
+def test_apply_ignores_non_matching_spec():
+    """
+    An ignore specification that matches no package leaves the report unchanged.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    ignored = _apply_ignores(report, ["nonexistent"])
+
+    assert ignored == set()
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}}
+
+
+def test_apply_ignores_version_specific_spec_does_not_match_other_version():
+    """
+    A version-specific ignore specification does not suppress findings for a different version
+    of the same package.
+    """
+    other_version = build_registry_package(ECOSYSTEM.PyPI, _PKG_A.name, "2.30.0")
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    ignored = _apply_ignores(report, [str(other_version)])
+
+    assert ignored == set()
+    assert report.get_findings() == {_PKG_A: {_CRITICAL_FINDING}}
+
+
+def test_apply_ignores_allows_previously_blocked_command():
+    """
+    After ignoring the only package with a critical finding, the firewall action becomes ALLOW.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+
+    _apply_ignores(report, [_PKG_A.name])
+    action, severity, relevant = _determine_firewall_action(report, None)
+
+    assert action == FirewallAction.ALLOW
+    assert severity is None
+    assert relevant is None
+
+
+def test_apply_ignores_leaves_unignored_critical_finding_blocking():
+    """
+    Ignoring one package does not prevent another package's critical finding from blocking.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_B, _CRITICAL_FINDING)
+
+    _apply_ignores(report, [_PKG_A.name])
+    action, severity, relevant = _determine_firewall_action(report, None)
+
+    assert action == FirewallAction.BLOCK
+    assert severity == FindingSeverity.CRITICAL
+    assert relevant == {_PKG_B: {_CRITICAL_FINDING}}
 
 
 def test_get_warning_action_cli_block():

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -269,6 +269,73 @@ def test_packages_no_duplicates_after_clean_to_findings_promotion():
     assert report.packages() == {_PKG_A}
 
 
+def test_ignore_finding_reclassifies_as_clean():
+    """
+    `ignore()` removes a package's findings and reclassifies it as clean.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.ignore(_PKG_A)
+    assert report.get_findings() == {}
+    assert _PKG_A in report.get_clean()
+
+
+def test_ignore_unverifiable_reclassifies_as_clean():
+    """
+    `ignore()` removes a package's unverifiable results and reclassifies it as clean.
+    """
+    report = VerificationReport()
+    report.insert_unverifiable(_PKG_B, _ERROR_MESSAGE)
+    report.ignore(_PKG_B)
+    assert report.get_unverifiable() == {}
+    assert _PKG_B in report.get_clean()
+
+
+def test_ignore_removes_findings_and_unverifiable_together():
+    """
+    `ignore()` clears both findings and unverifiable results for the same package.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_unverifiable(_PKG_A, _ERROR_MESSAGE)
+    report.ignore(_PKG_A)
+    assert report.get_findings() == {}
+    assert report.get_unverifiable() == {}
+    assert report.get_clean() == {_PKG_A}
+
+
+def test_ignore_only_affects_target_package():
+    """
+    `ignore()` leaves other packages' findings untouched.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.insert_finding(_PKG_B, _WARNING_FINDING)
+    report.ignore(_PKG_A)
+    assert report.get_findings() == {_PKG_B: {_WARNING_FINDING}}
+    assert report.get_clean() == {_PKG_A}
+
+
+def test_ignore_clean_package_is_noop():
+    """
+    Ignoring a package that is already clean leaves it clean.
+    """
+    report = VerificationReport()
+    report.insert_clean(_PKG_A)
+    report.ignore(_PKG_A)
+    assert report.get_clean() == {_PKG_A}
+
+
+def test_ignore_package_appears_in_packages():
+    """
+    An ignored package remains present in `packages()` as a clean package.
+    """
+    report = VerificationReport()
+    report.insert_finding(_PKG_A, _CRITICAL_FINDING)
+    report.ignore(_PKG_A)
+    assert report.packages() == {_PKG_A}
+
+
 def test_get_findings_returns_copy():
     """
     Mutating the set returned by `get_findings()` does not affect the report's internal state.


### PR DESCRIPTION
Follow-up to this issue: #294.

Adds a CLI flag `--ignore` that suppresses findings for matching packages, matching by name or full name-version string.