### PR TITLE
🐛 Preserve aliases across CLI configuration

### DIFF
--- a/docs/subcommands.md
+++ b/docs/subcommands.md
@@ -24,7 +24,7 @@ options:
 
 ## `scfw configure`
 
-The `configure` subcommand may be used to configure the environment with shell aliases and environment variables in order to get the most out of Supply Chain Firewall.  It may be run repeatedly to update desired configuration settings.
+The `configure` subcommand may be used to configure the environment with shell aliases and environment variables in order to get the most out of Supply Chain Firewall.  It may be run repeatedly to update desired configuration settings. Alias options are additive: aliases configured by an earlier invocation remain in place unless their corresponding `--remove-alias-*` option is passed.
 
 Selected configuration options are written to the user's pre-existing `~/.bashrc` and `~/.zshrc` files in a clearly delimited block that Supply Chain Firewall manages.  This block should never be manually edited, at the risk of breaking SCFW's ability to maintain these files and its own options successfully.
 
@@ -33,7 +33,7 @@ When run with no command-line arguments, the `configure` subcommand launches an 
 The `--remove` option may be used to remove all saved SCFW-managed configuration options.  It may not be passed with any other command-line option.
 
 ```bash
-usage: scfw configure [-h] [-r] [--alias-npm] [--alias-pip] [--alias-poetry] [--dd-agent-port PORT] [--dd-api-key KEY] [--dd-app-key KEY] [--dd-api-logger] [--dd-codesec-logger] [--dd-log-level LEVEL]
+usage: scfw configure [-h] [-r] [--alias-npm | --remove-alias-npm] [--alias-pip | --remove-alias-pip] [--alias-poetry | --remove-alias-poetry] [--dd-agent-port PORT] [--dd-api-key KEY] [--dd-app-key KEY] [--dd-api-logger] [--dd-codesec-logger] [--dd-log-level LEVEL]
                       [--dd-site SITE] [--scfw-home PATH]
 
 Configure the environment for using Supply Chain Firewall.
@@ -42,8 +42,12 @@ options:
   -h, --help            show this help message and exit
   -r, --remove          Remove all Supply Chain Firewall-managed configuration
   --alias-npm           Add shell aliases to always run npm commands through Supply Chain Firewall
+  --remove-alias-npm    Remove Supply Chain Firewall's npm shell alias
   --alias-pip           Add shell aliases to always run pip commands through Supply Chain Firewall
+  --remove-alias-pip    Remove Supply Chain Firewall's pip shell alias
   --alias-poetry        Add shell aliases to always run Poetry commands through Supply Chain Firewall
+  --remove-alias-poetry
+                        Remove Supply Chain Firewall's Poetry shell alias
   --dd-agent-port PORT  Configure log forwarding to the local Datadog Agent on the given port
   --dd-api-key KEY      API key for forwarding logs to the Datadog HTTP API or Code Security
   --dd-app-key KEY      Application key for forwarding logs to Datadog Code Security

--- a/scfw/cli/__init__.py
+++ b/scfw/cli/__init__.py
@@ -59,23 +59,52 @@ def _add_configure_cli(parser: ArgumentParser):
         help="Remove all Supply Chain Firewall-managed configuration"
     )
 
-    parser.add_argument(
+    npm_alias_group = parser.add_mutually_exclusive_group()
+    npm_alias_group.add_argument(
         "--alias-npm",
+        dest="alias_npm",
         action="store_true",
         help="Add shell aliases to always run npm commands through Supply Chain Firewall"
     )
 
-    parser.add_argument(
+    npm_alias_group.add_argument(
+        "--remove-alias-npm",
+        dest="alias_npm",
+        action="store_false",
+        help="Remove Supply Chain Firewall's npm shell alias"
+    )
+
+    pip_alias_group = parser.add_mutually_exclusive_group()
+    pip_alias_group.add_argument(
         "--alias-pip",
+        dest="alias_pip",
         action="store_true",
         help="Add shell aliases to always run pip commands through Supply Chain Firewall"
     )
 
-    parser.add_argument(
+    pip_alias_group.add_argument(
+        "--remove-alias-pip",
+        dest="alias_pip",
+        action="store_false",
+        help="Remove Supply Chain Firewall's pip shell alias"
+    )
+
+    poetry_alias_group = parser.add_mutually_exclusive_group()
+    poetry_alias_group.add_argument(
         "--alias-poetry",
+        dest="alias_poetry",
         action="store_true",
         help="Add shell aliases to always run Poetry commands through Supply Chain Firewall"
     )
+
+    poetry_alias_group.add_argument(
+        "--remove-alias-poetry",
+        dest="alias_poetry",
+        action="store_false",
+        help="Remove Supply Chain Firewall's Poetry shell alias"
+    )
+
+    parser.set_defaults(alias_npm=None, alias_pip=None, alias_poetry=None)
 
     parser.add_argument(
         "--dd-agent-port",
@@ -337,9 +366,11 @@ def _parse_command_line(argv: list[str]) -> tuple[Optional[Namespace], str]:
             args.subcommand == Subcommand.Configure
             and args.remove
             and any({
-                args.alias_npm,
-                args.alias_pip,
-                args.alias_poetry,
+                any(alias is not None for alias in (
+                    args.alias_npm,
+                    args.alias_pip,
+                    args.alias_poetry,
+                )),
                 args.dd_agent_port,
                 args.dd_api_key,
                 args.dd_app_key,

--- a/scfw/configure/__init__.py
+++ b/scfw/configure/__init__.py
@@ -45,9 +45,11 @@ def run_configure(args: Namespace) -> int:
 
     # The CLI parser guarantees that all of these arguments are present
     is_interactive = not any({
-        args.alias_npm,
-        args.alias_pip,
-        args.alias_poetry,
+        any(alias is not None for alias in (
+            args.alias_npm,
+            args.alias_pip,
+            args.alias_poetry,
+        )),
         args.dd_agent_port,
         args.dd_api_key,
         args.dd_app_key,

--- a/scfw/configure/env.py
+++ b/scfw/configure/env.py
@@ -18,6 +18,12 @@ _CONFIG_FILES = [".bashrc", ".zshrc"]
 _BLOCK_START = "# BEGIN SCFW MANAGED BLOCK"
 _BLOCK_END = "# END SCFW MANAGED BLOCK"
 
+_ALIASES = {
+    "alias_npm": 'alias npm="scfw run npm"',
+    "alias_pip": 'alias pip="scfw run pip"',
+    "alias_poetry": 'alias poetry="scfw run poetry"',
+}
+
 
 def remove_config() -> int:
     """
@@ -53,7 +59,6 @@ def update_config_files(answers: dict) -> int:
         An integer status code indicating normal or error exit.
     """
     error_count = 0
-    scfw_config = _format_answers(answers)
 
     for config_file in [Path.home() / file for file in _CONFIG_FILES]:
         if not config_file.exists():
@@ -61,6 +66,9 @@ def update_config_files(answers: dict) -> int:
             continue
 
         try:
+            original_config = config_file.read_text()
+            resolved_answers = _resolve_alias_answers(original_config, answers)
+            scfw_config = _format_answers(resolved_answers)
             _update_config_file(config_file, scfw_config)
             _log.info(f"Successfully updated configuration in file {config_file}")
 
@@ -69,6 +77,28 @@ def update_config_files(answers: dict) -> int:
             error_count += 1
 
     return 1 if error_count else 0
+
+
+def _resolve_alias_answers(original_config: str, answers: dict) -> dict:
+    """
+    Resolve unspecified alias answers from an existing managed configuration block.
+
+    Args:
+        original_config: The complete existing contents of a shell configuration file.
+        answers: A `dict` containing the configuration options requested by the user.
+
+    Returns:
+        A copy of `answers` where unspecified aliases reflect the existing configuration.
+    """
+    resolved_answers = answers.copy()
+    match = re.search(f"{_BLOCK_START}(.*?){_BLOCK_END}", original_config, flags=re.DOTALL)
+    managed_lines = set(match.group(1).splitlines()) if match else set()
+
+    for option, alias in _ALIASES.items():
+        if resolved_answers.get(option) is None:
+            resolved_answers[option] = alias in managed_lines
+
+    return resolved_answers
 
 
 def _update_config_file(config_file: Path, scfw_config: str):
@@ -105,12 +135,9 @@ def _format_answers(answers: dict) -> str:
     """
     config = ''
 
-    if answers.get("alias_npm"):
-        config += 'alias npm="scfw run npm"\n'
-    if answers.get("alias_pip"):
-        config += 'alias pip="scfw run pip"\n'
-    if answers.get("alias_poetry"):
-        config += 'alias poetry="scfw run poetry"\n'
+    for option, alias in _ALIASES.items():
+        if answers.get(option):
+            config += f"{alias}\n"
     if (dd_agent_port := answers.get("dd_agent_port")):
         config += f'export {DD_AGENT_PORT_VAR}="{dd_agent_port}"\n'
     if answers.get("dd_api_logger"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,9 +113,9 @@ def test_cli_configure_basic_usage():
     assert args.log_level == _DEFAULT_LOG_LEVEL
 
     assert not args.remove
-    assert not args.alias_npm
-    assert not args.alias_pip
-    assert not args.alias_poetry
+    assert args.alias_npm is None
+    assert args.alias_pip is None
+    assert args.alias_poetry is None
     assert args.dd_agent_port is None
     assert args.dd_api_key is None
     assert args.dd_app_key is None
@@ -132,6 +132,9 @@ def test_cli_configure_basic_usage():
             ["--alias-npm"],
             ["--alias-pip"],
             ["--alias-poetry"],
+            ["--remove-alias-npm"],
+            ["--remove-alias-pip"],
+            ["--remove-alias-poetry"],
             ["--dd-agent-port", "10365"],
             ["--dd-api-key", "foo"],
             ["--dd-app-key", "foo"],
@@ -148,6 +151,35 @@ def test_cli_configure_removal(option: list[str]):
     """
     argv = ["scfw", "configure", "--remove"] + option
     args, _ = _parse_command_line(argv)
+    assert args is None
+
+
+@pytest.mark.parametrize("package_manager", ["npm", "pip", "poetry"])
+def test_cli_configure_alias_options(package_manager: str):
+    """
+    Alias addition and removal options set an explicit desired state.
+    """
+    add_args, _ = _parse_command_line(["scfw", "configure", f"--alias-{package_manager}"])
+    remove_args, _ = _parse_command_line(["scfw", "configure", f"--remove-alias-{package_manager}"])
+
+    assert add_args is not None
+    assert getattr(add_args, f"alias_{package_manager}") is True
+    assert remove_args is not None
+    assert getattr(remove_args, f"alias_{package_manager}") is False
+
+
+@pytest.mark.parametrize("package_manager", ["npm", "pip", "poetry"])
+def test_cli_configure_alias_addition_and_removal_are_mutually_exclusive(package_manager: str):
+    """
+    An alias cannot be added and removed in the same invocation.
+    """
+    args, _ = _parse_command_line([
+        "scfw",
+        "configure",
+        f"--alias-{package_manager}",
+        f"--remove-alias-{package_manager}",
+    ])
+
     assert args is None
 
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -160,6 +160,59 @@ def test_remove_config_produces_empty_output():
         assert env._format_answers(answers) == ""
 
 
+def test_unspecified_aliases_are_preserved_from_existing_config():
+    """
+    Repeated configuration preserves aliases that the user did not mention.
+    """
+    answers = {
+        "alias_npm": None,
+        "alias_pip": True,
+        "alias_poetry": None,
+    }
+
+    resolved = env._resolve_alias_answers(enclose('alias npm="scfw run npm"\n'), answers)
+
+    assert env._format_answers(resolved) == (
+        'alias npm="scfw run npm"\n'
+        'alias pip="scfw run pip"\n'
+    )
+
+
+def test_alias_can_be_explicitly_removed_from_existing_config():
+    """
+    An explicitly removed alias is omitted while unspecified aliases remain.
+    """
+    existing = enclose(
+        'alias npm="scfw run npm"\n'
+        'alias pip="scfw run pip"\n'
+    )
+    answers = {
+        "alias_npm": False,
+        "alias_pip": None,
+        "alias_poetry": None,
+    }
+
+    resolved = env._resolve_alias_answers(existing, answers)
+
+    assert env._format_answers(resolved) == 'alias pip="scfw run pip"\n'
+
+
+def test_update_config_files_preserves_unspecified_aliases(tmp_path: Path):
+    """
+    Updating configuration on disk carries existing aliases into the new managed block.
+    """
+    config_file = tmp_path / ".bashrc"
+    config_file.write_text(enclose('alias npm="scfw run npm"\n'))
+
+    with patch.object(env, "_CONFIG_FILES", [str(config_file)]):
+        assert env.update_config_files({"alias_npm": None, "alias_pip": True}) == 0
+
+    assert config_file.read_text() == enclose(
+        'alias npm="scfw run npm"\n'
+        'alias pip="scfw run pip"\n'
+    )
+
+
 def enclose(scfw_config: str) -> str:
     """
     Enclose the given `scfw_config` in its block comments.


### PR DESCRIPTION
## 🚀 Motivation
Repeated `scfw configure` invocations replaced previously configured aliases, preventing users from building or selectively removing alias configuration over time.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Better alias configuration in CLI](https://datadoghq.atlassian.net/browse/K9CODESEC-5049)

## 📝 Summary
Treat npm, pip, and Poetry alias options as explicit add, remove, or unchanged states. Preserve omitted aliases from existing managed shell blocks and add mutually exclusive `--remove-alias-*` flags for selective removal. Update CLI documentation and behavior coverage.

## 🧪 Testing
- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: