### PR TITLE
:sparkles: Add scfw doctor command to troubleshoot installations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository guide
+
+Supply Chain Firewall (`scfw`) is a Go command-line application that protects package-manager operations. It resolves the packages an npm, pip, or Poetry command would install, asks the Datadog Code Security API to evaluate those packages, and then allows, warns about, or blocks the original command.
+
+## Repository structure
+
+- `scfw/main.go` is the executable entry point. Keep it limited to process-level setup and handing control to the CLI package.
+- `scfw/internal/cli` defines Cobra commands and owns user-facing command orchestration: configuration, diagnostics, package-manager selection, policy outcomes, prompts, and running the approved command.
+- `scfw/internal/build` owns build-time metadata such as the application version. Release builds inject these values through GoReleaser.
+- `scfw/internal/ddapi` owns Datadog authentication, HTTP transport, Code Security API request/response models, policy evaluation, and reporting. Package-manager-specific behavior does not belong here.
+- `scfw/internal/ecosystem` owns registry/ecosystem operations that are independent of a particular package-manager executable, such as resolving npm or PyPI publication data.
+- `scfw/internal/pm` owns the shared package and package-manager abstractions, version handling, and reusable collections. Keep this package independent of concrete package managers.
+- `scfw/internal/pm/npm`, `scfw/internal/pm/pip`, and `scfw/internal/pm/poetry` each own integration with that executable: supported commands and versions, dry-run or temporary-project behavior, output parsing, and conversion into the shared `pm.Package` model.
+- Tests live beside the code they cover as `*_test.go` files. Add or update focused tests with every behavioral change.
+- `.goreleaser.yml` is the authoritative cross-platform release-build configuration. Root-level files such as `go.mod`, `go.sum`, `Makefile`, and `.golangci.yml` define dependencies and development tooling.
+- `.github` contains CI, release, and repository automation; `images` contains documentation assets.
+
+## Structure maintenance rule
+
+Keep this guide accurate as part of every structural change. In the same change that creates, removes, renames, moves, or materially repurposes a package or top-level directory, update the structure section above to state its responsibility and boundaries. A new package must have one clear, cohesive responsibility, live at the narrowest appropriate scope, and avoid duplicating responsibilities already assigned here. If its purpose cannot be described in one concise sentence, reconsider the package boundary before adding it.
+
+Preserve the existing separation of concerns: the CLI orchestrates, `ddapi` communicates with Datadog, `ecosystem` communicates with registries, `pm` provides shared domain abstractions, and each `pm/<manager>` package implements one package-manager adapter. Do not put manager-specific parsing in `pm`, API transport in `cli`, or CLI presentation in lower-level packages.
+
+## Validation
+
+Run relevant unit tests while developing. The required build validation for every completed change is:
+
+```sh
+goreleaser build --snapshot --clean
+```
+
+Use this GoReleaser build rather than substituting `go build` or `make`; it validates the supported targets and the release-time flags defined in `.goreleaser.yml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,16 @@ Preserve the existing separation of concerns: the CLI orchestrates, `ddapi` comm
 
 ## Validation
 
-Run relevant unit tests while developing. The required build validation for every completed change is:
+Run relevant unit tests while developing. Before considering any change complete, run both repository lint targets and resolve every reported issue:
+
+```sh
+make lint
+make golangci-lint
+```
+
+Keep the local `golangci-lint` version aligned with the version used by CI. Do not skip linting because a change appears small or because focused tests pass.
+
+The required build validation for every completed change is:
 
 ```sh
 goreleaser build --snapshot --clean

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -183,26 +183,16 @@ func readManagedBlock(path string) (map[string]string, error) {
 	}
 
 	content := string(data)
-	start := strings.Index(content, blockStart)
-	if start == -1 {
-		if strings.Contains(content, blockEnd) {
-			return nil, fmt.Errorf("%s: malformed SCFW managed block: end marker without a start marker", path)
-		}
+	block, err := parseManagedBlock(content)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if !block.found {
 		return nil, nil
 	}
 
-	afterStart := start + len(blockStart)
-	endRel := strings.Index(content[afterStart:], blockEnd)
-	if endRel == -1 {
-		return nil, fmt.Errorf("%s: malformed SCFW managed block: missing end marker", path)
-	}
-	end := afterStart + endRel
-	if strings.Contains(content[end+len(blockEnd):], blockStart) {
-		return nil, fmt.Errorf("%s: multiple SCFW managed blocks found", path)
-	}
-
 	aliases := make(map[string]string)
-	for line := range strings.Lines(content[afterStart:end]) {
+	for line := range strings.Lines(content[block.contentStart:block.contentEnd]) {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "alias ") {
 			continue
@@ -226,6 +216,57 @@ const (
 	blockEnd   = "# END SCFW MANAGED BLOCK"
 )
 
+type managedBlock struct {
+	found                    bool
+	start, end               int
+	contentStart, contentEnd int
+}
+
+// parseManagedBlock validates marker ordering and returns the byte boundaries
+// of the single managed block, if present. Markers must occupy their own line.
+func parseManagedBlock(content string) (managedBlock, error) {
+	var block managedBlock
+	inside := false
+
+	for offset := 0; offset < len(content); {
+		lineStart := offset
+		lineEnd := len(content)
+		if newline := strings.IndexByte(content[offset:], '\n'); newline >= 0 {
+			lineEnd = offset + newline
+			offset = lineEnd + 1
+		} else {
+			offset = len(content)
+		}
+
+		marker := strings.TrimSpace(content[lineStart:lineEnd])
+		switch marker {
+		case blockStart:
+			if inside {
+				return managedBlock{}, fmt.Errorf("malformed SCFW managed block: nested start marker")
+			}
+			if block.found {
+				return managedBlock{}, fmt.Errorf("multiple SCFW managed blocks found")
+			}
+			block.found = true
+			block.start = lineStart
+			block.contentStart = offset
+			inside = true
+		case blockEnd:
+			if !inside {
+				return managedBlock{}, fmt.Errorf("malformed SCFW managed block: end marker without a start marker")
+			}
+			block.contentEnd = lineStart
+			block.end = offset
+			inside = false
+		}
+	}
+
+	if inside {
+		return managedBlock{}, fmt.Errorf("malformed SCFW managed block: missing end marker")
+	}
+	return block, nil
+}
+
 // mergeManagedBlock returns the contents of a shell rc file with SCFW's
 // managed block set to content. An empty content removes the block
 // entirely. original is left untouched outside the managed block.
@@ -236,11 +277,11 @@ func mergeManagedBlock(original, content string) (string, error) {
 		content = strings.TrimRight(content, "\n") + "\n"
 	}
 
-	start := strings.Index(original, blockStart)
-	if start == -1 {
-		if strings.Contains(original, blockEnd) {
-			return "", fmt.Errorf("malformed SCFW managed block: end marker without a start marker")
-		}
+	block, err := parseManagedBlock(original)
+	if err != nil {
+		return "", err
+	}
+	if !block.found {
 		if content == "" {
 			return original, nil
 		}
@@ -248,18 +289,7 @@ func mergeManagedBlock(original, content string) (string, error) {
 		return joinNonEmpty(original, blockStart+"\n"+content+blockEnd), nil
 	}
 
-	afterStart := start + len(blockStart)
-	endRel := strings.Index(original[afterStart:], blockEnd)
-	if endRel == -1 {
-		return "", fmt.Errorf("malformed SCFW managed block: missing end marker")
-	}
-	end := afterStart + endRel + len(blockEnd)
-
-	if strings.Contains(original[end:], blockStart) {
-		return "", fmt.Errorf("multiple SCFW managed blocks found")
-	}
-
-	before, after := original[:start], original[end:]
+	before, after := original[:block.start], original[block.end:]
 
 	if content == "" {
 		return joinNonEmpty(before, after), nil

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -167,6 +168,55 @@ func updateConfigFile(path, content string) error {
 		return fmt.Errorf("%s: %w", path, err)
 	}
 	return nil
+}
+
+// readManagedBlock returns the aliases defined in SCFW's managed
+// block in path. Files without a managed block (including missing files)
+// contain no managed aliases.
+func readManagedBlock(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	content := string(data)
+	start := strings.Index(content, blockStart)
+	if start == -1 {
+		if strings.Contains(content, blockEnd) {
+			return nil, fmt.Errorf("%s: malformed SCFW managed block: end marker without a start marker", path)
+		}
+		return nil, nil
+	}
+
+	afterStart := start + len(blockStart)
+	endRel := strings.Index(content[afterStart:], blockEnd)
+	if endRel == -1 {
+		return nil, fmt.Errorf("%s: malformed SCFW managed block: missing end marker", path)
+	}
+	end := afterStart + endRel
+	if strings.Contains(content[end+len(blockEnd):], blockStart) {
+		return nil, fmt.Errorf("%s: multiple SCFW managed blocks found", path)
+	}
+
+	aliases := make(map[string]string)
+	for line := range strings.Lines(content[afterStart:end]) {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "alias ") {
+			continue
+		}
+		name, value, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(line, "alias ")), "=")
+		if name = strings.TrimSpace(name); ok && name != "" {
+			value = strings.TrimSpace(value)
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				value = unquoted
+			}
+			aliases[name] = value
+		}
+	}
+	return aliases, nil
 }
 
 const (

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -121,6 +121,19 @@ func TestMergeManagedBlock(t *testing.T) {
 			content:  "anything",
 			wantErr:  true,
 		},
+		{
+			name: "nested start marker is an error",
+			original: blockStart + "\n" + blockStart + "\n" +
+				blockEnd + "\n" + blockEnd + "\n",
+			content: "anything",
+			wantErr: true,
+		},
+		{
+			name:     "orphaned end before a valid block is an error",
+			original: blockEnd + "\n" + existingBlock + "\n",
+			content:  "anything",
+			wantErr:  true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -380,6 +393,24 @@ func TestReadManagedBlock(t *testing.T) {
 		{name: "empty managed block", content: blockStart + "\n" + blockEnd + "\n"},
 		{name: "missing end marker", content: blockStart + "\nalias npm=command\n", wantErr: true},
 		{name: "end marker without start", content: blockEnd + "\n", wantErr: true},
+		{
+			name: "end marker before valid block",
+			content: blockEnd + "\n" + blockStart + "\n" +
+				`alias npm="scfw run -- npm"` + "\n" + blockEnd + "\n",
+			wantErr: true,
+		},
+		{
+			name: "nested start marker",
+			content: blockStart + "\n" + blockStart + "\n" +
+				`alias npm="scfw run -- npm"` + "\n" + blockEnd + "\n" + blockEnd + "\n",
+			wantErr: true,
+		},
+		{
+			name: "extra end marker after valid block",
+			content: blockStart + "\n" + `alias npm="scfw run -- npm"` + "\n" +
+				blockEnd + "\n" + blockEnd + "\n",
+			wantErr: true,
+		},
 		{
 			name: "multiple blocks",
 			content: blockStart + "\n" + blockEnd + "\n" +

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -352,6 +353,72 @@ func TestUpdateConfigFile_MalformedBlockIsError(t *testing.T) {
 
 	if err := updateConfigFile(path, "anything"); err == nil {
 		t.Fatal("updateConfigFile() = nil error, want error")
+	}
+}
+
+func TestReadManagedBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    map[string]string
+		wantErr bool
+	}{
+		{name: "no managed block", content: "alias user_alias=command\n"},
+		{
+			name: "returns managed aliases and ignores other settings",
+			content: "export BEFORE=1\n" + blockStart + "\n" +
+				`alias npm="scfw run -- npm"` + "\n" +
+				"export DD_SITE=datadoghq.eu\n" +
+				`alias pip="scfw run -- pip"` + "\n" +
+				`alias pip3="scfw run -- pip3"` + "\n" + blockEnd + "\n",
+			want: map[string]string{
+				"npm":  "scfw run -- npm",
+				"pip":  "scfw run -- pip",
+				"pip3": "scfw run -- pip3",
+			},
+		},
+		{name: "empty managed block", content: blockStart + "\n" + blockEnd + "\n"},
+		{name: "missing end marker", content: blockStart + "\nalias npm=command\n", wantErr: true},
+		{name: "end marker without start", content: blockEnd + "\n", wantErr: true},
+		{
+			name: "multiple blocks",
+			content: blockStart + "\n" + blockEnd + "\n" +
+				blockStart + "\n" + blockEnd + "\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".zshrc")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("failed to seed %q: %v", path, err)
+			}
+
+			got, err := readManagedBlock(path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("readManagedBlock() = %v, want error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("readManagedBlock() returned unexpected error: %v", err)
+			}
+			if !maps.Equal(got, tc.want) {
+				t.Fatalf("readManagedBlock() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadManagedBlock_MissingFile(t *testing.T) {
+	got, err := readManagedBlock(filepath.Join(t.TempDir(), ".bashrc"))
+	if err != nil {
+		t.Fatalf("readManagedBlock() returned unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("readManagedBlock() = %v, want nil", got)
 	}
 }
 

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -5,7 +5,12 @@
 
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/DataDog/supply-chain-firewall/scfw/internal/ddapi"
+	"github.com/spf13/cobra"
+)
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
@@ -16,5 +21,21 @@ var doctorCmd = &cobra.Command{
 
 func runDoctor(cmd *cobra.Command, args []string) error {
 	// Installation and configuration checks will be added here.
-	return nil
+	apiKey, appKey, apiKeyCredentialSource, appKeyCredentialSource, err := ddapi.DDCredentials()
+
+	if err != nil {
+		fmt.Printf("❌ Credentials not found with an error : %v\n", err)
+	} else {
+		if len(apiKey) == 0 {
+			fmt.Printf("❌ API Key not found in keychain nor environment\n")
+		} else {
+			fmt.Printf("✅ API Key found in %s\n", apiKeyCredentialSource)
+		}
+		if len(appKey) == 0 {
+			fmt.Printf("❌ Application Key not found in keychain nor environment\n")
+		} else {
+			fmt.Printf("✅ Application Key found in %s\n", appKeyCredentialSource)
+		}
+	}
+	return err
 }

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -75,12 +75,18 @@ func reportAliases(cmd *cobra.Command, home string) error {
 	aliasLocations := make(map[string][]string)
 	invalidAliases := make(map[string][]invalidAlias)
 	var errs []error
+	out := cmd.OutOrStdout()
+	writeReport := func(format string, args ...any) {
+		if _, err := fmt.Fprintf(out, format, args...); err != nil {
+			errs = append(errs, err)
+		}
+	}
 
 	for _, configFile := range configFiles {
 		path := filepath.Join(home, configFile)
 		aliases, err := readManagedBlock(path)
 		if err != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "⚠️ Could not read aliases from %s: %v\n", path, err)
+			writeReport("⚠️ Could not read aliases from %s: %v\n", path, err)
 			errs = append(errs, err)
 			continue
 		}
@@ -97,15 +103,14 @@ func reportAliases(cmd *cobra.Command, home string) error {
 		locations := aliasLocations[name]
 		invalid := invalidAliases[name]
 		if len(locations) == 0 && len(invalid) == 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "❌ Alias %s is not set\n", name)
+			writeReport("❌ Alias %s is not set\n", name)
 			continue
 		}
 		if len(locations) > 0 {
-			fmt.Fprintf(cmd.OutOrStdout(), "✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
+			writeReport("✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
 		}
 		for _, alias := range invalid {
-			fmt.Fprintf(
-				cmd.OutOrStdout(),
+			writeReport(
 				"❌ Alias %s in %s targets %q; expected %q\n",
 				name,
 				alias.path,
@@ -115,8 +120,7 @@ func reportAliases(cmd *cobra.Command, home string) error {
 		}
 	}
 	aliasNames := strings.Join(availableAliases, " ")
-	fmt.Fprintf(
-		cmd.OutOrStdout(),
+	writeReport(
 		"ℹ️ Run `alias %s` to check which aliases are active in the current terminal. If an alias configured above is not found, reload your terminal.\n",
 		aliasNames,
 	)

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -27,32 +27,34 @@ var doctorCmd = &cobra.Command{
 func runDoctor(cmd *cobra.Command, args []string) error {
 	apiKey, apiKeyCredentialSource, apiKeyErr := ddapi.ResolveDatadogAPIKey()
 	appKey, appKeyCredentialSource, appKeyErr := ddapi.ResolveDatadogAppKey()
-	reportCredential(cmd.OutOrStdout(), "API Key", apiKey, apiKeyCredentialSource, apiKeyErr)
-	reportCredential(cmd.OutOrStdout(), "Application Key", appKey, appKeyCredentialSource, appKeyErr)
+	apiKeyReportErr := reportCredential(cmd.OutOrStdout(), "API Key", apiKey, apiKeyCredentialSource, apiKeyErr)
+	appKeyReportErr := reportCredential(cmd.OutOrStdout(), "Application Key", appKey, appKeyCredentialSource, appKeyErr)
 	credentialErr := errors.Join(apiKeyErr, appKeyErr)
+	reportErr := errors.Join(apiKeyReportErr, appKeyReportErr)
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return errors.Join(credentialErr, fmt.Errorf("could not locate shell configuration: %w", err))
+		return errors.Join(credentialErr, reportErr, fmt.Errorf("could not locate shell configuration: %w", err))
 	}
 
 	if aliasErr := reportAliases(cmd, home); aliasErr != nil {
-		return errors.Join(credentialErr, aliasErr)
+		return errors.Join(credentialErr, reportErr, aliasErr)
 	}
 
-	return credentialErr
+	return errors.Join(credentialErr, reportErr)
 }
 
-func reportCredential(out io.Writer, name, value string, source ddapi.CredentialSource, err error) {
+func reportCredential(out io.Writer, name, value string, source ddapi.CredentialSource, err error) error {
 	if err != nil {
-		fmt.Fprintf(out, "❌ %s not found: %v\n", name, err)
-		return
+		_, writeErr := fmt.Fprintf(out, "❌ %s not found: %v\n", name, err)
+		return writeErr
 	}
 	if value == "" {
-		fmt.Fprintf(out, "❌ %s not found in keychain nor environment\n", name)
-		return
+		_, writeErr := fmt.Fprintf(out, "❌ %s not found in keychain nor environment\n", name)
+		return writeErr
 	}
-	fmt.Fprintf(out, "✅ %s found in %s\n", name, source)
+	_, writeErr := fmt.Fprintf(out, "✅ %s found in %s\n", name, source)
+	return writeErr
 }
 
 var availableAliases = []string{"npm", "pip", "pip3", "poetry"}

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -57,10 +57,21 @@ func reportCredential(out io.Writer, name, value string, source ddapi.Credential
 
 var availableAliases = []string{"npm", "pip", "pip3", "poetry"}
 
+type invalidAlias struct {
+	path   string
+	target string
+}
+
+func expectedAliasTarget(name string) string {
+	return "scfw run -- " + name
+}
+
 // reportAliases reports whether every alias supported by scfw configure is
-// present in SCFW's managed block and lists each shell config that defines it.
+// present in SCFW's managed block, targets SCFW, and lists each shell config
+// that correctly defines it.
 func reportAliases(cmd *cobra.Command, home string) error {
 	aliasLocations := make(map[string][]string)
+	invalidAliases := make(map[string][]invalidAlias)
 	var errs []error
 
 	for _, configFile := range configFiles {
@@ -71,18 +82,35 @@ func reportAliases(cmd *cobra.Command, home string) error {
 			errs = append(errs, err)
 			continue
 		}
-		for name := range aliases {
+		for name, target := range aliases {
+			if target != expectedAliasTarget(name) {
+				invalidAliases[name] = append(invalidAliases[name], invalidAlias{path: path, target: target})
+				continue
+			}
 			aliasLocations[name] = append(aliasLocations[name], path)
 		}
 	}
 
 	for _, name := range availableAliases {
 		locations := aliasLocations[name]
-		if len(locations) == 0 {
+		invalid := invalidAliases[name]
+		if len(locations) == 0 && len(invalid) == 0 {
 			fmt.Fprintf(cmd.OutOrStdout(), "❌ Alias %s is not set\n", name)
 			continue
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
+		if len(locations) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
+		}
+		for _, alias := range invalid {
+			fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"❌ Alias %s in %s targets %q; expected %q\n",
+				name,
+				alias.path,
+				alias.target,
+				expectedAliasTarget(name),
+			)
+		}
 	}
 	aliasNames := strings.Join(availableAliases, " ")
 	fmt.Fprintf(

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,23 +25,11 @@ var doctorCmd = &cobra.Command{
 }
 
 func runDoctor(cmd *cobra.Command, args []string) error {
-	// Installation and configuration checks will be added here.
-	apiKey, appKey, apiKeyCredentialSource, appKeyCredentialSource, credentialErr := ddapi.DDCredentials()
-
-	if credentialErr != nil {
-		fmt.Fprintf(cmd.OutOrStdout(), "❌ Credentials not found with an error : %v\n", credentialErr)
-	} else {
-		if len(apiKey) == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "❌ API Key not found in keychain nor environment")
-		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "✅ API Key found in %s\n", apiKeyCredentialSource)
-		}
-		if len(appKey) == 0 {
-			fmt.Fprintln(cmd.OutOrStdout(), "❌ Application Key not found in keychain nor environment")
-		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "✅ Application Key found in %s\n", appKeyCredentialSource)
-		}
-	}
+	apiKey, apiKeyCredentialSource, apiKeyErr := ddapi.ResolveDatadogAPIKey()
+	appKey, appKeyCredentialSource, appKeyErr := ddapi.ResolveDatadogAppKey()
+	reportCredential(cmd.OutOrStdout(), "API Key", apiKey, apiKeyCredentialSource, apiKeyErr)
+	reportCredential(cmd.OutOrStdout(), "Application Key", appKey, appKeyCredentialSource, appKeyErr)
+	credentialErr := errors.Join(apiKeyErr, appKeyErr)
 
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -52,6 +41,18 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	return credentialErr
+}
+
+func reportCredential(out io.Writer, name, value string, source ddapi.CredentialSource, err error) {
+	if err != nil {
+		fmt.Fprintf(out, "❌ %s not found: %v\n", name, err)
+		return
+	}
+	if value == "" {
+		fmt.Fprintf(out, "❌ %s not found in keychain nor environment\n", name)
+		return
+	}
+	fmt.Fprintf(out, "✅ %s found in %s\n", name, source)
 }
 
 var availableAliases = []string{"npm", "pip", "pip3", "poetry"}

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -83,6 +83,12 @@ func reportAliases(cmd *cobra.Command, home string) error {
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
 	}
+	aliasNames := strings.Join(availableAliases, " ")
+	fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"ℹ️ Run `alias %s` to check which aliases are active in the current terminal. If an alias configured above is not found, reload your terminal.\n",
+		aliasNames,
+	)
 
 	return errors.Join(errs...)
 }

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package cli
+
+import "github.com/spf13/cobra"
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check the Supply Chain Firewall installation and configuration.",
+	Args:  cobra.NoArgs,
+	RunE:  runDoctor,
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	// Installation and configuration checks will be added here.
+	return nil
+}

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -103,13 +103,22 @@ func reportAliases(cmd *cobra.Command, home string) error {
 		locations := aliasLocations[name]
 		invalid := invalidAliases[name]
 		if len(locations) == 0 && len(invalid) == 0 {
+			aliasErr := fmt.Errorf("alias %s is not set", name)
 			writeReport("❌ Alias %s is not set\n", name)
+			errs = append(errs, aliasErr)
 			continue
 		}
 		if len(locations) > 0 {
 			writeReport("✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
 		}
 		for _, alias := range invalid {
+			aliasErr := fmt.Errorf(
+				"alias %s in %s targets %q; expected %q",
+				name,
+				alias.path,
+				alias.target,
+				expectedAliasTarget(name),
+			)
 			writeReport(
 				"❌ Alias %s in %s targets %q; expected %q\n",
 				name,
@@ -117,6 +126,7 @@ func reportAliases(cmd *cobra.Command, home string) error {
 				alias.target,
 				expectedAliasTarget(name),
 			)
+			errs = append(errs, aliasErr)
 		}
 	}
 	aliasNames := strings.Join(availableAliases, " ")

--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -6,7 +6,11 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/DataDog/supply-chain-firewall/scfw/internal/ddapi"
 	"github.com/spf13/cobra"
@@ -21,21 +25,64 @@ var doctorCmd = &cobra.Command{
 
 func runDoctor(cmd *cobra.Command, args []string) error {
 	// Installation and configuration checks will be added here.
-	apiKey, appKey, apiKeyCredentialSource, appKeyCredentialSource, err := ddapi.DDCredentials()
+	apiKey, appKey, apiKeyCredentialSource, appKeyCredentialSource, credentialErr := ddapi.DDCredentials()
 
-	if err != nil {
-		fmt.Printf("❌ Credentials not found with an error : %v\n", err)
+	if credentialErr != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "❌ Credentials not found with an error : %v\n", credentialErr)
 	} else {
 		if len(apiKey) == 0 {
-			fmt.Printf("❌ API Key not found in keychain nor environment\n")
+			fmt.Fprintln(cmd.OutOrStdout(), "❌ API Key not found in keychain nor environment")
 		} else {
-			fmt.Printf("✅ API Key found in %s\n", apiKeyCredentialSource)
+			fmt.Fprintf(cmd.OutOrStdout(), "✅ API Key found in %s\n", apiKeyCredentialSource)
 		}
 		if len(appKey) == 0 {
-			fmt.Printf("❌ Application Key not found in keychain nor environment\n")
+			fmt.Fprintln(cmd.OutOrStdout(), "❌ Application Key not found in keychain nor environment")
 		} else {
-			fmt.Printf("✅ Application Key found in %s\n", appKeyCredentialSource)
+			fmt.Fprintf(cmd.OutOrStdout(), "✅ Application Key found in %s\n", appKeyCredentialSource)
 		}
 	}
-	return err
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return errors.Join(credentialErr, fmt.Errorf("could not locate shell configuration: %w", err))
+	}
+
+	if aliasErr := reportAliases(cmd, home); aliasErr != nil {
+		return errors.Join(credentialErr, aliasErr)
+	}
+
+	return credentialErr
+}
+
+var availableAliases = []string{"npm", "pip", "pip3", "poetry"}
+
+// reportAliases reports whether every alias supported by scfw configure is
+// present in SCFW's managed block and lists each shell config that defines it.
+func reportAliases(cmd *cobra.Command, home string) error {
+	aliasLocations := make(map[string][]string)
+	var errs []error
+
+	for _, configFile := range configFiles {
+		path := filepath.Join(home, configFile)
+		aliases, err := readManagedBlock(path)
+		if err != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "⚠️ Could not read aliases from %s: %v\n", path, err)
+			errs = append(errs, err)
+			continue
+		}
+		for name := range aliases {
+			aliasLocations[name] = append(aliasLocations[name], path)
+		}
+	}
+
+	for _, name := range availableAliases {
+		locations := aliasLocations[name]
+		if len(locations) == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "❌ Alias %s is not set\n", name)
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "✅ Alias %s is set in %s\n", name, strings.Join(locations, ", "))
+	}
+
+	return errors.Join(errs...)
 }

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -57,6 +57,7 @@ func TestReportAliases(t *testing.T) {
 		"✅ Alias pip is set in " + bashrc,
 		"❌ Alias pip3 is not set",
 		"✅ Alias poetry is set in " + zshrc,
+		"ℹ️ Run `alias npm pip pip3 poetry` to check which aliases are active in the current terminal. If an alias configured above is not found, reload your terminal.",
 	}
 	for _, want := range wantLines {
 		if !strings.Contains(output.String(), want+"\n") {

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -87,6 +87,30 @@ func TestReportAliases(t *testing.T) {
 	}
 }
 
+func TestReportAliases_RejectsAliasThatBypassesScfw(t *testing.T) {
+	home := t.TempDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	if err := os.WriteFile(bashrc, []byte(blockStart+"\n"+
+		`alias npm=npm`+"\n"+blockEnd+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", bashrc, err)
+	}
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	if err := reportAliases(cmd, home); err != nil {
+		t.Fatalf("reportAliases() returned unexpected error: %v", err)
+	}
+
+	want := `❌ Alias npm in ` + bashrc + ` targets "npm"; expected "scfw run -- npm"`
+	if !strings.Contains(output.String(), want+"\n") {
+		t.Errorf("reportAliases() output = %q, want line %q", output.String(), want)
+	}
+	if strings.Contains(output.String(), "✅ Alias npm") {
+		t.Errorf("reportAliases() marked bypassing npm alias healthy: %q", output.String())
+	}
+}
+
 func TestReportAliases_ReportsUnreadableConfigAndContinues(t *testing.T) {
 	home := t.TempDir()
 	bashrc := filepath.Join(home, ".bashrc")

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package cli
+
+import "testing"
+
+func TestDoctorCmdHasHandler(t *testing.T) {
+	if doctorCmd.Name() != "doctor" {
+		t.Fatalf("doctorCmd.Name() = %q, want doctor", doctorCmd.Name())
+	}
+	if doctorCmd.RunE == nil {
+		t.Fatal("doctor command has no RunE handler")
+	}
+}
+
+func TestDoctorCmdRejectsArguments(t *testing.T) {
+	if err := doctorCmd.Args(doctorCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("doctor command accepted an unexpected positional argument")
+	}
+}

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -5,7 +5,15 @@
 
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
 
 func TestDoctorCmdHasHandler(t *testing.T) {
 	if doctorCmd.Name() != "doctor" {
@@ -19,5 +27,63 @@ func TestDoctorCmdHasHandler(t *testing.T) {
 func TestDoctorCmdRejectsArguments(t *testing.T) {
 	if err := doctorCmd.Args(doctorCmd, []string{"unexpected"}); err == nil {
 		t.Fatal("doctor command accepted an unexpected positional argument")
+	}
+}
+
+func TestReportAliases(t *testing.T) {
+	home := t.TempDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	zshrc := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(bashrc, []byte(blockStart+"\n"+
+		`alias npm="scfw run -- npm"`+"\n"+
+		`alias pip="scfw run -- pip"`+"\n"+blockEnd+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", bashrc, err)
+	}
+	if err := os.WriteFile(zshrc, []byte(blockStart+"\n"+
+		`alias npm="scfw run -- npm"`+"\n"+
+		`alias poetry="scfw run -- poetry"`+"\n"+blockEnd+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", zshrc, err)
+	}
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	if err := reportAliases(cmd, home); err != nil {
+		t.Fatalf("reportAliases() returned unexpected error: %v", err)
+	}
+
+	wantLines := []string{
+		"✅ Alias npm is set in " + bashrc + ", " + zshrc,
+		"✅ Alias pip is set in " + bashrc,
+		"❌ Alias pip3 is not set",
+		"✅ Alias poetry is set in " + zshrc,
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(output.String(), want+"\n") {
+			t.Errorf("reportAliases() output = %q, want line %q", output.String(), want)
+		}
+	}
+}
+
+func TestReportAliases_ReportsUnreadableConfigAndContinues(t *testing.T) {
+	home := t.TempDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	if err := os.WriteFile(bashrc, []byte(blockStart+"\nalias npm=command\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", bashrc, err)
+	}
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	if err := reportAliases(cmd, home); err == nil {
+		t.Fatal("reportAliases() = nil error, want malformed-block error")
+	}
+	if !strings.Contains(output.String(), "Could not read aliases from "+bashrc) {
+		t.Fatalf("reportAliases() output = %q, want read warning for %q", output.String(), bashrc)
+	}
+	for _, name := range availableAliases {
+		if !strings.Contains(output.String(), "Alias "+name+" is not set") {
+			t.Errorf("reportAliases() output = %q, want missing status for %q", output.String(), name)
+		}
 	}
 }

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -61,7 +61,8 @@ func TestReportAliases(t *testing.T) {
 	zshrc := filepath.Join(home, ".zshrc")
 	if err := os.WriteFile(bashrc, []byte(blockStart+"\n"+
 		`alias npm="scfw run -- npm"`+"\n"+
-		`alias pip="scfw run -- pip"`+"\n"+blockEnd+"\n"), 0o644); err != nil {
+		`alias pip="scfw run -- pip"`+"\n"+
+		`alias pip3="scfw run -- pip3"`+"\n"+blockEnd+"\n"), 0o644); err != nil {
 		t.Fatalf("failed to seed %q: %v", bashrc, err)
 	}
 	if err := os.WriteFile(zshrc, []byte(blockStart+"\n"+
@@ -80,7 +81,7 @@ func TestReportAliases(t *testing.T) {
 	wantLines := []string{
 		"✅ Alias npm is set in " + bashrc + ", " + zshrc,
 		"✅ Alias pip is set in " + bashrc,
-		"❌ Alias pip3 is not set",
+		"✅ Alias pip3 is set in " + bashrc,
 		"✅ Alias poetry is set in " + zshrc,
 		"ℹ️ Run `alias npm pip pip3 poetry` to check which aliases are active in the current terminal. If an alias configured above is not found, reload your terminal.",
 	}
@@ -102,8 +103,8 @@ func TestReportAliases_RejectsAliasThatBypassesScfw(t *testing.T) {
 	var output bytes.Buffer
 	cmd := &cobra.Command{}
 	cmd.SetOut(&output)
-	if err := reportAliases(cmd, home); err != nil {
-		t.Fatalf("reportAliases() returned unexpected error: %v", err)
+	if err := reportAliases(cmd, home); err == nil {
+		t.Fatal("reportAliases() = nil error, want invalid-target error")
 	}
 
 	want := `❌ Alias npm in ` + bashrc + ` targets "npm"; expected "scfw run -- npm"`
@@ -112,6 +113,31 @@ func TestReportAliases_RejectsAliasThatBypassesScfw(t *testing.T) {
 	}
 	if strings.Contains(output.String(), "✅ Alias npm") {
 		t.Errorf("reportAliases() marked bypassing npm alias healthy: %q", output.String())
+	}
+}
+
+func TestReportAliases_ReturnsErrorForMissingAlias(t *testing.T) {
+	home := t.TempDir()
+	bashrc := filepath.Join(home, ".bashrc")
+	if err := os.WriteFile(bashrc, []byte(blockStart+"\n"+
+		`alias npm="scfw run -- npm"`+"\n"+
+		`alias pip="scfw run -- pip"`+"\n"+
+		`alias pip3="scfw run -- pip3"`+"\n"+blockEnd+"\n"), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", bashrc, err)
+	}
+
+	var output bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	err := reportAliases(cmd, home)
+	if err == nil {
+		t.Fatal("reportAliases() = nil error, want missing-alias error")
+	}
+	if !strings.Contains(err.Error(), "alias poetry is not set") {
+		t.Fatalf("reportAliases() error = %v, want missing poetry alias", err)
+	}
+	if !strings.Contains(output.String(), "❌ Alias poetry is not set\n") {
+		t.Errorf("reportAliases() output = %q, want missing poetry diagnostic", output.String())
 	}
 }
 

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -37,8 +37,12 @@ func TestReportCredentialDistinguishesCredentialErrors(t *testing.T) {
 	apiErr := errors.New("API key lookup failed")
 	appErr := errors.New("application key lookup failed")
 
-	reportCredential(&output, "API Key", "", ddapi.CredentialSourceKeychain, apiErr)
-	reportCredential(&output, "Application Key", "", ddapi.CredentialSourceKeychain, appErr)
+	if err := reportCredential(&output, "API Key", "", ddapi.CredentialSourceKeychain, apiErr); err != nil {
+		t.Fatalf("reportCredential() returned unexpected error: %v", err)
+	}
+	if err := reportCredential(&output, "Application Key", "", ddapi.CredentialSourceKeychain, appErr); err != nil {
+		t.Fatalf("reportCredential() returned unexpected error: %v", err)
+	}
 
 	wantLines := []string{
 		"❌ API Key not found: API key lookup failed",

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -7,11 +7,13 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/supply-chain-firewall/scfw/internal/ddapi"
 	"github.com/spf13/cobra"
 )
 
@@ -27,6 +29,25 @@ func TestDoctorCmdHasHandler(t *testing.T) {
 func TestDoctorCmdRejectsArguments(t *testing.T) {
 	if err := doctorCmd.Args(doctorCmd, []string{"unexpected"}); err == nil {
 		t.Fatal("doctor command accepted an unexpected positional argument")
+	}
+}
+
+func TestReportCredentialDistinguishesCredentialErrors(t *testing.T) {
+	var output bytes.Buffer
+	apiErr := errors.New("API key lookup failed")
+	appErr := errors.New("application key lookup failed")
+
+	reportCredential(&output, "API Key", "", ddapi.CredentialSourceKeychain, apiErr)
+	reportCredential(&output, "Application Key", "", ddapi.CredentialSourceKeychain, appErr)
+
+	wantLines := []string{
+		"❌ API Key not found: API key lookup failed",
+		"❌ Application Key not found: application key lookup failed",
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(output.String(), want+"\n") {
+			t.Errorf("reportCredential() output = %q, want line %q", output.String(), want)
+		}
 	}
 }
 

--- a/scfw/internal/cli/root.go
+++ b/scfw/internal/cli/root.go
@@ -47,6 +47,7 @@ func RootCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		configureCmd,
+		doctorCmd,
 		runCmd,
 	)
 

--- a/scfw/internal/ddapi/api.go
+++ b/scfw/internal/ddapi/api.go
@@ -37,7 +37,7 @@ func resolveDdSite() string {
 // Datadog credentials, logs the request/response bodies at DEBUG, and treats any
 // non-2xx status as an error.
 func postDatadogAPI(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
-	ddAPIKey, ddAppKey, err := ddCredentials()
+	ddAPIKey, ddAppKey, _, _, err := DDCredentials()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve Datadog credentials: %w", err)
 	}

--- a/scfw/internal/ddapi/api.go
+++ b/scfw/internal/ddapi/api.go
@@ -37,7 +37,7 @@ func resolveDdSite() string {
 // Datadog credentials, logs the request/response bodies at DEBUG, and treats any
 // non-2xx status as an error.
 func postDatadogAPI(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
-	ddAPIKey, ddAppKey, _, _, err := DDCredentials()
+	ddAPIKey, ddAppKey, err := ddCredentials()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve Datadog credentials: %w", err)
 	}

--- a/scfw/internal/ddapi/auth.go
+++ b/scfw/internal/ddapi/auth.go
@@ -30,31 +30,39 @@ const (
 	keychainBase64Prefix = "go-keyring-base64:"
 )
 
+// Represents where the credential have been sourced from
+type CredentialSource string
+
+const (
+	CredentialSourceKeychain CredentialSource = "Keychain"
+	CredentialSourceEnv      CredentialSource = "Environment"
+)
+
 // Return the configured Datadog API key and application key. Each is
 // resolved independently: the corresponding environment variable is
 // preferred, falling back to the system keychain if the environment
 // variable is unset or empty.
-func ddCredentials() (ddAPIKey, ddAppKey string, err error) {
-	if ddAPIKey, err = resolveCredential(KeychainAPIKeyAccount, ddAPIKeyVar); err != nil {
-		return "", "", fmt.Errorf("failed to resolve Datadog API key: %w", err)
+func DDCredentials() (ddAPIKey, ddAppKey string, apiKeyCredentialSource, appKeyCredentialSource CredentialSource, err error) {
+	if ddAPIKey, apiKeyCredentialSource, err = resolveCredential(KeychainAPIKeyAccount, ddAPIKeyVar); err != nil {
+		return "", "", apiKeyCredentialSource, "", fmt.Errorf("failed to resolve Datadog API key: %w", err)
 	}
-	if ddAppKey, err = resolveCredential(KeychainAppKeyAccount, ddAppKeyVar); err != nil {
-		return "", "", fmt.Errorf("failed to resolve Datadog application key: %w", err)
+	if ddAppKey, appKeyCredentialSource, err = resolveCredential(KeychainAppKeyAccount, ddAppKeyVar); err != nil {
+		return "", "", apiKeyCredentialSource, appKeyCredentialSource, fmt.Errorf("failed to resolve Datadog application key: %w", err)
 	}
-	return ddAPIKey, ddAppKey, nil
+	return ddAPIKey, ddAppKey, apiKeyCredentialSource, appKeyCredentialSource, nil
 }
 
 // resolveCredential returns the value of a single credential, preferring
 // envVar and falling back to the system keychain if envVar is unset or empty.
-func resolveCredential(account, envVar string) (string, error) {
+func resolveCredential(account, envVar string) (string, CredentialSource, error) {
 	if value := os.Getenv(envVar); value != "" {
-		return value, nil
+		return value, CredentialSourceEnv, nil
 	}
 	value, err := keychainSecret(account)
 	if err != nil {
-		return "", fmt.Errorf("not found in %s or keychain: %w", envVar, err)
+		return "", CredentialSourceKeychain, fmt.Errorf("not found in %s or keychain: %w", envVar, err)
 	}
-	return value, nil
+	return value, CredentialSourceKeychain, nil
 }
 
 // keyringGet indirects through keyring.Get so tests can substitute a fake.

--- a/scfw/internal/ddapi/auth.go
+++ b/scfw/internal/ddapi/auth.go
@@ -38,18 +38,36 @@ const (
 	CredentialSourceEnv      CredentialSource = "Environment"
 )
 
-// Return the configured Datadog API key and application key. Each is
+// Returns the configured Datadog API key and application key. Each is
 // resolved independently: the corresponding environment variable is
 // preferred, falling back to the system keychain if the environment
 // variable is unset or empty.
-func DDCredentials() (ddAPIKey, ddAppKey string, apiKeyCredentialSource, appKeyCredentialSource CredentialSource, err error) {
-	if ddAPIKey, apiKeyCredentialSource, err = resolveCredential(KeychainAPIKeyAccount, ddAPIKeyVar); err != nil {
-		return "", "", apiKeyCredentialSource, "", fmt.Errorf("failed to resolve Datadog API key: %w", err)
+func ddCredentials() (ddAPIKey, ddAppKey string, err error) {
+	if ddAPIKey, _, err = ResolveDatadogAPIKey(); err != nil {
+		return "", "", err
 	}
-	if ddAppKey, appKeyCredentialSource, err = resolveCredential(KeychainAppKeyAccount, ddAppKeyVar); err != nil {
-		return "", "", apiKeyCredentialSource, appKeyCredentialSource, fmt.Errorf("failed to resolve Datadog application key: %w", err)
+	if ddAppKey, _, err = ResolveDatadogAppKey(); err != nil {
+		return "", "", err
 	}
-	return ddAPIKey, ddAppKey, apiKeyCredentialSource, appKeyCredentialSource, nil
+	return ddAPIKey, ddAppKey, nil
+}
+
+// ResolveDatadogAPIKey returns the configured Datadog API key and its source.
+func ResolveDatadogAPIKey() (string, CredentialSource, error) {
+	value, source, err := resolveCredential(KeychainAPIKeyAccount, ddAPIKeyVar)
+	if err != nil {
+		return "", source, fmt.Errorf("failed to resolve Datadog API key: %w", err)
+	}
+	return value, source, nil
+}
+
+// ResolveDatadogAppKey returns the configured Datadog application key and its source.
+func ResolveDatadogAppKey() (string, CredentialSource, error) {
+	value, source, err := resolveCredential(KeychainAppKeyAccount, ddAppKeyVar)
+	if err != nil {
+		return "", source, fmt.Errorf("failed to resolve Datadog application key: %w", err)
+	}
+	return value, source, nil
 }
 
 // resolveCredential returns the value of a single credential, preferring

--- a/scfw/internal/ddapi/auth_test.go
+++ b/scfw/internal/ddapi/auth_test.go
@@ -68,15 +68,12 @@ func TestDdCredentials_EnvTakesPrecedenceOverKeychain(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
+	apiKey, appKey, err := ddCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "env-api-key" || appKey != "env-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "env-api-key", "env-app-key")
-	}
-	if apiKeySource != CredentialSourceEnv || appKeySource != CredentialSourceEnv {
-		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceEnv, CredentialSourceEnv)
 	}
 }
 
@@ -98,15 +95,12 @@ func TestDdCredentials_EachCredentialFallsBackToKeychainIndependently(t *testing
 		}
 	})
 
-	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
+	apiKey, appKey, err := ddCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "keychain-api-key" || appKey != "env-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "keychain-api-key", "env-app-key")
-	}
-	if apiKeySource != CredentialSourceKeychain || appKeySource != CredentialSourceEnv {
-		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceKeychain, CredentialSourceEnv)
 	}
 }
 
@@ -127,19 +121,16 @@ func TestDdCredentials_KeychainFallback(t *testing.T) {
 		}
 	})
 
-	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
+	apiKey, appKey, err := ddCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "keychain-api-key" || appKey != "keychain-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "keychain-api-key", "keychain-app-key")
 	}
-	if apiKeySource != CredentialSourceKeychain || appKeySource != CredentialSourceKeychain {
-		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceKeychain, CredentialSourceKeychain)
-	}
 }
 
-func TestDdCredentials_EnvPreferredEvenWithPartialKeychain(t *testing.T) {
+func TestResolveDatadogCredentials_ReturnSources(t *testing.T) {
 	withEnv(t, ddAPIKeyVar, "env-api-key")
 	withEnv(t, ddAppKeyVar, "")
 	withKeyringGet(t, func(service, account string) (string, error) {
@@ -154,15 +145,16 @@ func TestDdCredentials_EnvPreferredEvenWithPartialKeychain(t *testing.T) {
 		}
 	})
 
-	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
-	if err != nil {
-		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
+	apiKey, apiKeySource, apiKeyErr := ResolveDatadogAPIKey()
+	appKey, appKeySource, appKeyErr := ResolveDatadogAppKey()
+	if err := errors.Join(apiKeyErr, appKeyErr); err != nil {
+		t.Fatalf("credential resolvers returned unexpected error: %v", err)
 	}
 	if apiKey != "env-api-key" || appKey != "keychain-app-key" {
-		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "env-api-key", "keychain-app-key")
+		t.Fatalf("credential resolvers returned (%q, %q), want (%q, %q)", apiKey, appKey, "env-api-key", "keychain-app-key")
 	}
 	if apiKeySource != CredentialSourceEnv || appKeySource != CredentialSourceKeychain {
-		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceEnv, CredentialSourceKeychain)
+		t.Fatalf("credential resolver sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceEnv, CredentialSourceKeychain)
 	}
 }
 
@@ -173,7 +165,7 @@ func TestDdCredentials_MissingEverywhereReturnsError(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, _, _, err := DDCredentials()
+	_, _, err := ddCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -190,7 +182,7 @@ func TestDdCredentials_KeychainErrorPropagatesWhenEnvAlsoMissing(t *testing.T) {
 		return "", wantErr
 	})
 
-	if _, _, _, _, err := DDCredentials(); !errors.Is(err, wantErr) {
+	if _, _, err := ddCredentials(); !errors.Is(err, wantErr) {
 		t.Fatalf("ddCredentials() error = %v, want wrapping %v", err, wantErr)
 	}
 }
@@ -205,7 +197,7 @@ func TestDdCredentials_APIKeyLookupFailureShortCircuits(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, _, _, err := DDCredentials()
+	_, _, err := ddCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -224,7 +216,7 @@ func TestDdCredentials_AppKeyLookupFailure(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, _, _, err := DDCredentials()
+	_, _, err := ddCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -243,7 +235,7 @@ func TestDdCredentials_EmptyKeychainValueTreatedAsNotFound(t *testing.T) {
 		return "", nil
 	})
 
-	if _, _, _, _, err := DDCredentials(); !errors.Is(err, keyring.ErrNotFound) {
+	if _, _, err := ddCredentials(); !errors.Is(err, keyring.ErrNotFound) {
 		t.Fatalf("ddCredentials() error = %v, want wrapping %v", err, keyring.ErrNotFound)
 	}
 }

--- a/scfw/internal/ddapi/auth_test.go
+++ b/scfw/internal/ddapi/auth_test.go
@@ -68,12 +68,15 @@ func TestDdCredentials_EnvTakesPrecedenceOverKeychain(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	apiKey, appKey, err := ddCredentials()
+	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "env-api-key" || appKey != "env-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "env-api-key", "env-app-key")
+	}
+	if apiKeySource != CredentialSourceEnv || appKeySource != CredentialSourceEnv {
+		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceEnv, CredentialSourceEnv)
 	}
 }
 
@@ -95,12 +98,15 @@ func TestDdCredentials_EachCredentialFallsBackToKeychainIndependently(t *testing
 		}
 	})
 
-	apiKey, appKey, err := ddCredentials()
+	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "keychain-api-key" || appKey != "env-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "keychain-api-key", "env-app-key")
+	}
+	if apiKeySource != CredentialSourceKeychain || appKeySource != CredentialSourceEnv {
+		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceKeychain, CredentialSourceEnv)
 	}
 }
 
@@ -121,12 +127,15 @@ func TestDdCredentials_KeychainFallback(t *testing.T) {
 		}
 	})
 
-	apiKey, appKey, err := ddCredentials()
+	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "keychain-api-key" || appKey != "keychain-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "keychain-api-key", "keychain-app-key")
+	}
+	if apiKeySource != CredentialSourceKeychain || appKeySource != CredentialSourceKeychain {
+		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceKeychain, CredentialSourceKeychain)
 	}
 }
 
@@ -145,12 +154,15 @@ func TestDdCredentials_EnvPreferredEvenWithPartialKeychain(t *testing.T) {
 		}
 	})
 
-	apiKey, appKey, err := ddCredentials()
+	apiKey, appKey, apiKeySource, appKeySource, err := DDCredentials()
 	if err != nil {
 		t.Fatalf("ddCredentials() returned unexpected error: %v", err)
 	}
 	if apiKey != "env-api-key" || appKey != "keychain-app-key" {
 		t.Fatalf("ddCredentials() = (%q, %q), want (%q, %q)", apiKey, appKey, "env-api-key", "keychain-app-key")
+	}
+	if apiKeySource != CredentialSourceEnv || appKeySource != CredentialSourceKeychain {
+		t.Fatalf("ddCredentials() sources = (%q, %q), want (%q, %q)", apiKeySource, appKeySource, CredentialSourceEnv, CredentialSourceKeychain)
 	}
 }
 
@@ -161,7 +173,7 @@ func TestDdCredentials_MissingEverywhereReturnsError(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, err := ddCredentials()
+	_, _, _, _, err := DDCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -178,7 +190,7 @@ func TestDdCredentials_KeychainErrorPropagatesWhenEnvAlsoMissing(t *testing.T) {
 		return "", wantErr
 	})
 
-	if _, _, err := ddCredentials(); !errors.Is(err, wantErr) {
+	if _, _, _, _, err := DDCredentials(); !errors.Is(err, wantErr) {
 		t.Fatalf("ddCredentials() error = %v, want wrapping %v", err, wantErr)
 	}
 }
@@ -193,7 +205,7 @@ func TestDdCredentials_APIKeyLookupFailureShortCircuits(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, err := ddCredentials()
+	_, _, _, _, err := DDCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -212,7 +224,7 @@ func TestDdCredentials_AppKeyLookupFailure(t *testing.T) {
 		return "", keyring.ErrNotFound
 	})
 
-	_, _, err := ddCredentials()
+	_, _, _, _, err := DDCredentials()
 	if err == nil {
 		t.Fatal("ddCredentials() = nil error, want error")
 	}
@@ -231,7 +243,7 @@ func TestDdCredentials_EmptyKeychainValueTreatedAsNotFound(t *testing.T) {
 		return "", nil
 	})
 
-	if _, _, err := ddCredentials(); !errors.Is(err, keyring.ErrNotFound) {
+	if _, _, _, _, err := DDCredentials(); !errors.Is(err, keyring.ErrNotFound) {
 		t.Fatalf("ddCredentials() error = %v, want wrapping %v", err, keyring.ErrNotFound)
 	}
 }


### PR DESCRIPTION
## 🚀 Motivation
Make SCFW installation issues easier to diagnose by checking credentials and package-manager aliases from one command.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Add a scfw doctor command to troubleshoot install issues](https://datadoghq.atlassian.net/browse/K9CODESEC-5028)

## 📝 Summary
Adds a `scfw doctor` command that reports API and application key sources, inspects SCFW-managed shell aliases, and explains when the current terminal may need to be reloaded. Refactors credential resolution to expose its source, adds managed-block parsing and focused coverage, and documents repository package responsibilities and release-build validation in `AGENTS.md`.

## 🧪 Testing
- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [x] Proof that it works as expected, including profiling or UX screenshots.

<img width="1135" height="125" alt="image" src="https://github.com/user-attachments/assets/da79c1d0-e86a-4fc3-b3c2-a4ffedb22c54" />


## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: