### PR TITLE
Add support for uv package manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -361,6 +361,35 @@ jobs:
           make test-npm
           make test-npm-class
 
+  uv-integration:
+    name: uv-integration ${{ matrix.uv-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        uv-version: ["0.5.0", "0.6.0", "0.7.0", "0.8.0", "0.9.0", "0.10.0", "0.11.0", "0.12.0"]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ matrix.uv-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Install Supply-Chain Firewall
+        run: pip install .
+      - name: Test firewall uv integration
+        run: |
+          make test-uv
+          make test-uv-class
+
   report:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ checks: typecheck lint test
 
 coverage: test coverage-report
 
-test: test-cli test-configure test-firewall test-loggers test-npm test-npm-class test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-report test-verifiers
+test: test-cli test-configure test-firewall test-loggers test-npm test-npm-class test-pip-executable test-pip test-pip-class test-poetry test-poetry-class test-uv test-uv-class test-report test-verifiers
 
 typecheck:
 	mypy --install-types --non-interactive examples/ scfw/ tests/
@@ -68,6 +68,7 @@ coverage-report:
 	.coverage.npm .coverage.npm.class \
 	.coverage.pip.executable .coverage.pip .coverage.pip.class \
 	.coverage.poetry .coverage.poetry.class \
+	.coverage.uv .coverage.uv.class \
 	.coverage.report .coverage.verifiers
 	coverage report
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ test-poetry:
 test-poetry-class:
 	COVERAGE_FILE=.coverage.poetry.class coverage run -m pytest tests/package_managers/test_poetry_class.py
 
+test-uv:
+	COVERAGE_FILE=.coverage.uv coverage run -m pytest tests/package_managers/test_uv.py
+
+test-uv-class:
+	COVERAGE_FILE=.coverage.uv.class coverage run -m pytest tests/package_managers/test_uv_class.py
+
 test-report:
 	COVERAGE_FILE=.coverage.report coverage run -m pytest tests/test_report.py
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the `configure` command [documentation](https://github.com/DataDog/supply-ch
 | npm               | >= 7.0                | `install` (including aliases)      |
 | pip               | >= 22.2               | `install`                          |
 | poetry            | >= 1.7                | `add`, `install`, `sync`, `update` |
-| uv                | >= 0.4.1              | `sync`                             |
+| uv                | >= 0.5.0              | `sync`                             |
 
 Supply Chain Firewall may only know how to inspect some of the "installish" subcommands for its supported package managers.  These are shown in the above table.  Any other subcommands are always allowed to run.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See the `configure` command [documentation](https://github.com/DataDog/supply-ch
 | npm               | >= 7.0                | `install` (including aliases)      |
 | pip               | >= 22.2               | `install`                          |
 | poetry            | >= 1.7                | `add`, `install`, `sync`, `update` |
+| uv                | >= 0.4.1              | `sync`                             |
 
 Supply Chain Firewall may only know how to inspect some of the "installish" subcommands for its supported package managers.  These are shown in the above table.  Any other subcommands are always allowed to run.
 

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -65,6 +65,8 @@ For `pip install` commands, packages will be installed in the same environment (
 
 For `poetry`, target resolution for `add`/`update` is based entirely on the project's `pyproject.toml`/`poetry.lock`. If a project's installed environment has drifted out of sync with its lock file (e.g. the lock was regenerated or checked in separately without running `poetry install`/`sync` afterward), `scfw` has no reliable way to detect that drift, since Poetry itself does not expose the actual installed version of a package independently of what the lock file says. Keeping a project's environment in sync with its lock file is out of scope for this tool.
 
+For `uv sync` commands, target resolution is based on exporting the projects `pyproject.toml`/`uv.lock` via `uv export`. Much like `poetry`, if a project's installed environment has drifted out of sync with its lock file, `scfw` has no reliable way to detect that drift, since this resolution is based entirely on the lock file's contents rather than the environment's actual state. Keeping a project's environment in sync with its lock file is out of scope for this tool.
+
 ```bash
 $ scfw run --help
 usage: scfw run [options] COMMAND

--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -10,12 +10,12 @@ Currently, `npm` audits do not take globally installed packages into considerati
 
 ```bash
 $ scfw audit --help
-usage: scfw audit [-h] [--executable PATH] {npm,pip,poetry}
+usage: scfw audit [-h] [--executable PATH] {npm,pip,poetry,uv}
 
 Audit installed packages using Supply Chain Firewall's verifiers.
 
 positional arguments:
-  {npm,pip,poetry}   The package manager whose installed packages should be verified
+  {npm,pip,poetry,uv}   The package manager whose installed packages should be verified
 
 options:
   -h, --help         show this help message and exit
@@ -44,6 +44,7 @@ options:
   --alias-npm           Add shell aliases to always run npm commands through Supply Chain Firewall
   --alias-pip           Add shell aliases to always run pip commands through Supply Chain Firewall
   --alias-poetry        Add shell aliases to always run Poetry commands through Supply Chain Firewall
+  --alias-uv            Add shell aliases to always run uv commands through Supply Chain Firewall
   --dd-agent-port PORT  Configure log forwarding to the local Datadog Agent on the given port
   --dd-api-key KEY      API key for forwarding logs to the Datadog HTTP API or Code Security
   --dd-app-key KEY      Application key for forwarding logs to Datadog Code Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ packages = [
     "scfw.package_managers",
     "scfw.package_managers.npm",
     "scfw.package_managers.poetry",
+    "scfw.package_managers.uv",
     "scfw.verifiers",
     "scfw.verifiers.age_verifier",
     "scfw.verifiers.dd_verifier",

--- a/scfw/cli/__init__.py
+++ b/scfw/cli/__init__.py
@@ -78,6 +78,12 @@ def _add_configure_cli(parser: ArgumentParser):
     )
 
     parser.add_argument(
+        "--alias-uv",
+        action="store_true",
+        help="Add shell aliases to always run uv commands through Supply Chain Firewall"
+    )
+
+    parser.add_argument(
         "--dd-agent-port",
         type=str,
         default=None,

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -31,7 +31,7 @@ def remove_config() -> int:
         "alias_npm": False,
         "alias_pip": False,
         "alias_poetry": False,
-        "alias-uv": False,
+        "alias_uv": False,
         "dd_agent_port": None,
         "dd_api_key": None,
         "dd_app_key": None,
@@ -112,7 +112,7 @@ def _format_answers(answers: dict) -> str:
         config += 'alias pip="scfw run pip"\n'
     if answers.get("alias_poetry"):
         config += 'alias poetry="scfw run poetry"\n'
-    if answers.get("alias-uv"):
+    if answers.get("alias_uv"):
         config += 'alias uv="scfw run uv"\n'
     if (dd_agent_port := answers.get("dd_agent_port")):
         config += f'export {DD_AGENT_PORT_VAR}="{dd_agent_port}"\n'

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -31,6 +31,7 @@ def remove_config() -> int:
         "alias_npm": False,
         "alias_pip": False,
         "alias_poetry": False,
+        "alias-uv": False,
         "dd_agent_port": None,
         "dd_api_key": None,
         "dd_app_key": None,
@@ -111,6 +112,8 @@ def _format_answers(answers: dict) -> str:
         config += 'alias pip="scfw run pip"\n'
     if answers.get("alias_poetry"):
         config += 'alias poetry="scfw run poetry"\n'
+    if answers.get("alias-uv"):
+        config += 'alias uv="scfw run uv"\n'
     if (dd_agent_port := answers.get("dd_agent_port")):
         config += f'export {DD_AGENT_PORT_VAR}="{dd_agent_port}"\n'
     if answers.get("dd_api_logger"):

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -59,6 +59,11 @@ def get_answers() -> dict:
             default=True
         ),
         inquirer.Confirm(
+            name="alias-uv",
+            message="Would you like to set a shell alias to run all uv commands through SCFW?",
+            default=True
+        ),
+        inquirer.Confirm(
             name="dd_agent_logger",
             message="If you have the Datadog Agent installed locally, would you like to forward SCFW logs to it?",
             default=False

--- a/scfw/configure/interactive.py
+++ b/scfw/configure/interactive.py
@@ -59,7 +59,7 @@ def get_answers() -> dict:
             default=True
         ),
         inquirer.Confirm(
-            name="alias-uv",
+            name="alias_uv",
             message="Would you like to set a shell alias to run all uv commands through SCFW?",
             default=True
         ),

--- a/scfw/firewall.py
+++ b/scfw/firewall.py
@@ -13,7 +13,7 @@ from typing import Optional
 from scfw.constants import ON_WARNING_VAR
 from scfw.logger import FirewallAction, FirewallRunSummary
 from scfw.loggers import FirewallLoggers
-from scfw.package_manager import UnsupportedVersionError
+from scfw.package_manager import InstallTargetResolutionError, UnsupportedVersionError
 import scfw.package_managers as package_managers
 from scfw.report import FindingsReport, VerificationReport, show_reports
 from scfw.verifier import FindingSeverity
@@ -126,6 +126,30 @@ def run_firewall(args: Namespace) -> int:
             ),
         )
         return package_manager.run_command(args.command)
+
+    except InstallTargetResolutionError as e:
+        _log.error(e)
+        _log.error(
+            "Failed to resolve install targets safely: blocking command to prevent unverified installs"
+        )
+
+        if package_manager:
+            loggers.log_firewall_run(
+                package_manager.ecosystem(),
+                package_manager.name(),
+                package_manager.executable(),
+                FirewallRunSummary(
+                    timestamp,
+                    args.command,
+                    install_targets=None,
+                    report=None,
+                    relevant_findings=None,
+                    warning=True,
+                    action=FirewallAction.BLOCK,
+                ),
+            )
+
+        return 1 if args.error_on_block else 0
 
 
 def _determine_firewall_action(

--- a/scfw/package_manager.py
+++ b/scfw/package_manager.py
@@ -98,3 +98,11 @@ class UnsupportedVersionError(Exception):
     and run commands with unsupported versions of supported package managers.
     """
     pass
+
+
+class InstallTargetResolutionError(Exception):
+    """
+    An exception that occurs when a package manager command's installation
+    targets cannot be resolved safely for verification.
+    """
+    pass

--- a/scfw/package_managers/__init__.py
+++ b/scfw/package_managers/__init__.py
@@ -9,11 +9,13 @@ from scfw.package_manager import PackageManager
 from scfw.package_managers.npm import Npm
 from scfw.package_managers.pip import Pip
 from scfw.package_managers.poetry import Poetry
+from scfw.package_managers.uv import Uv
 
 SUPPORTED_PACKAGE_MANAGERS = [
     Npm.name(),
     Pip.name(),
     Poetry.name(),
+    Uv.name(),
 ]
 """
 Contains the command line names of supported package managers.
@@ -43,5 +45,7 @@ def get_package_manager(name: str, executable: Optional[str] = None) -> PackageM
         return Pip(executable)
     if name == Poetry.name():
         return Poetry(executable)
+    if name == Uv.name():
+        return Uv(executable)
 
     raise ValueError(f"Unsupported package manager '{name}'")

--- a/scfw/package_managers/uv/__init__.py
+++ b/scfw/package_managers/uv/__init__.py
@@ -87,7 +87,7 @@ class Uv(PackageManager):
 
     def resolve_install_targets(self, command: list[str]) -> set[Package]:
         """
-        Resolve the installationj targets of the given `uv` command.
+        Resolve the installation targets of the given `uv` command.
 
         For `uv sync`, the project's requirements are exported via `uv export` and pip
         is used to determine what packages would actually be installed.
@@ -98,7 +98,7 @@ class Uv(PackageManager):
                 are to be resolved.
 
         Returns:
-            A `set[Package]` representing the package targets that would be instlled
+            A `set[Package]` representing the package targets that would be installed
             if `command` were run.
 
         Raises:
@@ -145,7 +145,7 @@ class Uv(PackageManager):
         Return the set of `PyPI` packages installed in the active `uv `environment.
 
         Returns:
-            A `set[Package]` representing al `PyPI` packages installed in the active
+            A `set[Package]` representing all `PyPI` packages installed in the active
             `uv` environment.
 
         Raises:

--- a/scfw/package_managers/uv/__init__.py
+++ b/scfw/package_managers/uv/__init__.py
@@ -19,7 +19,7 @@ from scfw.package_managers.uv.temp_project import TemporaryUvProject
 
 _log = logging.getLogger(__name__)
 
-MIN_UV_VERSION = version_parse("0.4.1")
+MIN_UV_VERSION = version_parse("0.5.0")
 
 INSPECTED_SUBCOMMANDS: set[str] = {
     "sync",

--- a/scfw/package_managers/uv/__init__.py
+++ b/scfw/package_managers/uv/__init__.py
@@ -1,0 +1,215 @@
+"""
+Provides a `PackageManager` representation of `uv`.
+"""
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from typing import Optional
+
+from packaging.version import InvalidVersion, Version, parse as version_parse
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.package import Package
+from scfw.package_manager import InstallTargetResolutionError, PackageManager, UnsupportedVersionError
+from scfw.package_managers.uv.temp_project import TemporaryUvProject
+
+_log = logging.getLogger(__name__)
+
+MIN_UV_VERSION = version_parse("0.4.1")
+
+INSPECTED_SUBCOMMANDS: set[str] = {
+    "sync",
+}
+
+
+class Uv(PackageManager):
+    """
+    A `PackageManager` representation of `uv`.
+    """
+    def __init__(self, executable: Optional[str] = None):
+        """
+        Initialize a new `Uv` instance.
+
+        Args:
+            executable:
+                An optional path in the local filesystem to the `uv` executable to use.
+                If not provided, this value is determined by the current environment.
+
+        Raises:
+            RuntimeError: A valid executable could not be resolved.
+        """
+        executable = executable if executable else shutil.which(self.name())
+        if not executable:
+            raise RuntimeError("Failed to resolve local uv executable: is uv installed?")
+        if not os.path.isfile(executable):
+            raise RuntimeError(f"Path '{executable}' does not correspond to a regular file")
+
+        self._executable = executable
+
+    @classmethod
+    def name(cls) -> str:
+        """
+        Return the token for invoking `uv` on the command line.
+        """
+        return "uv"
+
+    @classmethod
+    def ecosystem(cls) -> ECOSYSTEM:
+        """
+        Return the ecosystem of packages managed by `uv`.
+        """
+        return ECOSYSTEM.PyPI
+
+    def executable(self) -> str:
+        """
+        Return the local filesystem path to the underlying `uv` executable.
+        """
+        return self._executable
+
+    def run_command(self, command: list[str]) -> int:
+        """
+        Run a `uv` command.
+
+        Args:
+            command: A `list[str]` containing a `uv` command to execute.
+
+        Returns:
+            An `int` return code describing the exit status of the executed `uv` command.
+
+        Raises:
+            ValueError: The given `command` is empty or not a valid `uv` command.
+        """
+        return subprocess.run(self._normalize_command(command), check=False).returncode
+
+    def resolve_install_targets(self, command: list[str]) -> set[Package]:
+        """
+        Resolve the installationj targets of the given `uv` command.
+
+        For `uv sync`, the project's requirements are exported via `uv export` and pip
+        is used to determine what packages would actually be installed.
+
+        Args:
+            command:
+                A `list[str]` representing a `uv` command whose installation targets
+                are to be resolved.
+
+        Returns:
+            A `set[Package]` representing the package targets that would be instlled
+            if `command` were run.
+
+        Raises:
+            ValueError: The given `command` is empty or not a valid `uv` command.
+            UnsupportedVersionError: The underlying `uv` executable is of an unsupported version.
+        """
+        normalized_command = self._normalize_command(command)
+        if not any(subcommand in normalized_command for subcommand in INSPECTED_SUBCOMMANDS):
+            return set()
+
+        self._check_version()
+
+        # https://docs.astral.sh/uv/reference/cli/
+        common_flags: set[str] = {
+            "-V",
+            "--version",
+            "-h",
+            "--help",
+            "--dry-run",
+        }
+        if any(opt in normalized_command for opt in common_flags):
+            return set()
+
+        try:
+            with TemporaryUvProject(self._executable) as temp_project:
+                return temp_project.resolve_via_export()
+        except subprocess.CalledProcessError as e:
+            _log.error(
+                "Encountered an error while resolving uv installation targets: %s",
+                (e.stderr or e.stdout or "").strip(),
+                exc_info=True,
+            )
+            raise InstallTargetResolutionError("Failed to resolve uv installation targets") from e
+        except Exception as e:
+            _log.error(
+                "Encountered an unexpected error while preparing temporary uv project: %s",
+                str(e),
+                exc_info=True,
+            )
+            raise InstallTargetResolutionError("Failed to prepare temporary uv project") from e
+
+    def get_installed_packages(self) -> set[Package]:
+        """
+        Return the set of `PyPI` packages installed in the active `uv `environment.
+
+        Returns:
+            A `set[Package]` representing al `PyPI` packages installed in the active
+            `uv` environment.
+
+        Raises:
+            RuntimeError: Failed to determine the installed packages.
+            UnsupportedVersionError: The underlying `uv` executable is of an unsupported version.
+        """
+        self._check_version()
+
+        try:
+            uv_pip_list_command: list[str] = [self._executable, "pip", "list", "--format", "json"]
+            result = subprocess.run(uv_pip_list_command, check=True, capture_output=True, text=True)
+
+            entries = json.loads(result.stdout)
+            return {
+                Package(ECOSYSTEM.PyPI, entry["name"], entry["version"])
+                for entry in entries
+                if entry.get("name") and entry.get("version")
+            }
+        except subprocess.CalledProcessError:
+            raise RuntimeError("Failed to determine uv installed packages")
+
+    def _check_version(self):
+        """
+        Check whether the underlying `uv` executable is of a supported version.
+
+        Raises:
+            UnsupportedVersionError: The underlying `uv` executable is of an unsupported version.
+        """
+        def get_uv_version(executable: str) -> Optional[Version]:
+            try:
+                result = subprocess.run(
+                    [executable, "--version"],
+                    check=True,
+                    text=True,
+                    capture_output=True,
+                )
+                match = re.match(r"^uv\s+(\S+)", result.stdout.strip())
+                if not match:
+                    return None
+
+                return version_parse(match.group(1))
+            except (IndexError, InvalidVersion):
+                return None
+
+        uv_version = get_uv_version(self._executable)
+        if not uv_version or uv_version < MIN_UV_VERSION:
+            raise UnsupportedVersionError(f"uv before v{MIN_UV_VERSION} is not supported")
+
+    def _normalize_command(self, command: list[str]) -> list[str]:
+        """
+        Normalize a `uv` command by replacing the `uv` token with the resolved executable path.
+
+        Args:
+            command: A `list[str]` containing a `uv` command (starting with `"uv"`).
+
+        Returns:
+            The normalized command with the executable path substituted for `"uv"`.
+
+        Raises:
+            ValueError: The given `command` is empty or not a valid `uv` command.
+        """
+        if not command:
+            raise ValueError("Received empty uv command line")
+        if command[0] != self.name():
+            raise ValueError("Received invalid uv command line")
+
+        return [self._executable] + command[1:]

--- a/scfw/package_managers/uv/__init__.py
+++ b/scfw/package_managers/uv/__init__.py
@@ -14,7 +14,11 @@ from packaging.version import InvalidVersion, Version, parse as version_parse
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.package_manager import InstallTargetResolutionError, PackageManager, UnsupportedVersionError
+from scfw.package_manager import (
+    InstallTargetResolutionError,
+    PackageManager,
+    UnsupportedVersionError,
+)
 from scfw.package_managers.uv.temp_project import TemporaryUvProject
 
 _log = logging.getLogger(__name__)
@@ -22,6 +26,7 @@ _log = logging.getLogger(__name__)
 MIN_UV_VERSION = version_parse("0.5.0")
 
 INSPECTED_SUBCOMMANDS: set[str] = {
+    "add",
     "sync",
 }
 
@@ -43,6 +48,7 @@ class Uv(PackageManager):
             RuntimeError: A valid executable could not be resolved.
         """
         executable = executable if executable else shutil.which(self.name())
+
         if not executable:
             raise RuntimeError("Failed to resolve local uv executable: is uv installed?")
         if not os.path.isfile(executable):
@@ -106,10 +112,17 @@ class Uv(PackageManager):
             UnsupportedVersionError: The underlying `uv` executable is of an unsupported version.
         """
         normalized_command = self._normalize_command(command)
-        if not any(subcommand in normalized_command for subcommand in INSPECTED_SUBCOMMANDS):
-            return set()
 
-        self._check_version()
+        positional_args = [
+            arg
+            for arg in normalized_command[1:]
+            if not arg.startswith("-")
+        ]
+
+        subcommand = positional_args[0] if positional_args else None
+
+        if subcommand not in INSPECTED_SUBCOMMANDS:
+            return set()
 
         # https://docs.astral.sh/uv/reference/cli/
         common_flags: set[str] = {
@@ -119,12 +132,22 @@ class Uv(PackageManager):
             "--help",
             "--dry-run",
         }
+
         if any(opt in normalized_command for opt in common_flags):
             return set()
 
+        self._check_version()
+
         try:
             with TemporaryUvProject(self._executable) as temp_project:
-                return temp_project.resolve_via_export()
+                if subcommand == "add":
+                    return temp_project.resolve_add_targets(normalized_command)
+
+                if subcommand == "sync":
+                    return temp_project.resolve_sync_targets(normalized_command)
+
+                return set()
+
         except subprocess.CalledProcessError as e:
             _log.error(
                 "Encountered an error while resolving uv installation targets: %s",
@@ -155,26 +178,50 @@ class Uv(PackageManager):
         self._check_version()
 
         try:
-            uv_pip_list_command: list[str] = [self._executable, "pip", "list", "--format", "json"]
-            result = subprocess.run(uv_pip_list_command, check=True, capture_output=True, text=True)
+            uv_pip_list_command: list[str] = [
+                self._executable,
+                "pip",
+                "list",
+                "--format",
+                "json",
+            ]
+
+            result = subprocess.run(
+                uv_pip_list_command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
             entries = json.loads(result.stdout)
+
             return {
-                Package(ECOSYSTEM.PyPI, entry["name"], entry["version"])
+                Package(
+                    ECOSYSTEM.PyPI,
+                    entry["name"],
+                    entry["version"],
+                )
                 for entry in entries
                 if entry.get("name") and entry.get("version")
             }
+
         except subprocess.CalledProcessError:
-            raise RuntimeError("Failed to determine uv installed packages")
+            raise RuntimeError(
+                "Failed to determine uv installed packages"
+            )
 
     def _check_version(self):
         """
         Check whether the underlying `uv` executable is of a supported version.
 
         Raises:
-            UnsupportedVersionError: The underlying `uv` executable is of an unsupported version.
+            UnsupportedVersionError:
+                The underlying `uv` executable is of an unsupported version.
         """
-        def get_uv_version(executable: str) -> Optional[Version]:
+
+        def get_uv_version(
+            executable: str,
+        ) -> Optional[Version]:
             try:
                 result = subprocess.run(
                     [executable, "--version"],
@@ -182,7 +229,12 @@ class Uv(PackageManager):
                     text=True,
                     capture_output=True,
                 )
-                match = re.match(r"^uv\s+(\S+)", result.stdout.strip())
+
+                match = re.match(
+                    r"^uv\s+(\S+)",
+                    result.stdout.strip(),
+                )
+
                 if not match:
                     return None
 

--- a/scfw/package_managers/uv/common.py
+++ b/scfw/package_managers/uv/common.py
@@ -19,15 +19,3 @@ UV_ADD_VALUE_OPTIONS: set[str] = {
     "--subdirectory",
     "--python",
 }
-
-# uv add options that do not consume a following argument
-UV_ADD_BOOLEAN_OPTIONS: set[str] = {
-    "--dev",
-    "--no-sync",
-    "--frozen",
-    "--locked",
-    "--active",
-    "--no-active",
-    "--preview",
-    "--no-preview",
-}

--- a/scfw/package_managers/uv/common.py
+++ b/scfw/package_managers/uv/common.py
@@ -19,3 +19,15 @@ UV_ADD_VALUE_OPTIONS: set[str] = {
     "--subdirectory",
     "--python",
 }
+
+ALLOW_EXPORT_PREFIXES: tuple = (
+    "--extra",
+    "--all-extras",
+    "--no-extra",
+    "--group",
+    "--only-group",
+    "--no-group",
+    "--all-groups",
+    "--dev",
+    "--no-dev",
+)

--- a/scfw/package_managers/uv/common.py
+++ b/scfw/package_managers/uv/common.py
@@ -2,9 +2,6 @@
 Provides common definitions related to uv.
 """
 
-# uv creates virtual environment inside the project directory by default
-VIRTUAL_ENV_PREFIX = ".venv/"
-
 UV_LOCK = "uv.lock"
 PYPROJECT_TOML = "pyproject.toml"
 PYTHON_VERSION_FILE = ".python-version"

--- a/scfw/package_managers/uv/common.py
+++ b/scfw/package_managers/uv/common.py
@@ -1,0 +1,10 @@
+"""
+Provides common definitions related to uv.
+"""
+
+# uv creates virtual environment inside the project directory by default
+VIRTUAL_ENV_PREFIX = ".venv/"
+
+UV_LOCK = "uv.lock"
+PYPROJECT_TOML = "pyproject.toml"
+PYTHON_VERSION_FILE = ".python-version"

--- a/scfw/package_managers/uv/common.py
+++ b/scfw/package_managers/uv/common.py
@@ -5,3 +5,29 @@ Provides common definitions related to uv.
 UV_LOCK = "uv.lock"
 PYPROJECT_TOML = "pyproject.toml"
 PYTHON_VERSION_FILE = ".python-version"
+
+# uv add options that do consume the following argument
+UV_ADD_VALUE_OPTIONS: set[str] = {
+    "--group",
+    "--optional",
+    "--index",
+    "--default-index",
+    "--index-strategy",
+    "--branch",
+    "--tag",
+    "--rev",
+    "--subdirectory",
+    "--python",
+}
+
+# uv add options that do not consume a following argument
+UV_ADD_BOOLEAN_OPTIONS: set[str] = {
+    "--dev",
+    "--no-sync",
+    "--frozen",
+    "--locked",
+    "--active",
+    "--no-active",
+    "--preview",
+    "--no-preview",
+}

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -21,7 +21,6 @@ from scfw.package import Package
 from scfw.package_managers.uv.common import (
     PYTHON_VERSION_FILE,
     PYPROJECT_TOML,
-    UV_ADD_BOOLEAN_OPTIONS,
     UV_ADD_VALUE_OPTIONS,
     UV_LOCK,
 )
@@ -249,8 +248,8 @@ class TemporaryUvProject:
             command:
                 A normalized uv command beginning with the uv executable.
 
-            cwd:
-                Optional working directory. Defaults to the temporary project.
+        cwd:
+            Optional working directory. Defaults to the temporary project.
 
         Returns:
             The completed subprocess result.
@@ -285,7 +284,6 @@ class TemporaryUvProject:
             A set of resolved PyPI packages.
         """
         temp_dir_path = self._temp_path()
-
         requirements_file = (
             temp_dir_path
             / f".scfw-requirements-{uuid.uuid4().hex[:8]}.txt"
@@ -299,7 +297,7 @@ class TemporaryUvProject:
             "--format",
             "requirements.txt",
             "--no-hashes",
-            "--no-emit-project",
+            "--no-emit-workspace",
             *sync_flags,
             "-o",
             str(requirements_file),
@@ -309,21 +307,19 @@ class TemporaryUvProject:
 
         try:
             self._run_uv(export_command)
-
             if not requirements_file.is_file():
                 return set()
-
             return self._parse_requirements_file(requirements_file)
+        except subprocess.CalledProcessError as e:
+            _log.debug("Export failed during sync target resolution: %s", e.stderr)
+            return set()
         finally:
             requirements_file.unlink(missing_ok=True)
 
     def resolve_add_targets(self, command: list[str]) -> set[Package]:
         """
         Resolve the explicitly requested packages and their transitive
-        dependencies for `uv add`.
-
-        The dependency resolution is performed in an isolated temporary uv
-        project so that the user's project is never built or modified.
+        dependencies for `uv add` using the target project's context.
 
         Args:
             command:
@@ -333,36 +329,23 @@ class TemporaryUvProject:
             A set of resolved PyPI packages.
         """
         targets = self._extract_add_targets(command)
-
         if not targets:
             return set()
 
-        with TemporaryDirectory() as resolution_dir:
-            resolution_path = Path(resolution_dir)
-
-            self._run_uv(
-                [
-                    self._executable,
-                    "init",
-                    "--bare",
-                    "--name",
-                    "scfw-resolution",
-                ],
-                cwd=resolution_path,
-            )
-
+        temp_dir_path = self._temp_path()
+        try:
             add_command = [
                 self._executable,
                 "add",
+                "--no-sync",
                 *targets,
             ]
 
-            self._run_uv(
-                add_command,
-                cwd=resolution_path,
-            )
-
-            return self._export_project_targets(resolution_path)
+            self._run_uv(add_command, cwd=temp_dir_path)
+            return self._export_project_targets(temp_dir_path)
+        except subprocess.CalledProcessError as e:
+            _log.debug("Package resolution failed during `uv add`: %s", e.stderr)
+            return set()
 
     def _export_project_targets(self, project_path: Path) -> set[Package]:
         """
@@ -401,7 +384,9 @@ class TemporaryUvProject:
                 return set()
 
             return self._parse_requirements_file(requirements_file)
-
+        except subprocess.CalledProcessError as e:
+            _log.debug("Failed to export project targets: %s", e.stderr)
+            return set()
         finally:
             requirements_file.unlink(missing_ok=True)
 
@@ -463,11 +448,13 @@ class TemporaryUvProject:
                 targets.extend(args)
                 break
 
-            if arg in UV_ADD_VALUE_OPTIONS:
-                next(args, None)
-                continue
+            if arg.startswith("-"):
+                if "=" in arg:
+                    continue
 
-            if arg in UV_ADD_BOOLEAN_OPTIONS or arg.startswith("-"):
+                if arg in UV_ADD_VALUE_OPTIONS:
+                    next(args, None)
+
                 continue
 
             targets.append(arg)

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -1,5 +1,5 @@
 """
-Providers helpers for resolving uv project dependencies via requirements export,
+Provides helpers for resolving uv project dependencies via requirements export,
 along with a class for spinning up an ephemeral copy of a uv project to run them in.
 """
 
@@ -21,7 +21,7 @@ _log = logging.getLogger(__name__)
 class TemporaryUvProject:
     """
     Prepares a temporary uv project that duplicates a given one, allowing for executing
-    `uv` commands in the context of that project safely and withoiut affecting the original.
+    `uv` commands in the context of that project safely and without affecting the original.
 
     This class implements the context manager protocol, and indeed, the temporary resources
     needed by this class to run commands that exist only while inside a context. Invoking this

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -6,12 +6,16 @@ along with classes for spinning up ephemeral uv projects.
 import logging
 import shutil
 import subprocess
-import tomllib
 import uuid
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
 from typing import Optional
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from packaging.requirements import Requirement
 from typing_extensions import Self

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -17,12 +17,12 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-from packaging.requirements import Requirement
 from typing_extensions import Self
 
 from scfw.ecosystem import ECOSYSTEM
-from scfw.package import Package
+from scfw.package import LocalPackageSource, Package, RemotePackageSource
 from scfw.package_managers.uv.common import (
+    ALLOW_EXPORT_PREFIXES,
     PYTHON_VERSION_FILE,
     PYPROJECT_TOML,
     UV_ADD_VALUE_OPTIONS,
@@ -288,12 +288,12 @@ class TemporaryUvProject:
             A set of resolved PyPI packages.
         """
         temp_dir_path = self._temp_path()
-        requirements_file = (
-            temp_dir_path
-            / f".scfw-requirements-{uuid.uuid4().hex[:8]}.txt"
-        )
+        requirements_file = temp_dir_path / f".scfw-reqs-{uuid.uuid4().hex[:8]}.txt"
 
-        sync_flags = [arg for arg in command[1:] if arg.startswith("-")]
+        export_flags = [
+            arg for arg in command[1:]
+            if any(arg.startswith(prefix) for prefix in ALLOW_EXPORT_PREFIXES)
+        ]
 
         export_command = [
             self._executable,
@@ -302,7 +302,7 @@ class TemporaryUvProject:
             "requirements.txt",
             "--no-hashes",
             "--no-emit-workspace",
-            *sync_flags,
+            *export_flags,
             "-o",
             str(requirements_file),
             "--project",
@@ -337,6 +337,11 @@ class TemporaryUvProject:
             return set()
 
         temp_dir_path = self._temp_path()
+        lock_file = temp_dir_path / UV_LOCK
+        packages_before: set[Package] = set()
+        if lock_file.is_file():
+            packages_before = self._parse_uv_lock(lock_file)
+
         try:
             add_command = [
                 self._executable,
@@ -346,53 +351,69 @@ class TemporaryUvProject:
             ]
 
             self._run_uv(add_command, cwd=temp_dir_path)
-            return self._export_project_targets(temp_dir_path)
+            packages_after = self._parse_uv_lock(lock_file)
+            before_map = {pkg.name: pkg.version for pkg in packages_before}
+
+            return {
+                pkg for pkg in packages_after
+                if pkg.name not in before_map or before_map[pkg.name] != pkg.version
+            }
         except subprocess.CalledProcessError as e:
             _log.debug("Package resolution failed during `uv add`: %s", e.stderr)
             return set()
 
-    def _export_project_targets(self, project_path: Path) -> set[Package]:
+    @staticmethod
+    def _parse_uv_lock(lock_file: Path) -> set[Package]:
         """
-        Export the resolved dependencies of a uv project and return them
-        as SCFW Package objects.
+        Parse a uv.lock file to extract resolved Package objects.
 
         Args:
-            project_path:
-                The root path of the project directory to export dependencies from.
+            lock_file: Path to the generated uv.lock file.
 
         Returns:
-            A set of resolved PyPI packages.
+            A set of resolved PyPI packages parsed from the lockfile data.
         """
-        requirements_file = (
-            project_path
-            / f".scfw-requirements-{uuid.uuid4().hex[:8]}.txt"
-        )
+        packages: set[Package] = set()
+        if not lock_file.is_file():
+            return packages
 
-        export_command = [
-            self._executable,
-            "export",
-            "--format",
-            "requirements.txt",
-            "--no-hashes",
-            "--no-emit-project",
-            "-o",
-            str(requirements_file),
-            "--project",
-            str(project_path),
-        ]
+        data = tomllib.loads(lock_file.read_text(encoding="utf-8"))
+        for pkg_data in data.get("package", []):
+            name = pkg_data.get("name")
+            version = pkg_data.get("version")
+            pkg_source = pkg_data.get("source", {})
 
-        try:
-            self._run_uv(export_command, cwd=project_path)
+            if not name or not version:
+                continue
 
-            if not requirements_file.is_file():
-                return set()
+            if isinstance(pkg_source, dict) and "virtual" in pkg_source:
+                continue
 
-            return self._parse_requirements_file(requirements_file)
-        except subprocess.CalledProcessError as e:
-            _log.debug("Failed to export project targets: %s", e.stderr)
-            return set()
-        finally:
-            requirements_file.unlink(missing_ok=True)
+            resolved_source: LocalPackageSource | RemotePackageSource | None = None
+            if wheels := pkg_data.get("wheels"):
+                if url := wheels[0].get("url"):
+                    resolved_source = RemotePackageSource(url)
+            elif sdist := pkg_data.get("sdist"):
+                if url := sdist.get("url"):
+                    resolved_source = RemotePackageSource(url)
+
+            # Fallback to registry URL
+            if resolved_source is None:
+                if isinstance(pkg_source, dict) and (registry_url := pkg_source.get("registry")):
+                    resolved_source = RemotePackageSource(registry_url)
+                else:
+                    resolved_source = RemotePackageSource("https://pypi.org/simple")
+
+            packages.add(
+                Package(
+                    ecosystem=ECOSYSTEM.PyPI,
+                    name=name,
+                    version=version,
+                    source=resolved_source,
+                )
+            )
+
+        return packages
 
     def _parse_requirements_file(self, requirements_file: Path) -> set[Package]:
         """
@@ -406,27 +427,27 @@ class TemporaryUvProject:
             A set of parsed SCFW Package targets.
         """
         packages: set[Package] = set()
+        default_source = RemotePackageSource("https://pypi.org/simple")
 
-        for raw_line in requirements_file.read_text(encoding="utf-8").splitlines():
-            line = raw_line.split("#", 1)[0].strip()
-
-            if not line or line.startswith("-"):
+        for line in requirements_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("-"):
                 continue
 
-            try:
-                req = Requirement(line)
-            except Exception:
-                _log.debug("Skipping unparseable uv requirement: %s", line)
-                continue
+            # Get package name and version
+            if "==" in line:
+                name, version = line.split("==", 1)
+                name = name.split("[")[0].strip()
+                version = version.split(";")[0].strip()
 
-            exact_versions = [
-                s.version for s in req.specifier if s.operator == "=="
-            ]
-
-            if len(exact_versions) == 1:
-                packages.add(Package(ECOSYSTEM.PyPI, req.name, exact_versions[0]))
-            else:
-                _log.debug("Skipping non-exact uv requirement: %s", line)
+                packages.add(
+                    Package(
+                        ecosystem=ECOSYSTEM.PyPI,
+                        name=name,
+                        version=version,
+                        source=default_source,
+                    )
+                )
 
         return packages
 

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -1,0 +1,160 @@
+"""
+Providers helpers for resolving uv project dependencies via requirements export,
+along with a class for spinning up an ephemeral copy of a uv project to run them in.
+"""
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import TracebackType
+from typing import Optional
+from typing_extensions import Self
+
+from scfw.package import Package
+from scfw.package_managers.uv.common import UV_LOCK, PYPROJECT_TOML, PYTHON_VERSION_FILE
+
+_log = logging.getLogger(__name__)
+
+
+class TemporaryUvProject:
+    """
+    Prepares a temporary uv project that duplicates a given one, allowing for executing
+    `uv` commands in the context of that project safely and withoiut affecting the original.
+
+    This class implements the context manager protocol, and indeed, the temporary resources
+    needed by this class to run commands that exist only while inside a context. Invoking this
+    class' methods outside of a context will result in an error.
+    """
+    def __init__(self, executable: str):
+        """
+        Initialize a new `TemporaryUvProject`.
+
+        Args:
+            executable: the path to the `uv` executable
+        """
+        self._temp_dir: Optional[TemporaryDirectory] = None
+        self._executable = executable
+
+        try:
+            self.project_root = self._get_project_root(executable)
+        except Exception as e:
+            raise RuntimeError(f"Failed to resolve uv project root: {e}")
+
+    def _get_project_root(self, executable: str) -> Optional[Path]:
+        """
+        Resolves the root directory of the current uv project.
+        """
+        try:
+            uv_project_root_command: list[str] = [executable, "workspace", "dir"]
+            uv_project_root_process = subprocess.run(
+                uv_project_root_command,
+                check=True,
+                text=True,
+                capture_output=True,
+                cwd=Path.cwd(),
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None
+
+        uv_project = uv_project_root_process.stdout.strip()
+        if not uv_project:
+            return None
+
+        project_root = Path(uv_project)
+        if (project_root / PYPROJECT_TOML).is_file():
+            return project_root
+
+        return None
+
+    def __enter__(self) -> Self:
+        """
+        Convert a `TemporaryUvProject` instance into a context manager.
+
+        Returns:
+            The given `TemporaryUvProject` instance, now as a context manager.
+        """
+        if not self.project_root:
+            raise RuntimeError("Could not resolve uv project root")
+
+        self._temp_dir = TemporaryDirectory()
+        temp_dir_path = Path(self._temp_dir.name)
+
+        try:
+            self._copy_project_files(self.project_root, temp_dir_path)
+        except Exception:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
+            raise
+
+        return self
+
+    def _copy_project_files(self, project_root: Path, temp_dir_path: Path) -> None:
+        """
+        Copies uv.lock, pyproject.toml, and other optional files to the temporary project directory.
+        """
+        orig_pyproject = project_root / PYPROJECT_TOML
+        if not orig_pyproject.is_file():
+            raise RuntimeError(f"Missing required project file: {orig_pyproject}")
+
+        shutil.copy2(orig_pyproject, temp_dir_path / PYPROJECT_TOML)
+
+        for filename in (UV_LOCK, PYTHON_VERSION_FILE):
+            orig_file = project_root / filename
+            if orig_file.is_file():
+                shutil.copy2(orig_file, temp_dir_path / filename)
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """
+        Release the underlying `TemporaryUvProject` resources on context manager exit.
+        """
+        if self._temp_dir is None:
+            _log.warning("No handle to temporary uv project directory found on context exit")
+            return
+
+        self._temp_dir.cleanup()
+        self._temp_dir = None
+
+    def resolve_via_export(self) -> set[Package]:
+        """
+        Export the requirements of a uv project referenced by `uv export` as
+        a requirements.txt file inside the temporary environment.
+        """
+        if not self._temp_dir:
+            raise RuntimeError("Cannot run commands in a temporary project environment outside of a context manager")
+
+        from scfw.package_managers.pip import Pip
+
+        temp_dir_path = Path(self._temp_dir.name)
+        requirements_file = temp_dir_path / "requirements.txt"
+
+        export_command = [
+            self._executable,
+            "export",
+            "--format",
+            "requirements.txt",
+            "--no-hashes",
+            "--no-emit-project",
+            "-o",
+            str(requirements_file),
+            "--project",
+            str(temp_dir_path),
+        ]
+
+        try:
+            subprocess.run(export_command, check=True, text=True, capture_output=True)
+        except subprocess.CalledProcessError as e:
+            _log.error("Failed to export uv project requirements: %s", e)
+            raise
+
+        if not requirements_file.is_file():
+            return set()
+
+        pip = Pip()
+        return pip.resolve_install_targets(["pip", "install", "-r", str(requirements_file)])

--- a/scfw/package_managers/uv/temp_project.py
+++ b/scfw/package_managers/uv/temp_project.py
@@ -1,68 +1,95 @@
 """
 Provides helpers for resolving uv project dependencies via requirements export,
-along with a class for spinning up an ephemeral copy of a uv project to run them in.
+along with classes for spinning up ephemeral uv projects.
 """
 
 import logging
 import shutil
 import subprocess
+import tomllib
+import uuid
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
 from typing import Optional
+
+from packaging.requirements import Requirement
 from typing_extensions import Self
 
+from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
-from scfw.package_managers.uv.common import UV_LOCK, PYPROJECT_TOML, PYTHON_VERSION_FILE
+from scfw.package_managers.uv.common import (
+    PYTHON_VERSION_FILE,
+    PYPROJECT_TOML,
+    UV_ADD_BOOLEAN_OPTIONS,
+    UV_ADD_VALUE_OPTIONS,
+    UV_LOCK,
+)
 
 _log = logging.getLogger(__name__)
 
 
 class TemporaryUvProject:
     """
-    Prepares a temporary uv project that duplicates a given one, allowing for executing
-    `uv` commands in the context of that project safely and without affecting the original.
+    Prepares a temporary copy of an existing uv project.
 
-    This class implements the context manager protocol, and indeed, the temporary resources
-    needed by this class to run commands that exist only while inside a context. Invoking this
-    class' methods outside of a context will result in an error.
+    This class is used for commands such as `uv sync`, where the dependency
+    resolution must reflect the existing project's pyproject.toml and uv.lock.
     """
+
     def __init__(self, executable: str):
         """
-        Initialize a new `TemporaryUvProject`.
+        Initialize a new TemporaryUvProject.
 
         Args:
-            executable: the path to the `uv` executable
+            executable:
+                The path to the uv executable.
         """
         self._temp_dir: Optional[TemporaryDirectory] = None
         self._executable = executable
+        self.project_root = self._get_project_root(executable)
 
-        try:
-            self.project_root = self._get_project_root(executable)
-        except Exception as e:
-            raise RuntimeError(f"Failed to resolve uv project root: {e}")
+    def _get_project_root(
+        self,
+        executable: str,
+    ) -> Optional[Path]:
+        """
+        Resolve the root directory of the current uv project.
 
-    def _get_project_root(self, executable: str) -> Optional[Path]:
-        """
-        Resolves the root directory of the current uv project.
+        Args:
+            executable:
+                The path to the uv executable.
+
+        Returns:
+            The resolved project root path if valid, otherwise None.
         """
         try:
-            uv_project_root_command: list[str] = [executable, "workspace", "dir"]
-            uv_project_root_process = subprocess.run(
-                uv_project_root_command,
+            command = [
+                executable,
+                "workspace",
+                "dir",
+            ]
+
+            result = subprocess.run(
+                command,
                 check=True,
                 text=True,
                 capture_output=True,
                 cwd=Path.cwd(),
             )
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+        ):
             return None
 
-        uv_project = uv_project_root_process.stdout.strip()
+        uv_project = result.stdout.strip()
+
         if not uv_project:
             return None
 
         project_root = Path(uv_project)
+
         if (project_root / PYPROJECT_TOML).is_file():
             return project_root
 
@@ -70,19 +97,21 @@ class TemporaryUvProject:
 
     def __enter__(self) -> Self:
         """
-        Convert a `TemporaryUvProject` instance into a context manager.
-
-        Returns:
-            The given `TemporaryUvProject` instance, now as a context manager.
+        Create the temporary project directory.
         """
         if not self.project_root:
-            raise RuntimeError("Could not resolve uv project root")
+            raise RuntimeError(
+                "Could not resolve uv project root. Ensure you are running inside a valid uv project."
+            )
 
         self._temp_dir = TemporaryDirectory()
         temp_dir_path = Path(self._temp_dir.name)
 
         try:
-            self._copy_project_files(self.project_root, temp_dir_path)
+            self._copy_project_files(
+                self.project_root,
+                temp_dir_path,
+            )
         except Exception:
             self._temp_dir.cleanup()
             self._temp_dir = None
@@ -90,20 +119,80 @@ class TemporaryUvProject:
 
         return self
 
-    def _copy_project_files(self, project_root: Path, temp_dir_path: Path) -> None:
+    def _copy_project_files(
+        self,
+        project_root: Path,
+        temp_dir_path: Path,
+    ) -> None:
         """
-        Copies uv.lock, pyproject.toml, and other optional files to the temporary project directory.
+        Copy the uv project files required for dependency resolution,
+        including workspace metadata for multi-package projects.
+
+        Args:
+            project_root:
+                The root path of the source uv project.
+            temp_dir_path:
+                The target temporary directory path.
+
+        Raises:
+            RuntimeError:
+                If the required pyproject.toml is missing from the project root.
         """
         orig_pyproject = project_root / PYPROJECT_TOML
+
         if not orig_pyproject.is_file():
-            raise RuntimeError(f"Missing required project file: {orig_pyproject}")
+            raise RuntimeError(
+                f"Missing required project file: {orig_pyproject}"
+            )
 
-        shutil.copy2(orig_pyproject, temp_dir_path / PYPROJECT_TOML)
+        shutil.copy2(
+            orig_pyproject,
+            temp_dir_path / PYPROJECT_TOML,
+        )
 
-        for filename in (UV_LOCK, PYTHON_VERSION_FILE):
+        for filename in (
+            UV_LOCK,
+            PYTHON_VERSION_FILE,
+        ):
             orig_file = project_root / filename
+
             if orig_file.is_file():
-                shutil.copy2(orig_file, temp_dir_path / filename)
+                shutil.copy2(
+                    orig_file,
+                    temp_dir_path / filename,
+                )
+
+        self._copy_workspace_metadata(project_root, temp_dir_path)
+
+    def _copy_workspace_metadata(self, project_root: Path, temp_dir_path: Path) -> None:
+        """
+        Replicate workspace member pyproject.toml files so `uv export` can resolve
+        the complete dependency graph without needing full source directory trees.
+
+        Args:
+            project_root:
+                The root path of the source uv project.
+            temp_dir_path:
+                The target temporary directory path.
+        """
+        pyproject_path = project_root / PYPROJECT_TOML
+        try:
+            with pyproject_path.open("rb") as f:
+                data = tomllib.load(f)
+        except Exception as e:
+            _log.debug("Could not parse root pyproject.toml for workspace info: %s", e)
+            return
+
+        members = data.get("tool", {}).get("uv", {}).get("workspace", {}).get("members", [])
+
+        for pattern in members:
+            for member_dir in project_root.glob(pattern):
+                member_pyproject = member_dir / PYPROJECT_TOML
+                if member_pyproject.is_file():
+                    rel_dir = member_dir.relative_to(project_root)
+                    target_dir = temp_dir_path / rel_dir
+                    target_dir.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(member_pyproject, target_dir / PYPROJECT_TOML)
 
     def __exit__(
         self,
@@ -112,27 +201,185 @@ class TemporaryUvProject:
         exc_tb: Optional[TracebackType],
     ) -> None:
         """
-        Release the underlying `TemporaryUvProject` resources on context manager exit.
+        Release the temporary project resources.
+
+        Args:
+            exc_type:
+                The exception class if an exception occurred within the context.
+            exc_val:
+                The exception instance if an exception occurred.
+            exc_tb:
+                The traceback object if an exception occurred.
         """
         if self._temp_dir is None:
-            _log.warning("No handle to temporary uv project directory found on context exit")
+            _log.warning(
+                "No handle to temporary uv project directory found "
+                "on context exit"
+            )
             return
 
         self._temp_dir.cleanup()
         self._temp_dir = None
 
-    def resolve_via_export(self) -> set[Package]:
+    def _temp_path(self) -> Path:
         """
-        Export the requirements of a uv project referenced by `uv export` as
-        a requirements.txt file inside the temporary environment.
+        Return the path to the temporary project directory.
+
+        Raises:
+            RuntimeError:
+                If called outside the context manager.
         """
         if not self._temp_dir:
-            raise RuntimeError("Cannot run commands in a temporary project environment outside of a context manager")
+            raise RuntimeError(
+                "Cannot run commands in a temporary project environment "
+                "outside of a context manager."
+            )
 
-        from scfw.package_managers.pip import Pip
+        return Path(self._temp_dir.name)
 
-        temp_dir_path = Path(self._temp_dir.name)
-        requirements_file = temp_dir_path / "requirements.txt"
+    def _run_uv(
+        self,
+        command: list[str],
+        cwd: Optional[Path] = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """
+        Run a uv command.
+
+        Args:
+            command:
+                A normalized uv command beginning with the uv executable.
+
+            cwd:
+                Optional working directory. Defaults to the temporary project.
+
+        Returns:
+            The completed subprocess result.
+        """
+        working_directory = cwd or self._temp_path()
+
+        _log.debug(
+            "Running uv command in temp project: %s",
+            " ".join(command),
+        )
+
+        return subprocess.run(
+            command,
+            check=True,
+            text=True,
+            capture_output=True,
+            cwd=working_directory,
+        )
+
+    def resolve_sync_targets(self, command: list[str]) -> set[Package]:
+        """
+        Resolve the packages that `uv sync` would synchronize.
+
+        The existing project is copied into a temporary directory and its
+        resolved dependency set is exported directly by uv.
+
+        Args:
+            command:
+                A normalized `uv sync` command.
+
+        Returns:
+            A set of resolved PyPI packages.
+        """
+        temp_dir_path = self._temp_path()
+
+        requirements_file = (
+            temp_dir_path
+            / f".scfw-requirements-{uuid.uuid4().hex[:8]}.txt"
+        )
+
+        sync_flags = [arg for arg in command[1:] if arg.startswith("-")]
+
+        export_command = [
+            self._executable,
+            "export",
+            "--format",
+            "requirements.txt",
+            "--no-hashes",
+            "--no-emit-project",
+            *sync_flags,
+            "-o",
+            str(requirements_file),
+            "--project",
+            str(temp_dir_path),
+        ]
+
+        try:
+            self._run_uv(export_command)
+
+            if not requirements_file.is_file():
+                return set()
+
+            return self._parse_requirements_file(requirements_file)
+        finally:
+            requirements_file.unlink(missing_ok=True)
+
+    def resolve_add_targets(self, command: list[str]) -> set[Package]:
+        """
+        Resolve the explicitly requested packages and their transitive
+        dependencies for `uv add`.
+
+        The dependency resolution is performed in an isolated temporary uv
+        project so that the user's project is never built or modified.
+
+        Args:
+            command:
+                A normalized `uv add` command containing package targets and flags.
+
+        Returns:
+            A set of resolved PyPI packages.
+        """
+        targets = self._extract_add_targets(command)
+
+        if not targets:
+            return set()
+
+        with TemporaryDirectory() as resolution_dir:
+            resolution_path = Path(resolution_dir)
+
+            self._run_uv(
+                [
+                    self._executable,
+                    "init",
+                    "--bare",
+                    "--name",
+                    "scfw-resolution",
+                ],
+                cwd=resolution_path,
+            )
+
+            add_command = [
+                self._executable,
+                "add",
+                *targets,
+            ]
+
+            self._run_uv(
+                add_command,
+                cwd=resolution_path,
+            )
+
+            return self._export_project_targets(resolution_path)
+
+    def _export_project_targets(self, project_path: Path) -> set[Package]:
+        """
+        Export the resolved dependencies of a uv project and return them
+        as SCFW Package objects.
+
+        Args:
+            project_path:
+                The root path of the project directory to export dependencies from.
+
+        Returns:
+            A set of resolved PyPI packages.
+        """
+        requirements_file = (
+            project_path
+            / f".scfw-requirements-{uuid.uuid4().hex[:8]}.txt"
+        )
 
         export_command = [
             self._executable,
@@ -144,17 +391,85 @@ class TemporaryUvProject:
             "-o",
             str(requirements_file),
             "--project",
-            str(temp_dir_path),
+            str(project_path),
         ]
 
         try:
-            subprocess.run(export_command, check=True, text=True, capture_output=True)
-        except subprocess.CalledProcessError as e:
-            _log.error("Failed to export uv project requirements: %s", e)
-            raise
+            self._run_uv(export_command, cwd=project_path)
 
-        if not requirements_file.is_file():
-            return set()
+            if not requirements_file.is_file():
+                return set()
 
-        pip = Pip()
-        return pip.resolve_install_targets(["pip", "install", "-r", str(requirements_file)])
+            return self._parse_requirements_file(requirements_file)
+
+        finally:
+            requirements_file.unlink(missing_ok=True)
+
+    def _parse_requirements_file(self, requirements_file: Path) -> set[Package]:
+        """
+        Parse a requirements.txt generated by uv export into Package targets.
+
+        Args:
+            requirements_file:
+                Path to the generated requirements.txt file.
+
+        Returns:
+            A set of parsed SCFW Package targets.
+        """
+        packages: set[Package] = set()
+
+        for raw_line in requirements_file.read_text(encoding="utf-8").splitlines():
+            line = raw_line.split("#", 1)[0].strip()
+
+            if not line or line.startswith("-"):
+                continue
+
+            try:
+                req = Requirement(line)
+            except Exception:
+                _log.debug("Skipping unparseable uv requirement: %s", line)
+                continue
+
+            exact_versions = [
+                s.version for s in req.specifier if s.operator == "=="
+            ]
+
+            if len(exact_versions) == 1:
+                packages.add(Package(ECOSYSTEM.PyPI, req.name, exact_versions[0]))
+            else:
+                _log.debug("Skipping non-exact uv requirement: %s", line)
+
+        return packages
+
+    def _extract_add_targets(self, command: list[str]) -> list[str]:
+        """
+        Extract explicit package targets from a `uv add` command.
+
+        Args:
+            command:
+                The argument list representing a `uv add` command.
+
+        Returns:
+            A list of positional target arguments representing requested packages.
+        """
+        if "add" not in command:
+            return []
+
+        args = iter(command[command.index("add") + 1:])
+        targets: list[str] = []
+
+        for arg in args:
+            if arg == "--":
+                targets.extend(args)
+                break
+
+            if arg in UV_ADD_VALUE_OPTIONS:
+                next(args, None)
+                continue
+
+            if arg in UV_ADD_BOOLEAN_OPTIONS or arg.startswith("-"):
+                continue
+
+            targets.append(arg)
+
+        return targets

--- a/tests/package_managers/test_uv.py
+++ b/tests/package_managers/test_uv.py
@@ -25,7 +25,7 @@ def uv_pip_list() -> str:
 
 def test_uv_version_output():
     """
-    Tests that `uv --version` has the required format and parses correctly.
+    Test that `uv --version` has the required format and parses correctly.
     """
     uv_version = subprocess.run(UV_COMMAND_PREFIX + ["--version"], check=True, text=True, capture_output=True)
     match = re.match(r"^uv\s+(\S+)", uv_version.stdout.strip())
@@ -64,7 +64,7 @@ def test_normalize_command(tmp_path: Path):
 )
 def test_uv_no_change_flags(command_line: list[str]):
     """
-    Tests that help and version flags execute without error
+    Test that help and version flags execute without error
     and do not modify the active environment state.
     """
     init_state = uv_pip_list()
@@ -81,7 +81,7 @@ def test_uv_no_change_flags(command_line: list[str]):
 )
 def test_uv_command_error(command_line: list[str]):
     """
-    Tests that invalid commands or flags raise a CalledProcessError.
+    Test that invalid commands or flags raise a CalledProcessError.
     """
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(command_line, check=True, capture_output=True)
@@ -120,7 +120,7 @@ def test_uv_export_requirements_format(tmp_path: Path):
 
 def test_uv_pip_list_json_format():
     """
-    Tests that `uv pip list --format json` produces valid, parseable JSON metadata.
+    Test that `uv pip list --format json` produces valid, parseable JSON metadata.
     """
     cmd = UV_COMMAND_PREFIX + ["pip", "list", "--format", "json"]
     proc = subprocess.run(cmd, check=True, text=True, capture_output=True)

--- a/tests/package_managers/test_uv.py
+++ b/tests/package_managers/test_uv.py
@@ -110,7 +110,7 @@ def test_uv_export_requirements_format(tmp_path: Path):
         "--format",
         "requirements.txt",
         "--no-hashes",
-        "--no-emit-project",
+        "--no-emit-workspace",
         "-o",
         str(requirements_file),
         "--project",

--- a/tests/package_managers/test_uv.py
+++ b/tests/package_managers/test_uv.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import packaging.version as version
 import pytest
 
-from scfw.package_managers.uv import Uv
+from scfw.package_managers.uv import Uv, TemporaryUvProject
+from scfw.package import RemotePackageSource
 
 UV_COMMAND_PREFIX = ["uv"]
 
@@ -139,3 +140,56 @@ def test_uv_pip_list_json_format():
         first = entries[0]
         assert "name" in first
         assert "version" in first
+
+
+def test_parse_uv_lock(tmp_path: Path):
+    """
+    Test parsing uv.lock files into Package objects under various source configurations.
+    """
+    lock_file = tmp_path / "uv.lock"
+
+    assert TemporaryUvProject._parse_uv_lock(lock_file) == set()
+
+    lock_content = """
+version = 1
+revision = 1
+
+[[package]]
+name = "my-root-pkg"
+version = "0.1.0"
+source = { virtual = "." }
+
+[[package]]
+name = "wheel-pkg"
+version = "1.2.3"
+wheels = [
+    { url = "https://custom.index/wheels/wheel_pkg-1.2.3-py3-none-any.whl" }
+]
+
+[[package]]
+name = "sdist-pkg"
+version = "2.0.0"
+sdist = { url = "https://custom.index/sdist/sdist_pkg-2.0.0.tar.gz" }
+"""
+    lock_file.write_text(lock_content, encoding="utf-8")
+
+    packages = TemporaryUvProject._parse_uv_lock(lock_file)
+
+    assert len(packages) == 2
+
+    pkg_map = {pkg.name: pkg for pkg in packages}
+
+    assert pkg_map["wheel-pkg"].version == "1.2.3"
+    assert isinstance(pkg_map["wheel-pkg"].source, RemotePackageSource)
+    assert (
+        pkg_map["wheel-pkg"].source.remote_source
+        == "https://custom.index/wheels/wheel_pkg-1.2.3-py3-none-any.whl"
+    )
+
+    # Verify sdist source resolution
+    assert pkg_map["sdist-pkg"].version == "2.0.0"
+    assert isinstance(pkg_map["sdist-pkg"].source, RemotePackageSource)
+    assert (
+        pkg_map["sdist-pkg"].source.remote_source
+        == "https://custom.index/sdist/sdist_pkg-2.0.0.tar.gz"
+    )

--- a/tests/package_managers/test_uv.py
+++ b/tests/package_managers/test_uv.py
@@ -4,13 +4,13 @@ Tests of uv's command line behavior.
 
 import json
 import re
-from pathlib import Path
 import subprocess
-
-from scfw.package_managers.uv import Uv
+from pathlib import Path
 
 import packaging.version as version
 import pytest
+
+from scfw.package_managers.uv import Uv
 
 UV_COMMAND_PREFIX = ["uv"]
 
@@ -20,14 +20,18 @@ def uv_pip_list() -> str:
     Get the state of packages installed in an active environment via uv.
     """
     uv_command_list = UV_COMMAND_PREFIX + ["pip", "list", "--format", "freeze"]
-    return subprocess.run(uv_command_list, check=True, text=True, capture_output=True).stdout.lower()
+    return subprocess.run(
+        uv_command_list, check=True, text=True, capture_output=True
+    ).stdout.lower()
 
 
 def test_uv_version_output():
     """
     Test that `uv --version` has the required format and parses correctly.
     """
-    uv_version = subprocess.run(UV_COMMAND_PREFIX + ["--version"], check=True, text=True, capture_output=True)
+    uv_version = subprocess.run(
+        UV_COMMAND_PREFIX + ["--version"], check=True, text=True, capture_output=True
+    )
     match = re.match(r"^uv\s+(\S+)", uv_version.stdout.strip())
     assert match is not None
     parsed_version = version.parse(match.group(1))
@@ -60,6 +64,8 @@ def test_normalize_command(tmp_path: Path):
         UV_COMMAND_PREFIX + ["sync", "--help"],
         UV_COMMAND_PREFIX + ["export", "-h"],
         UV_COMMAND_PREFIX + ["export", "--help"],
+        UV_COMMAND_PREFIX + ["add", "-h"],
+        UV_COMMAND_PREFIX + ["add", "--help"],
     ],
 )
 def test_uv_no_change_flags(command_line: list[str]):
@@ -77,6 +83,7 @@ def test_uv_no_change_flags(command_line: list[str]):
     [
         UV_COMMAND_PREFIX + ["export", "--format", "invalid_format_type"],
         UV_COMMAND_PREFIX + ["sync", "--invalid=flag-abc"],
+        UV_COMMAND_PREFIX + ["add", "--invalid-option-xyz"],
     ],
 )
 def test_uv_command_error(command_line: list[str]):

--- a/tests/package_managers/test_uv.py
+++ b/tests/package_managers/test_uv.py
@@ -1,0 +1,134 @@
+"""
+Tests of uv's command line behavior.
+"""
+
+import json
+import re
+from pathlib import Path
+import subprocess
+
+from scfw.package_managers.uv import Uv
+
+import packaging.version as version
+import pytest
+
+UV_COMMAND_PREFIX = ["uv"]
+
+
+def uv_pip_list() -> str:
+    """
+    Get the state of packages installed in an active environment via uv.
+    """
+    uv_command_list = UV_COMMAND_PREFIX + ["pip", "list", "--format", "freeze"]
+    return subprocess.run(uv_command_list, check=True, text=True, capture_output=True).stdout.lower()
+
+
+def test_uv_version_output():
+    """
+    Tests that `uv --version` has the required format and parses correctly.
+    """
+    uv_version = subprocess.run(UV_COMMAND_PREFIX + ["--version"], check=True, text=True, capture_output=True)
+    match = re.match(r"^uv\s+(\S+)", uv_version.stdout.strip())
+    assert match is not None
+    parsed_version = version.parse(match.group(1))
+    assert isinstance(parsed_version, version.Version)
+
+
+def test_normalize_command(tmp_path: Path):
+    """
+    Test command normalization with invalid and valid commands.
+    """
+    dummy_exe = tmp_path / "uv"
+    dummy_exe.touch()
+    uv = Uv(executable=str(dummy_exe))
+
+    assert uv._normalize_command(["uv", "sync"]) == [str(dummy_exe), "sync"]
+
+    with pytest.raises(ValueError, match="Received empty uv command"):
+        uv._normalize_command([])
+
+    with pytest.raises(ValueError, match="Received invalid uv command line"):
+        uv._normalize_command(["pip", "install"])
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    [
+        UV_COMMAND_PREFIX + ["-V"],
+        UV_COMMAND_PREFIX + ["--version"],
+        UV_COMMAND_PREFIX + ["sync", "-h"],
+        UV_COMMAND_PREFIX + ["sync", "--help"],
+        UV_COMMAND_PREFIX + ["export", "-h"],
+        UV_COMMAND_PREFIX + ["export", "--help"],
+    ],
+)
+def test_uv_no_change_flags(command_line: list[str]):
+    """
+    Tests that help and version flags execute without error
+    and do not modify the active environment state.
+    """
+    init_state = uv_pip_list()
+    subprocess.run(command_line, check=True)
+    assert uv_pip_list() == init_state
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    [
+        UV_COMMAND_PREFIX + ["export", "--format", "invalid_format_type"],
+        UV_COMMAND_PREFIX + ["sync", "--invalid=flag-abc"],
+    ],
+)
+def test_uv_command_error(command_line: list[str]):
+    """
+    Tests that invalid commands or flags raise a CalledProcessError.
+    """
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.run(command_line, check=True, capture_output=True)
+
+
+def test_uv_export_requirements_format(tmp_path: Path):
+    """
+    Test that `uv export` produces a valid requirements.txt file output.
+    """
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(
+        '[project]\nname = "test-pkg"\nversion = "0.1.0"\ndependencies = ["packaging>=20.0"]\n',
+        encoding="utf-8",
+    )
+
+    requirements_file = tmp_path / "requirements.txt"
+    export_cmd = UV_COMMAND_PREFIX + [
+        "export",
+        "--format",
+        "requirements.txt",
+        "--no-hashes",
+        "--no-emit-project",
+        "-o",
+        str(requirements_file),
+        "--project",
+        str(tmp_path),
+    ]
+
+    subprocess.run(export_cmd, check=True, capture_output=True)
+
+    assert requirements_file.is_file()
+
+    file_content = requirements_file.read_text(encoding="utf-8")
+    assert "packaging==" in file_content.lower()
+
+
+def test_uv_pip_list_json_format():
+    """
+    Tests that `uv pip list --format json` produces valid, parseable JSON metadata.
+    """
+    cmd = UV_COMMAND_PREFIX + ["pip", "list", "--format", "json"]
+    proc = subprocess.run(cmd, check=True, text=True, capture_output=True)
+
+    entries = json.loads(proc.stdout)
+    assert isinstance(entries, list)
+
+    if entries:
+        first = entries[0]
+        assert "name" in first
+        assert "version" in first

--- a/tests/package_managers/test_uv_class.py
+++ b/tests/package_managers/test_uv_class.py
@@ -49,7 +49,7 @@ def test_metadata():
 )
 def test_uv_command_resolve_install_targets(command_line: list[str], has_targets: bool, monkeypatch, tmp_path: Path):
     """
-    Tests that `Uv.resolve_install_targets` correctly identifies whether commands
+    Test that `Uv.resolve_install_targets` correctly identifies whether commands
     have installation targets or should be skipped via flags/subcommands,
     without modifying the environment.
     """
@@ -75,7 +75,7 @@ def test_uv_command_resolve_install_targets(command_line: list[str], has_targets
 
 def test_uv_get_installed_packages(monkeypatch):
     """
-    Tests that `Uv.get_installed_packages` returns the set of installed packages
+    Test that `Uv.get_installed_packages` returns the set of installed packages
     matching the environment state.
     """
     with TemporaryDirectory() as tmp:

--- a/tests/package_managers/test_uv_class.py
+++ b/tests/package_managers/test_uv_class.py
@@ -1,0 +1,98 @@
+"""
+Tests of `Uv`, the `PackageManager` subclass.
+"""
+
+import shutil
+import subprocess
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import pytest
+
+from scfw.ecosystem import ECOSYSTEM
+from scfw.package import Package
+from scfw.package_managers.uv import Uv
+from .test_uv import uv_pip_list
+
+PACKAGE_MANAGER = Uv()
+
+
+def test_executable():
+    """
+    Test whether `Uv` correctly discovers the uv executable active in the
+    current environment.
+    """
+    uv_exe = shutil.which("uv")
+    assert uv_exe and PACKAGE_MANAGER.executable() == uv_exe
+
+
+def test_metadata():
+    """
+    Test static properties of the Uv class.
+    """
+    assert PACKAGE_MANAGER.name() == "uv"
+    assert PACKAGE_MANAGER.ecosystem() == ECOSYSTEM.PyPI
+
+
+@pytest.mark.parametrize(
+    "command_line,has_targets",
+    [
+        (["uv", "sync"], True),
+        (["uv", "sync", "-h"], False),
+        (["uv", "sync", "--help"], False),
+        (["uv", "sync", "-V"], False),
+        (["uv", "sync", "--version"], False),
+        (["uv", "sync", "--dry-run"], False),
+        (["uv", "add", "requests"], False),
+        (["uv", "export", "-h"], False),
+    ],
+)
+def test_uv_command_resolve_install_targets(command_line: list[str], has_targets: bool, monkeypatch, tmp_path: Path):
+    """
+    Tests that `Uv.resolve_install_targets` correctly identifies whether commands
+    have installation targets or should be skipped via flags/subcommands,
+    without modifying the environment.
+    """
+    init_state = uv_pip_list()
+
+    if has_targets:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test-pkg"\nversion = "0.1.0"\ndependencies = ["packaging>=20.0"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        targets = PACKAGE_MANAGER.resolve_install_targets(command_line)
+        assert targets
+        assert any(pkg.name == "packaging" for pkg in targets)
+    else:
+        targets = PACKAGE_MANAGER.resolve_install_targets(command_line)
+        assert not targets
+
+    assert uv_pip_list() == init_state
+
+
+def test_uv_get_installed_packages(monkeypatch):
+    """
+    Tests that `Uv.get_installed_packages` returns the set of installed packages
+    matching the environment state.
+    """
+    with TemporaryDirectory() as tmp:
+        monkeypatch.chdir(tmp)
+        tmp_path = Path(tmp)
+        venv_dir = tmp_path / ".venv"
+
+        subprocess.run([PACKAGE_MANAGER.executable(), "venv", str(venv_dir)], check=True)
+
+        monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
+
+        subprocess.run(
+            [PACKAGE_MANAGER.executable(), "pip", "install", "packaging==24.0"],
+            check=True,
+        )
+
+        installed_packages = PACKAGE_MANAGER.get_installed_packages()
+
+        target_package = Package(ECOSYSTEM.PyPI, "packaging", "24.0")
+        assert target_package in installed_packages

--- a/tests/package_managers/test_uv_class.py
+++ b/tests/package_managers/test_uv_class.py
@@ -78,11 +78,17 @@ def test_uv_command_resolve_install_targets_sync(
     assert uv_pip_list() == init_state
 
 
-def test_uv_command_resolve_install_targets_add():
+def test_uv_command_resolve_install_targets_add(tmp_path: Path, monkeypatch):
     """
     Test that `Uv.resolve_install_targets` correctly resolves target packages
     for `uv add` commands via isolated temporary resolution environments.
     """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[project]\nname = "test-pkg"\nversion = "0.1.0"\n', encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
     init_state = uv_pip_list()
 
     command_line = ["uv", "add", "requests==2.32.3"]
@@ -121,3 +127,35 @@ def test_uv_get_installed_packages(monkeypatch):
 
         target_package = Package(ECOSYSTEM.PyPI, "packaging", "24.0")
         assert target_package in installed_packages
+
+
+@pytest.mark.parametrize(
+    "command_line,has_targets",
+    [
+        (["uv", "run", "pytest"], False),
+        (["uv", "pip", "install", "requests"], False),
+        (["uv", "tool", "run", "ruff"], False),
+        (["uv", "export"], False),
+        (["uv", "add", "requests", "-h"], False),
+        (["uv", "add", "requests", "--help"], False),
+        (["uv", "add", "requests", "-V"], False),
+        (["uv", "add", "requests", "--version"], False),
+        (["uv", "add", "requests", "--dry-run"], False),
+        (["uv"], False),
+    ],
+)
+def test_uv_command_resolve_install_targets_early_returns(
+    command_line: list[str],
+    has_targets: bool,
+):
+    """
+    Test that `Uv.resolve_install_targets` returns empty sets for uninspected
+    subcommands, bare binary execution, and early-exit flags without spawning
+    resolution environments.
+    """
+    init_state = uv_pip_list()
+
+    targets = PACKAGE_MANAGER.resolve_install_targets(command_line)
+
+    assert (bool(targets)) == has_targets
+    assert uv_pip_list() == init_state

--- a/tests/package_managers/test_uv_class.py
+++ b/tests/package_managers/test_uv_class.py
@@ -4,14 +4,15 @@ Tests of `Uv`, the `PackageManager` subclass.
 
 import shutil
 import subprocess
-from tempfile import TemporaryDirectory
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 
 from scfw.ecosystem import ECOSYSTEM
 from scfw.package import Package
 from scfw.package_managers.uv import Uv
+
 from .test_uv import uv_pip_list
 
 PACKAGE_MANAGER = Uv()
@@ -38,20 +39,24 @@ def test_metadata():
     "command_line,has_targets",
     [
         (["uv", "sync"], True),
+        (["uv", "sync", "--all-extras"], True),
         (["uv", "sync", "-h"], False),
         (["uv", "sync", "--help"], False),
         (["uv", "sync", "-V"], False),
         (["uv", "sync", "--version"], False),
         (["uv", "sync", "--dry-run"], False),
-        (["uv", "add", "requests"], False),
         (["uv", "export", "-h"], False),
     ],
 )
-def test_uv_command_resolve_install_targets(command_line: list[str], has_targets: bool, monkeypatch, tmp_path: Path):
+def test_uv_command_resolve_install_targets_sync(
+    command_line: list[str],
+    has_targets: bool,
+    monkeypatch,
+    tmp_path: Path,
+):
     """
-    Test that `Uv.resolve_install_targets` correctly identifies whether commands
-    have installation targets or should be skipped via flags/subcommands,
-    without modifying the environment.
+    Test that `Uv.resolve_install_targets` correctly resolves packages for `uv sync`
+    commands, respecting pass-through flags without altering the active environment.
     """
     init_state = uv_pip_list()
 
@@ -73,6 +78,23 @@ def test_uv_command_resolve_install_targets(command_line: list[str], has_targets
     assert uv_pip_list() == init_state
 
 
+def test_uv_command_resolve_install_targets_add():
+    """
+    Test that `Uv.resolve_install_targets` correctly resolves target packages
+    for `uv add` commands via isolated temporary resolution environments.
+    """
+    init_state = uv_pip_list()
+
+    command_line = ["uv", "add", "requests==2.32.3"]
+    targets = PACKAGE_MANAGER.resolve_install_targets(command_line)
+
+    assert targets
+    assert any(pkg.name == "requests" and pkg.version == "2.32.3" for pkg in targets)
+    assert any(pkg.name == "urllib3" for pkg in targets)
+
+    assert uv_pip_list() == init_state
+
+
 def test_uv_get_installed_packages(monkeypatch):
     """
     Test that `Uv.get_installed_packages` returns the set of installed packages
@@ -83,7 +105,10 @@ def test_uv_get_installed_packages(monkeypatch):
         tmp_path = Path(tmp)
         venv_dir = tmp_path / ".venv"
 
-        subprocess.run([PACKAGE_MANAGER.executable(), "venv", str(venv_dir)], check=True)
+        subprocess.run(
+            [PACKAGE_MANAGER.executable(), "venv", str(venv_dir)],
+            check=True,
+        )
 
         monkeypatch.setenv("VIRTUAL_ENV", str(venv_dir))
 


### PR DESCRIPTION
## Support uv package manager

Implements support for `uv` package manager with `uv sync`  and `uv add` integration.

Issue: #181 

---

### Usage

Configuring `uv` alias:

```sh
$ scfw configure
Thank you for using scfw, the Supply Chain Firewall by Datadog!

Supply Chain Firewall is a tool for preventing the installation of malicious npm and PyPI packages.

This script will walk you through setting up your environment to get the most out of scfw.
You can rerun this script at any time to update your configuration settings.

[?] Enter a directory that Supply Chain Firewall can use as a local cache (default: /home/<user>/.scfw):
[?] Would you like to set a shell alias to run all npm commands through SCFW? (Y/n):
[?] Would you like to set a shell alias to run all pip commands through SCFW? (Y/n):
[?] Would you like to set a shell alias to run all Poetry commands through SCFW? (Y/n):
[?] Would you like to set a shell alias to run all uv commands through SCFW? (Y/n):

...
...
...

$ cat ~/.zshrc 2>/dev/null || cat ~/.bashrc
# BEGIN SCFW MANAGED BLOCK
alias npm="scfw run npm"
alias pip="scfw run pip"
alias poetry="scfw run poetry"
alias uv="scfw run uv"
export SCFW_HOME="/home/<user>/.scfw"
# END SCFW MANAGED BLOCK
```

Syncing project dependencies:

```
$ uv sync
Package python-dotenv-1.1.0:
  - An OSV.dev advisory exists for package python-dotenv-1.1.0:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-2270
  - An OSV.dev advisory exists for package python-dotenv-1.1.0:
      * [Medium] https://osv.dev/vulnerability/GHSA-mf9w-mj56-hr94
Package requests-2.32.4:
  - An OSV.dev advisory exists for package requests-2.32.4:
      * [Medium] https://osv.dev/vulnerability/GHSA-gc5v-m9x4-r6x2
  - An OSV.dev advisory exists for package requests-2.32.4:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-2275
Package urllib3-2.5.0:
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1996
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-38jv-5279-wg99
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1998
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-141
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-2xpw-w6gg-jr37
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-gm62-xv2j-4w53
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1994
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-qccp-gfcp-xxvc
[?] Proceed with installation? (y/N): n


The command was blocked. No changes have been made.
```

Adding single dependency to a project:

```sh
$ uv add urllib3==2.5.0
Package urllib3-2.5.0:
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-gm62-xv2j-4w53
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1994
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1998
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-qccp-gfcp-xxvc
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-2xpw-w6gg-jr37
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-141
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1996
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-38jv-5279-wg99
[?] Proceed with installation? (y/N): n


The command was blocked. No changes have been made.
```

Piping `scfw` with optional flags when installing single dependency in a dev dependency group with `uv add`:

```sh
$ scfw --log-level DEBUG run uv add --dev urllib3==2.5.0
[SCFW] INFO: Starting Supply Chain Firewall on Sun Aug 23 16:00:29 2026
[SCFW] DEBUG: Command line: {'log_level': 'DEBUG', 'subcommand': <Subcommand.Run: 'run'>, 'package_manager': 'uv', 'dry_run': False, 'allow_on_warning': False, 'allow_unsupported': False, 'block_on_warning': False, 'error_on_block': False, 'executable': None, 'command': ['uv', 'add', '--dev', 'urllib3==2.5.0']}
[SCFW] DEBUG: Module dd_logger does not export a logger
[SCFW] INFO: Command: 'uv add --dev urllib3==2.5.0'
[SCFW] DEBUG: Running uv command in temp project: /home/<user>/.local/bin/uv init --bare --name scfw-resolution
[SCFW] DEBUG: Running uv command in temp project: /home/<user>/.local/bin/uv add urllib3==2.5.0
[SCFW] DEBUG: Running uv command in temp project: /home/<user>/.local/bin/uv export --format requirements.txt --no-hashes --no-emit-project -o /tmp/tmp_12flcnd/.scfw-requirements-76e63c73.txt --project /tmp/tmp_12flcnd
[SCFW] INFO: Command would install: [urllib3-2.5.0]
[SCFW] INFO: Using package verifiers: [PackageAgeVerifier, DatadogMaliciousPackagesVerifier, FindingsListVerifier, OsvVerifier]
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package urllib3-2.5.0: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package urllib3-2.5.0: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package urllib3-2.5.0: assuming PyPI registry source
[SCFW] INFO: Verifier DatadogMaliciousPackagesVerifier had no findings for package urllib3-2.5.0
[SCFW] WARNING: OsvVerifier: Unknown source for package urllib3-2.5.0: assuming PyPI registry source
[SCFW] INFO: Verifier FindingsListVerifier had no findings for package urllib3-2.5.0
[SCFW] INFO: Verifier PackageAgeVerifier had no findings for package urllib3-2.5.0
[SCFW] INFO: Verifier OsvVerifier had findings for package urllib3-2.5.0
[SCFW] INFO: Verification of packages complete
Package urllib3-2.5.0:
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-38jv-5279-wg99
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-141
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1994
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-2xpw-w6gg-jr37
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-qccp-gfcp-xxvc
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/GHSA-gm62-xv2j-4w53
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1996
  - An OSV.dev advisory exists for package urllib3-2.5.0:
      * [High] https://osv.dev/vulnerability/PYSEC-2026-1998
[?] Proceed with installation? (y/N): n


The command was blocked. No changes have been made.
```

Auditing all installed packages in the invoking environment:

```sh
$ scfw audit uv
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package certifi-2026.7.22: assuming PyPI registry source
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package charset-normalizer-3.5.1: assuming PyPI registry source
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package idna-3.19: assuming PyPI registry source
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package urllib3-2.7.0: assuming PyPI registry source
[SCFW] WARNING: PackageAgeVerifier: Unknown source for package requests-2.32.3: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package certifi-2026.7.22: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package charset-normalizer-3.5.1: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package urllib3-2.7.0: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package idna-3.19: assuming PyPI registry source
[SCFW] WARNING: DatadogMaliciousPackagesVerifier: Unknown source for package requests-2.32.3: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package charset-normalizer-3.5.1: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package certifi-2026.7.22: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package urllib3-2.7.0: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package idna-3.19: assuming PyPI registry source
[SCFW] WARNING: FindingsListVerifier: Unknown source for package requests-2.32.3: assuming PyPI registry source
[SCFW] WARNING: OsvVerifier: Unknown source for package certifi-2026.7.22: assuming PyPI registry source
[SCFW] WARNING: OsvVerifier: Unknown source for package idna-3.19: assuming PyPI registry source
[SCFW] WARNING: OsvVerifier: Unknown source for package charset-normalizer-3.5.1: assuming PyPI registry source
[SCFW] WARNING: OsvVerifier: Unknown source for package urllib3-2.7.0: assuming PyPI registry source
[SCFW] WARNING: OsvVerifier: Unknown source for package requests-2.32.3: assuming PyPI registry source
Package requests-2.32.3:
  - An OSV.dev advisory exists for package requests-2.32.3:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-1872
  - An OSV.dev advisory exists for package requests-2.32.3:
      * [Medium] https://osv.dev/vulnerability/GHSA-gc5v-m9x4-r6x2
  - An OSV.dev advisory exists for package requests-2.32.3:
      * [Medium] https://osv.dev/vulnerability/PYSEC-2026-2275
  - An OSV.dev advisory exists for package requests-2.32.3:
      * [Medium] https://osv.dev/vulnerability/GHSA-9hjg-9r4m-mvj7
```
