### PR TITLE
✨ Improve SCFW help and verbose logging

### DIFF
--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -118,7 +118,14 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 			errs = append(errs, err)
 		}
 	}
-	return errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "Configuration updated. Restart your terminal for the changes to take effect."); err != nil {
+		return fmt.Errorf("scfw configure: write restart notice: %w", err)
+	}
+	return nil
 }
 
 // buildManagedBlock formats the currently selected configuration options

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -385,6 +386,26 @@ func TestRunConfigure(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(home, name)); !os.IsNotExist(err) {
 			t.Fatalf("runConfigure() created %q, want it skipped since it didn't already exist", name)
 		}
+	}
+}
+
+func TestRunConfigure_TellsUserToRestartTerminal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	withAliasPip(t, true)
+
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), nil, 0o644); err != nil {
+		t.Fatalf("failed to seed .zshrc: %v", err)
+	}
+
+	var output bytes.Buffer
+	cmd := *configureCmd
+	cmd.SetOut(&output)
+	if err := runConfigure(&cmd, nil); err != nil {
+		t.Fatalf("runConfigure() returned unexpected error: %v", err)
+	}
+	if want := "restart your terminal"; !strings.Contains(strings.ToLower(output.String()), want) {
+		t.Fatalf("configure output %q does not contain %q", output.String(), want)
 	}
 }
 

--- a/scfw/internal/cli/root.go
+++ b/scfw/internal/cli/root.go
@@ -37,7 +37,7 @@ func RootCmd() *cobra.Command {
 		Long: `Supply Chain Firewall is a Datadog tool that prevents the installation of malicious software packages.
 
 Set SCFW_VERBOSE to enable detailed progress and diagnostic logging.`,
-		Example: `  scfw configure --alias-npm --alias-pip --alias-poetry
+		Example: `  scfw configure --dd-api-key=<your-api-key> --dd-app-key=<your-app-key> --alias-npm --alias-pip --alias-poetry
   scfw run -- npm install react
   scfw run -- pip install requests`,
 		Version: build.GetVersion(),

--- a/scfw/internal/cli/root.go
+++ b/scfw/internal/cli/root.go
@@ -28,18 +28,21 @@ var logLevels = map[string]slog.Level{
 
 var logLevel string
 
+const verboseEnvVar = "SCFW_VERBOSE"
+
 func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "scfw",
-		Short:   "Supply Chain Firewall, a tool for preventing the installation of malicious software packages.",
+		Use:   "scfw",
+		Short: "Supply Chain Firewall is a Datadog tool that prevents the installation of malicious software packages.",
+		Long: `Supply Chain Firewall is a Datadog tool that prevents the installation of malicious software packages.
+
+Set SCFW_VERBOSE to enable detailed progress and diagnostic logging.`,
+		Example: `  scfw configure --alias-npm --alias-pip --alias-poetry
+  scfw run -- npm install react
+  scfw run -- pip install requests`,
 		Version: build.GetVersion(),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			level, ok := logLevels[logLevel]
-			if !ok {
-				return fmt.Errorf("invalid --log-level %q: must be one of %v", logLevel, slices.Sorted(maps.Keys(logLevels)))
-			}
-			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
-			return nil
+			return configureLogging(logLevel)
 		},
 	}
 
@@ -51,6 +54,18 @@ func RootCmd() *cobra.Command {
 	)
 
 	return cmd
+}
+
+func configureLogging(logLevel string) error {
+	level, ok := logLevels[logLevel]
+	if !ok {
+		return fmt.Errorf("invalid --log-level %q: must be one of %v", logLevel, slices.Sorted(maps.Keys(logLevels)))
+	}
+	if os.Getenv(verboseEnvVar) != "" {
+		level = slog.LevelDebug
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+	return nil
 }
 
 // Raises error if any of cmd's string flags was given a value starting with "--",

--- a/scfw/internal/cli/root_test.go
+++ b/scfw/internal/cli/root_test.go
@@ -6,11 +6,51 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestRootHelpIdentifiesDatadogAndIncludesExamples(t *testing.T) {
+	cmd := RootCmd()
+	defer cmd.RemoveCommand(configureCmd, runCmd)
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() returned unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Datadog",
+		"Examples:",
+		"scfw configure --alias-npm --alias-pip --alias-poetry",
+		"scfw run -- npm install react",
+		"scfw run -- pip install requests",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("help output %q does not contain %q", output.String(), want)
+		}
+	}
+}
+
+func TestConfigureLogging_VerboseEnvironmentEnablesDebug(t *testing.T) {
+	t.Setenv(verboseEnvVar, "true")
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	if err := configureLogging("WARNING"); err != nil {
+		t.Fatalf("configureLogging() returned unexpected error: %v", err)
+	}
+	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("SCFW_VERBOSE did not enable debug logging")
+	}
+}
 
 func TestRejectFlagLikeValues(t *testing.T) {
 	newCmd := func() *cobra.Command {

--- a/scfw/internal/cli/root_test.go
+++ b/scfw/internal/cli/root_test.go
@@ -29,7 +29,7 @@ func TestRootHelpIdentifiesDatadogAndIncludesExamples(t *testing.T) {
 	for _, want := range []string{
 		"Datadog",
 		"Examples:",
-		"scfw configure --alias-npm --alias-pip --alias-poetry",
+		"scfw configure --dd-api-key=<your-api-key> --dd-app-key=<your-app-key> --alias-npm --alias-pip --alias-poetry",
 		"scfw run -- npm install react",
 		"scfw run -- pip install requests",
 	} {

--- a/scfw/internal/cli/run.go
+++ b/scfw/internal/cli/run.go
@@ -107,6 +107,7 @@ func runFirewall(cmd *cobra.Command, args []string) error {
 
 	cmdArgs := args[cmd.ArgsLenAtDash():]
 	packageManagerName := filepath.Base(cmdArgs[0])
+	slog.Debug("preparing package manager command", "package_manager", packageManagerName, "command", cmdArgs)
 
 	packageManagerFactory, ok := findPackageManagerFactory(packageManagerName)
 	if !ok {
@@ -117,6 +118,7 @@ func runFirewall(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scfw run: %w", err)
 	}
 
+	slog.Debug("resolving package installation targets", "package_manager", packageManagerName)
 	installTargets, err := packageManager.ResolveInstallTargets(cmd.Context(), cmdArgs[1:])
 	if err != nil {
 		return fmt.Errorf("scfw run: %w", err)
@@ -130,11 +132,13 @@ func runFirewall(cmd *cobra.Command, args []string) error {
 		// there's nothing a policy decision could act on anyway.
 		evaluationReport = ddapi.ScfwPolicyEvaluationReport{Outcome: ddapi.OutcomeAllow, Results: []ddapi.PackageEvaluationResult{}}
 	} else {
+		slog.Debug("evaluating package installation targets", "count", installTargets.Len())
 		evaluationReport, err = ddapi.EvaluateInstallTargets(cmd.Context(), isInteractive, installTargets)
 		if err != nil {
 			return fmt.Errorf("scfw run: %w", err)
 		}
 	}
+	slog.Debug("resolved firewall policy outcome", "outcome", evaluationReport.Outcome)
 
 	// Explain the outcome before anything else, so the user sees why a command was
 	// blocked or flagged before any interactive prompt asks them to decide.
@@ -158,6 +162,7 @@ func runFirewall(cmd *cobra.Command, args []string) error {
 
 	switch action {
 	case ddapi.OutcomeAllow:
+		slog.Debug("running approved package manager command", "package_manager", packageManagerName)
 		if err := packageManager.RunCommand(cmd.Context(), cmdArgs[1:]); err != nil {
 			// Preserve the wrapped command's own exit code.
 			if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {

--- a/scfw/internal/pm/pip/pip.go
+++ b/scfw/internal/pm/pip/pip.go
@@ -128,9 +128,9 @@ func (pip Pip) ResolveInstallTargets(ctx context.Context, command []string) (*pm
 	output, err := exec.CommandContext(ctx, pip.Executable(), dryRunArgs...).Output()
 	if err != nil {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			// Log the failure since it's otherwise indistinguishable from a
-			// legitimate no-op install.
-			slog.Warn("pip dry-run install failed; treating as no install targets", "command", dryRunArgs, "stderr", string(exitErr.Stderr))
+			// Keep the diagnostic available in verbose mode without printing the
+			// same package-manager error before the real command runs.
+			slog.Debug("pip dry-run install failed; treating as no install targets", "command", dryRunArgs, "stderr", string(exitErr.Stderr))
 			return pm.NewSet[pm.Package](), nil
 		}
 		return nil, fmt.Errorf("failed to run pip dry-run install: %w", err)

--- a/scfw/internal/pm/pip/pip_test.go
+++ b/scfw/internal/pm/pip/pip_test.go
@@ -6,15 +6,52 @@
 package pip
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/DataDog/supply-chain-firewall/scfw/internal/ecosystem"
 	"github.com/DataDog/supply-chain-firewall/scfw/internal/pm"
 )
+
+func TestResolveInstallTargets_DryRunFailureLogsOnlyAtDebug(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "pip")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\necho 'no matching distribution' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("failed to create fake pip: %v", err)
+	}
+	pip := Pip{executable: executable, version: minPipVersion}
+
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	var warningOutput bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&warningOutput, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	if _, err := pip.ResolveInstallTargets(context.Background(), []string{"install", "missing==1.0"}); err != nil {
+		t.Fatalf("ResolveInstallTargets() returned unexpected error: %v", err)
+	}
+	if warningOutput.Len() != 0 {
+		t.Fatalf("default log output = %q, want dry-run failure suppressed to avoid duplicate package-manager errors", warningOutput.String())
+	}
+
+	var debugOutput bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&debugOutput, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	if _, err := pip.ResolveInstallTargets(context.Background(), []string{"install", "missing==1.0"}); err != nil {
+		t.Fatalf("ResolveInstallTargets() returned unexpected error: %v", err)
+	}
+	for _, want := range []string{"pip dry-run install failed", "no matching distribution"} {
+		if !strings.Contains(debugOutput.String(), want) {
+			t.Errorf("verbose log output %q does not contain %q", debugOutput.String(), want)
+		}
+	}
+}
 
 // testTarget is a small, stable, pinned PyPI package used as a dry-run
 // install target. Pinning avoids resolution drift over time.

--- a/scfw/internal/pm/poetry/poetry_test.go
+++ b/scfw/internal/pm/poetry/poetry_test.go
@@ -37,8 +37,8 @@ const poetryTarget = "idna"
 // fetched from PyPI at collection time, to avoid flakiness from a new
 // release appearing mid-run.
 const (
-	poetryTargetLatest   = "3.18"
-	poetryTargetPrevious = "3.17"
+	poetryTargetLatest   = "3.19"
+	poetryTargetPrevious = "3.18"
 )
 
 var poetryTargetRepo = "https://github.com/kjd/idna"
@@ -47,8 +47,8 @@ var poetryTargetRepo = "https://github.com/kjd/idna"
 // versions used as test targets, confirmed against the PyPI registry, so that
 // expected targets can be asserted by full equality rather than field by field.
 var testPackagePublishDates = map[string]time.Time{
-	poetryTargetPrevious: time.Date(2026, 5, 28, 14, 32, 38, 550900000, time.UTC),
-	poetryTargetLatest:   time.Date(2026, 6, 2, 14, 34, 7, 794523000, time.UTC),
+	poetryTargetPrevious: time.Date(2026, 6, 2, 14, 34, 7, 794523000, time.UTC),
+	poetryTargetLatest:   time.Date(2026, 8, 18, 5, 14, 24, 270231000, time.UTC),
 }
 
 // poetryTargetPackage returns the expected resolved pm.Package for poetryTarget
@@ -192,8 +192,8 @@ func poetryProjectTargetPreviousLooseConstraint(t *testing.T) string {
 	}
 	text := string(data)
 	// Poetry >=2.0 declares dependencies as PEP 621 strings (e.g.
-	// "idna (==3.17)"), while Poetry <2.0 uses the legacy
-	// [tool.poetry.dependencies] table syntax (e.g. idna = "3.17").
+	// "idna (==3.18)"), while Poetry <2.0 uses the legacy
+	// [tool.poetry.dependencies] table syntax (e.g. idna = "3.18").
 	// Loosen whichever form is present.
 	text = strings.ReplaceAll(text, poetryTarget+" (=="+poetryTargetPrevious+")", poetryTarget)
 	text = strings.ReplaceAll(text, poetryTarget+` = "`+poetryTargetPrevious+`"`, poetryTarget+` = "*"`)


### PR DESCRIPTION
## 🚀 Motivation

Make the SCFW CLI easier to understand and troubleshoot following bug-bash feedback about help text, duplicate errors, verbose diagnostics, and configuration guidance.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Update SCFW Go CLI --help flag and logging](https://datadoghq.atlassian.net/browse/K9CODESEC-5029)

## 📝 Summary

Clarify that SCFW is a Datadog tool and add practical usage examples to its help output. Enable debug diagnostics through `SCFW_VERBOSE`, add progress logging around package-manager evaluation, suppress duplicate pip dry-run errors at the default log level, and remind users to restart their terminal after configuration changes.

_**Note** : The poetry test update is unrelated to the motivation and is a fixed because they stopped passing due to a package update (and the test is targeting latest), what has been done is only a quick fix and a deeper look into our E2E test is planned under [K9CODESEC-5163](https://datadoghq.atlassian.net/browse/K9CODESEC-5163)_

## 🧪 Testing

- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:


[K9CODESEC-5163]: https://datadoghq.atlassian.net/browse/K9CODESEC-5163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ