### PR TITLE
✨ Add autocomplete to SCFW Go CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When passing these values via shell variables, e.g. in scripts, prefer this `=` 
 This does two things:
 
 1. Stores your Datadog API key and application key securely in your system's keychain, so credentials don't need to be kept in plaintext or supplied on every command.
-2. Enables `scfw` shell completion and adds shell wrappers to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. The wrappers preserve each package manager's existing completion integration. Restart your shell (or source the relevant rc file) for the changes to take effect.
+2. Enables `scfw` shell completion (from `.zshrc` for zsh) and adds shell wrappers to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. The wrappers preserve each package manager's existing completion integration. Restart your shell (or source the relevant rc file) for the changes to take effect.
 
 `scfw configure` is idempotent and may be re-run at any time to change your configuration. It manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This does two things:
 
 `scfw configure` is idempotent and may be re-run at any time to change your configuration. It manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 
+Bash completion requires the [`bash-completion`](https://github.com/scop/bash-completion) package to be installed and initialized before the SCFW managed block is sourced. SCFW reports a warning at shell startup and leaves completion disabled when that dependency is unavailable.
+
 Available `configure` options:
 
 | Flag | Description |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When passing these values via shell variables, e.g. in scripts, prefer this `=` 
 This does two things:
 
 1. Stores your Datadog API key and application key securely in your system's keychain, so credentials don't need to be kept in plaintext or supplied on every command.
-2. Adds shell aliases to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. Restart your shell (or source the relevant rc file) for the aliases to take effect.
+2. Enables `scfw` shell completion and adds shell wrappers to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. The wrappers preserve each package manager's existing completion integration. Restart your shell (or source the relevant rc file) for the changes to take effect.
 
 `scfw configure` is idempotent and may be re-run at any time to change your configuration. It manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 
@@ -73,9 +73,9 @@ Available `configure` options:
 | `--dd-api-key` | Datadog API key used for policy evaluation and reporting. |
 | `--dd-app-key` | Datadog application key used for policy evaluation and reporting. |
 | `--dd-site` | Datadog site parameter used for policy evaluation and reporting (default: `datadoghq.com`). |
-| `--alias-npm` | Add a shell alias to run all npm commands through `scfw`. |
-| `--alias-pip` | Add shell aliases to run all pip/pip3 commands through `scfw`. |
-| `--alias-poetry` | Add a shell alias to run all poetry commands through `scfw`. |
+| `--alias-npm` | Add a shell wrapper to run all npm commands through `scfw`. |
+| `--alias-pip` | Add shell wrappers to run all pip/pip3 commands through `scfw`. |
+| `--alias-poetry` | Add a shell wrapper to run all poetry commands through `scfw`. |
 | `--scfw-home` | Directory Supply Chain Firewall can use as a local cache. |
 | `--remove` | Remove all Supply Chain Firewall managed configuration. |
 
@@ -118,7 +118,7 @@ Package some-evil-package-1.0.0:
 The command was blocked. No changes have been made.
 ```
 
-Note that, once shell aliases have been configured via `scfw configure --alias-npm`/`--alias-pip`/`--alias-poetry`, the explicit `scfw run --` prefix is no longer needed: commands for these package managers run through `scfw` automatically.
+Note that, once shell wrappers have been configured via `scfw configure --alias-npm`/`--alias-pip`/`--alias-poetry`, the explicit `scfw run --` prefix is no longer needed: commands for these package managers run through `scfw` automatically.
 
 `scfw run` supports the following options:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This does two things:
 
 `scfw configure` is idempotent and may be re-run at any time to change your configuration. It manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 
-Bash completion requires the [`bash-completion`](https://github.com/scop/bash-completion) package to be installed and initialized before the SCFW managed block is sourced. SCFW reports a warning at shell startup and leaves completion disabled when that dependency is unavailable.
+Bash completion requires the [`bash-completion`](https://github.com/scop/bash-completion) package to be installed and initialized before the SCFW managed block is sourced. SCFW reports a warning at interactive shell startup and leaves completion disabled when that dependency is unavailable. Non-interactive shells skip completion setup.
 
 Available `configure` options:
 

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -75,19 +75,22 @@ func init() {
 }
 
 // configFile describes a shell rc file, relative to the user's home directory,
-// and the shell whose completion script should be installed in it.
+// and, when non-empty, the shell whose completion script should be installed in it.
 type configFile struct {
-	name  string
-	shell string
+	name            string
+	completionShell string
 }
 
 // configFiles lists the shell rc files that SCFW's managed block is written to.
 // A file is skipped entirely if it does not already exist.
 var configFiles = []configFile{
-	{name: ".bashrc", shell: "bash"},
-	{name: ".bash_profile", shell: "bash"},
-	{name: ".zshrc", shell: "zsh"},
-	{name: ".zprofile", shell: "zsh"},
+	{name: ".bashrc", completionShell: "bash"},
+	{name: ".bash_profile", completionShell: "bash"},
+	{name: ".zshrc", completionShell: "zsh"},
+	// .zprofile is also read by non-interactive login shells and runs before
+	// .zshrc. Keep wrappers and exports there, but initialize completion only
+	// after interactive-shell plugins have configured fpath in .zshrc.
+	{name: ".zprofile"},
 }
 
 func runConfigure(cmd *cobra.Command, args []string) error {
@@ -122,7 +125,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 	for _, file := range configFiles {
 		var content string
 		if !remove {
-			content = buildManagedBlock(file.shell)
+			content = buildManagedBlock(file.completionShell)
 		}
 		if err := updateConfigFile(filepath.Join(home, file.name), content); err != nil {
 			errs = append(errs, err)

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -64,9 +64,9 @@ func registerConfigureArg[T configureArgType](name string, defaultValue T, help 
 
 func init() {
 	configureCmd.Flags().BoolVar(&remove, "remove", false, "Remove all Supply Chain Firewall managed configuration.")
-	registerConfigureArg("alias-npm", false, "Add shell aliases to run all npm commands through Supply Chain Firewall.", &aliasNpm)
-	registerConfigureArg("alias-pip", false, "Add shell aliases to run all pip commands through Supply Chain Firewall.", &aliasPip)
-	registerConfigureArg("alias-poetry", false, "Add shell aliases to run all poetry commands through Supply Chain Firewall.", &aliasPoetry)
+	registerConfigureArg("alias-npm", false, "Add a shell wrapper to run all npm commands through Supply Chain Firewall.", &aliasNpm)
+	registerConfigureArg("alias-pip", false, "Add shell wrappers to run all pip commands through Supply Chain Firewall.", &aliasPip)
+	registerConfigureArg("alias-poetry", false, "Add a shell wrapper to run all poetry commands through Supply Chain Firewall.", &aliasPoetry)
 	registerConfigureArg("dd-api-key", "", "Datadog API key used for policy evaluation and reporting.", &ddAPIKey)
 	registerConfigureArg("dd-app-key", "", "Datadog application key used for policy evaluation and reporting.", &ddAppKey)
 	registerConfigureArg("dd-site", "", "Datadog site parameter used for policy evaluation and reporting.", &ddSite)
@@ -74,10 +74,21 @@ func init() {
 	configureCmd.MarkFlagsOneRequired(configureArgNames...)
 }
 
-// configFiles lists the shell rc files, relative to the user's home
-// directory, that SCFW's managed block is written to. A file is skipped
-// entirely if it does not already exist.
-var configFiles = []string{".bashrc", ".bash_profile", ".zshrc", ".zprofile"}
+// configFile describes a shell rc file, relative to the user's home directory,
+// and the shell whose completion script should be installed in it.
+type configFile struct {
+	name  string
+	shell string
+}
+
+// configFiles lists the shell rc files that SCFW's managed block is written to.
+// A file is skipped entirely if it does not already exist.
+var configFiles = []configFile{
+	{name: ".bashrc", shell: "bash"},
+	{name: ".bash_profile", shell: "bash"},
+	{name: ".zshrc", shell: "zsh"},
+	{name: ".zprofile", shell: "zsh"},
+}
 
 func runConfigure(cmd *cobra.Command, args []string) error {
 	var errs []error
@@ -108,32 +119,35 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		return errors.Join(errs...)
 	}
 
-	var content string
-	if !remove {
-		content = buildManagedBlock()
-	}
-
-	for _, name := range configFiles {
-		if err := updateConfigFile(filepath.Join(home, name), content); err != nil {
+	for _, file := range configFiles {
+		var content string
+		if !remove {
+			content = buildManagedBlock(file.shell)
+		}
+		if err := updateConfigFile(filepath.Join(home, file.name), content); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// buildManagedBlock formats the currently selected configuration options
-// into the content of SCFW's managed block.
-func buildManagedBlock() string {
+// buildManagedBlock formats shell completion and the currently selected
+// configuration options into the content of SCFW's managed block.
+func buildManagedBlock(shell string) string {
 	var b strings.Builder
+	if shell == "zsh" {
+		b.WriteString("if ! type compdef >/dev/null 2>&1; then\n\tautoload -Uz compinit && compinit\nfi\n")
+	}
+	fmt.Fprintf(&b, "source <(scfw completion %s)\n", shell)
 	if aliasNpm {
-		b.WriteString(`alias npm="scfw run -- npm"` + "\n")
+		writePackageManagerFunction(&b, "npm")
 	}
 	if aliasPip {
-		b.WriteString(`alias pip="scfw run -- pip"` + "\n")
-		b.WriteString(`alias pip3="scfw run -- pip3"` + "\n")
+		writePackageManagerFunction(&b, "pip")
+		writePackageManagerFunction(&b, "pip3")
 	}
 	if aliasPoetry {
-		b.WriteString(`alias poetry="scfw run -- poetry"` + "\n")
+		writePackageManagerFunction(&b, "poetry")
 	}
 	if scfwHome != "" {
 		fmt.Fprintf(&b, "export SCFW_HOME=%q\n", scfwHome)
@@ -142,6 +156,13 @@ func buildManagedBlock() string {
 		fmt.Fprintf(&b, "export DD_SITE=%q\n", ddSite)
 	}
 	return b.String()
+}
+
+// writePackageManagerFunction adds a transparent package-manager wrapper. Shell
+// functions keep completion definitions registered for the original command name
+// working, unlike aliases that can be expanded before completion (notably in zsh).
+func writePackageManagerFunction(b *strings.Builder, name string) {
+	fmt.Fprintf(b, "unalias %s 2>/dev/null || true\n%s() {\n\tscfw run -- %s \"$@\"\n}\n", name, name, name)
 }
 
 // updateConfigFile merges content into path's managed block and writes the

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -140,10 +140,12 @@ func buildManagedBlock(shell string) string {
 	var b strings.Builder
 	switch shell {
 	case "bash":
-		b.WriteString("if type _get_comp_words_by_ref >/dev/null 2>&1; then\n")
-		b.WriteString("\teval \"$(scfw completion bash)\"\n")
-		b.WriteString("else\n")
-		b.WriteString("\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n")
+		b.WriteString("if [[ $- == *i* ]]; then\n")
+		b.WriteString("\tif type _get_comp_words_by_ref >/dev/null 2>&1; then\n")
+		b.WriteString("\t\teval \"$(scfw completion bash)\"\n")
+		b.WriteString("\telse\n")
+		b.WriteString("\t\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n")
+		b.WriteString("\tfi\n")
 		b.WriteString("fi\n")
 	case "zsh":
 		b.WriteString("if ! type compdef >/dev/null 2>&1; then\n\tautoload -Uz compinit && compinit\nfi\n")

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -135,10 +135,17 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 // configuration options into the content of SCFW's managed block.
 func buildManagedBlock(shell string) string {
 	var b strings.Builder
-	if shell == "zsh" {
+	switch shell {
+	case "bash":
+		b.WriteString("if type _get_comp_words_by_ref >/dev/null 2>&1; then\n")
+		b.WriteString("\teval \"$(scfw completion bash)\"\n")
+		b.WriteString("else\n")
+		b.WriteString("\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n")
+		b.WriteString("fi\n")
+	case "zsh":
 		b.WriteString("if ! type compdef >/dev/null 2>&1; then\n\tautoload -Uz compinit && compinit\nfi\n")
+		b.WriteString("source <(scfw completion zsh)\n")
 	}
-	fmt.Fprintf(&b, "source <(scfw completion %s)\n", shell)
 	if aliasNpm {
 		writePackageManagerFunction(&b, "npm")
 	}

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -187,7 +188,11 @@ func withAliasPoetry(t *testing.T, value bool) {
 
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	want := `source <(scfw completion bash)` + "\n"
+	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
+		"\teval \"$(scfw completion bash)\"\n" +
+		"else\n" +
+		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
+		"fi\n"
 	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
@@ -228,7 +233,11 @@ func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	want := `source <(scfw completion bash)` + "\n"
+	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
+		"\teval \"$(scfw completion bash)\"\n" +
+		"else\n" +
+		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
+		"fi\n"
 	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
@@ -240,6 +249,52 @@ func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 		"}\n"
 	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildManagedBlock_BashCompletionDependency(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not installed")
+	}
+	fakeBinDir := t.TempDir()
+	fakeScfw := filepath.Join(fakeBinDir, "scfw")
+	if err := os.WriteFile(fakeScfw, []byte("#!/bin/sh\nprintf 'SCFW_COMPLETION_LOADED=1\\n'\n"), 0o755); err != nil {
+		t.Fatalf("failed to create fake scfw executable: %v", err)
+	}
+
+	block := buildManagedBlock("bash")
+	tests := []struct {
+		name       string
+		setup      string
+		assertion  string
+		wantOutput string
+	}{
+		{
+			name:      "sources completion when dependency is available",
+			setup:     "_get_comp_words_by_ref() { :; }\n",
+			assertion: `test "${SCFW_COMPLETION_LOADED:-}" = 1`,
+		},
+		{
+			name:       "warns and skips completion when dependency is missing",
+			setup:      "unset -f _get_comp_words_by_ref 2>/dev/null || true\n",
+			assertion:  `test -z "${SCFW_COMPLETION_LOADED:-}"`,
+			wantOutput: "SCFW: bash completion is unavailable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			script := tc.setup + block + tc.assertion
+			cmd := exec.Command("bash", "--noprofile", "--norc", "-c", script)
+			cmd.Env = append(os.Environ(), "PATH="+fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("bash completion setup failed: %v\n%s", err, output)
+			}
+			if tc.wantOutput != "" && !strings.Contains(string(output), tc.wantOutput) {
+				t.Fatalf("bash completion setup output = %q, want it to contain %q", output, tc.wantOutput)
+			}
+		})
 	}
 }
 
@@ -256,7 +311,11 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withAliasPip(t, true)
 	withDdSite(t, "datadoghq.eu")
 
-	want := `source <(scfw completion bash)` + "\n" +
+	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
+		"\teval \"$(scfw completion bash)\"\n" +
+		"else\n" +
+		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
+		"fi\n" +
 		"unalias pip 2>/dev/null || true\npip() {\n\tscfw run -- pip \"$@\"\n}\n" +
 		"unalias pip3 2>/dev/null || true\npip3() {\n\tscfw run -- pip3 \"$@\"\n}\n" +
 		`export DD_SITE="datadoghq.eu"` + "\n"
@@ -486,7 +545,11 @@ func TestRunConfigure_TogglingOffKeepsCompletion(t *testing.T) {
 		t.Fatalf("failed to read %q: %v", path, err)
 	}
 	want := "export FOO=1\n\n" + blockStart + "\n" +
-		"source <(scfw completion bash)\n" + blockEnd + "\n"
+		"if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
+		"\teval \"$(scfw completion bash)\"\n" +
+		"else\n" +
+		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
+		"fi\n" + blockEnd + "\n"
 	if string(got) != want {
 		t.Fatalf(".bashrc = %q, want %q", got, want)
 	}
@@ -506,14 +569,16 @@ func TestRunConfigure_UsesCompletionForEachShell(t *testing.T) {
 		t.Fatalf("runConfigure() returned unexpected error: %v", err)
 	}
 
-	for name, shell := range map[string]string{".bashrc": "bash", ".zshrc": "zsh"} {
+	for name, completionSetup := range map[string]string{
+		".bashrc": `eval "$(scfw completion bash)"`,
+		".zshrc":  `source <(scfw completion zsh)`,
+	} {
 		got, err := os.ReadFile(filepath.Join(home, name))
 		if err != nil {
 			t.Fatalf("failed to read %q: %v", name, err)
 		}
-		want := fmt.Sprintf("source <(scfw completion %s)", shell)
-		if !strings.Contains(string(got), want) {
-			t.Fatalf("%s = %q, want it to contain %q", name, got, want)
+		if !strings.Contains(string(got), completionSetup) {
+			t.Fatalf("%s = %q, want it to contain %q", name, got, completionSetup)
 		}
 	}
 }

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -558,8 +558,10 @@ func TestRunConfigure_TogglingOffKeepsCompletion(t *testing.T) {
 func TestRunConfigure_UsesCompletionForEachShell(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	withAliasPoetry(t, true)
+	withScfwHome(t, "/tmp/scfw-home")
 
-	for _, name := range []string{".bashrc", ".zshrc"} {
+	for _, name := range []string{".bashrc", ".zshrc", ".zprofile"} {
 		if err := os.WriteFile(filepath.Join(home, name), nil, 0o644); err != nil {
 			t.Fatalf("failed to seed %q: %v", name, err)
 		}
@@ -579,6 +581,19 @@ func TestRunConfigure_UsesCompletionForEachShell(t *testing.T) {
 		}
 		if !strings.Contains(string(got), completionSetup) {
 			t.Fatalf("%s = %q, want it to contain %q", name, got, completionSetup)
+		}
+	}
+
+	zprofile, err := os.ReadFile(filepath.Join(home, ".zprofile"))
+	if err != nil {
+		t.Fatalf("failed to read .zprofile: %v", err)
+	}
+	if strings.Contains(string(zprofile), "scfw completion") || strings.Contains(string(zprofile), "compinit") {
+		t.Fatalf(".zprofile = %q, want no completion initialization", zprofile)
+	}
+	for _, want := range []string{"poetry() {", `export SCFW_HOME="/tmp/scfw-home"`} {
+		if !strings.Contains(string(zprofile), want) {
+			t.Fatalf(".zprofile = %q, want it to contain %q", zprofile, want)
 		}
 	}
 }

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -186,13 +186,17 @@ func withAliasPoetry(t *testing.T, value bool) {
 	t.Cleanup(func() { aliasPoetry = original })
 }
 
+const expectedBashCompletionConfig = "if [[ $- == *i* ]]; then\n" +
+	"\tif type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
+	"\t\teval \"$(scfw completion bash)\"\n" +
+	"\telse\n" +
+	"\t\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
+	"\tfi\n" +
+	"fi\n"
+
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
-		"\teval \"$(scfw completion bash)\"\n" +
-		"else\n" +
-		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
-		"fi\n"
+	want := expectedBashCompletionConfig
 	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
@@ -233,11 +237,7 @@ func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
-		"\teval \"$(scfw completion bash)\"\n" +
-		"else\n" +
-		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
-		"fi\n"
+	want := expectedBashCompletionConfig
 	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
@@ -256,6 +256,8 @@ func TestBuildManagedBlock_BashCompletionDependency(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not installed")
 	}
+	withAliasPoetry(t, true)
+	withScfwHome(t, "/tmp/scfw-home")
 	fakeBinDir := t.TempDir()
 	fakeScfw := filepath.Join(fakeBinDir, "scfw")
 	if err := os.WriteFile(fakeScfw, []byte("#!/bin/sh\nprintf 'SCFW_COMPLETION_LOADED=1\\n'\n"), 0o755); err != nil {
@@ -264,28 +266,43 @@ func TestBuildManagedBlock_BashCompletionDependency(t *testing.T) {
 
 	block := buildManagedBlock("bash")
 	tests := []struct {
-		name       string
-		setup      string
-		assertion  string
-		wantOutput string
+		name         string
+		interactive  bool
+		setup        string
+		assertion    string
+		wantOutput   string
+		forbidOutput string
 	}{
 		{
-			name:      "sources completion when dependency is available",
-			setup:     "_get_comp_words_by_ref() { :; }\n",
-			assertion: `test "${SCFW_COMPLETION_LOADED:-}" = 1`,
+			name:        "sources completion when dependency is available",
+			interactive: true,
+			setup:       "_get_comp_words_by_ref() { :; }\n",
+			assertion:   `test "${SCFW_COMPLETION_LOADED:-}" = 1`,
 		},
 		{
-			name:       "warns and skips completion when dependency is missing",
-			setup:      "unset -f _get_comp_words_by_ref 2>/dev/null || true\n",
-			assertion:  `test -z "${SCFW_COMPLETION_LOADED:-}"`,
-			wantOutput: "SCFW: bash completion is unavailable",
+			name:        "warns and skips completion when dependency is missing",
+			interactive: true,
+			setup:       "unset -f _get_comp_words_by_ref 2>/dev/null || true\n",
+			assertion:   `test -z "${SCFW_COMPLETION_LOADED:-}"`,
+			wantOutput:  "SCFW: bash completion is unavailable",
+		},
+		{
+			name:         "skips completion silently in a non-interactive shell",
+			setup:        "unset -f _get_comp_words_by_ref 2>/dev/null || true\n",
+			assertion:    `test -z "${SCFW_COMPLETION_LOADED:-}"`,
+			forbidOutput: "SCFW: bash completion is unavailable",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			script := tc.setup + block + tc.assertion
-			cmd := exec.Command("bash", "--noprofile", "--norc", "-c", script)
+			script := tc.setup + block + tc.assertion +
+				` && test "$(type -t poetry)" = function && test "$SCFW_HOME" = /tmp/scfw-home`
+			args := []string{"--noprofile", "--norc"}
+			if tc.interactive {
+				args = append(args, "-i")
+			}
+			cmd := exec.Command("bash", append(args, "-c", script)...)
 			cmd.Env = append(os.Environ(), "PATH="+fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			output, err := cmd.CombinedOutput()
 			if err != nil {
@@ -293,6 +310,9 @@ func TestBuildManagedBlock_BashCompletionDependency(t *testing.T) {
 			}
 			if tc.wantOutput != "" && !strings.Contains(string(output), tc.wantOutput) {
 				t.Fatalf("bash completion setup output = %q, want it to contain %q", output, tc.wantOutput)
+			}
+			if tc.forbidOutput != "" && strings.Contains(string(output), tc.forbidOutput) {
+				t.Fatalf("bash completion setup output = %q, want it not to contain %q", output, tc.forbidOutput)
 			}
 		})
 	}
@@ -311,11 +331,7 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withAliasPip(t, true)
 	withDdSite(t, "datadoghq.eu")
 
-	want := "if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
-		"\teval \"$(scfw completion bash)\"\n" +
-		"else\n" +
-		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
-		"fi\n" +
+	want := expectedBashCompletionConfig +
 		"unalias pip 2>/dev/null || true\npip() {\n\tscfw run -- pip \"$@\"\n}\n" +
 		"unalias pip3 2>/dev/null || true\npip3() {\n\tscfw run -- pip3 \"$@\"\n}\n" +
 		`export DD_SITE="datadoghq.eu"` + "\n"
@@ -545,11 +561,7 @@ func TestRunConfigure_TogglingOffKeepsCompletion(t *testing.T) {
 		t.Fatalf("failed to read %q: %v", path, err)
 	}
 	want := "export FOO=1\n\n" + blockStart + "\n" +
-		"if type _get_comp_words_by_ref >/dev/null 2>&1; then\n" +
-		"\teval \"$(scfw completion bash)\"\n" +
-		"else\n" +
-		"\tprintf '%s\\n' 'SCFW: bash completion is unavailable; install and initialize bash-completion to enable it.' >&2\n" +
-		"fi\n" + blockEnd + "\n"
+		expectedBashCompletionConfig + blockEnd + "\n"
 	if string(got) != want {
 		t.Fatalf(".bashrc = %q, want %q", got, want)
 	}

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -187,39 +187,58 @@ func withAliasPoetry(t *testing.T, value bool) {
 
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	if got := buildManagedBlock(); got != "" {
-		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
+	want := `source <(scfw completion bash)` + "\n"
+	if got := buildManagedBlock("bash"); got != want {
+		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 
 	withAliasPip(t, true)
-	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	want += "unalias pip 2>/dev/null || true\n" +
+		"pip() {\n" +
+		"\tscfw run -- pip \"$@\"\n" +
+		"}\n" +
+		"unalias pip3 2>/dev/null || true\n" +
+		"pip3() {\n" +
+		"\tscfw run -- pip3 \"$@\"\n" +
+		"}\n"
+	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 	withAliasNpm(t, false)
-	if got := buildManagedBlock(); got != "" {
-		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
+	want := "if ! type compdef >/dev/null 2>&1; then\n" +
+		"\tautoload -Uz compinit && compinit\n" +
+		"fi\n" +
+		`source <(scfw completion zsh)` + "\n"
+	if got := buildManagedBlock("zsh"); got != want {
+		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 
 	withAliasNpm(t, true)
-	want := `alias npm="scfw run -- npm"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	want += "unalias npm 2>/dev/null || true\n" +
+		"npm() {\n" +
+		"\tscfw run -- npm \"$@\"\n" +
+		"}\n"
+	if got := buildManagedBlock("zsh"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	if got := buildManagedBlock(); got != "" {
-		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
+	want := `source <(scfw completion bash)` + "\n"
+	if got := buildManagedBlock("bash"); got != want {
+		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 
 	withAliasPoetry(t, true)
-	want := `alias poetry="scfw run -- poetry"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	want += "unalias poetry 2>/dev/null || true\n" +
+		"poetry() {\n" +
+		"\tscfw run -- poetry \"$@\"\n" +
+		"}\n"
+	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -237,8 +256,11 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withAliasPip(t, true)
 	withDdSite(t, "datadoghq.eu")
 
-	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export DD_SITE="datadoghq.eu"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	want := `source <(scfw completion bash)` + "\n" +
+		"unalias pip 2>/dev/null || true\npip() {\n\tscfw run -- pip \"$@\"\n}\n" +
+		"unalias pip3 2>/dev/null || true\npip3() {\n\tscfw run -- pip3 \"$@\"\n}\n" +
+		`export DD_SITE="datadoghq.eu"` + "\n"
+	if got := buildManagedBlock("bash"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -256,8 +278,12 @@ func TestBuildManagedBlock_IncludesScfwHome(t *testing.T) {
 	withAliasPip(t, true)
 	withScfwHome(t, "/tmp/scfw-home")
 
-	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export SCFW_HOME="/tmp/scfw-home"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	want := "if ! type compdef >/dev/null 2>&1; then\n\tautoload -Uz compinit && compinit\nfi\n" +
+		`source <(scfw completion zsh)` + "\n" +
+		"unalias pip 2>/dev/null || true\npip() {\n\tscfw run -- pip \"$@\"\n}\n" +
+		"unalias pip3 2>/dev/null || true\npip3() {\n\tscfw run -- pip3 \"$@\"\n}\n" +
+		`export SCFW_HOME="/tmp/scfw-home"` + "\n"
+	if got := buildManagedBlock("zsh"); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -440,7 +466,7 @@ func TestRunConfigure_WritesScfwHomeExportWithoutCreatingDir(t *testing.T) {
 	}
 }
 
-func TestRunConfigure_TogglingOffRemovesExistingBlock(t *testing.T) {
+func TestRunConfigure_TogglingOffKeepsCompletion(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -459,11 +485,36 @@ func TestRunConfigure_TogglingOffRemovesExistingBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read %q: %v", path, err)
 	}
-	if strings.Contains(string(got), blockStart) {
-		t.Fatalf(".bashrc = %q, want the managed block removed", got)
-	}
-	if want := "export FOO=1\n"; string(got) != want {
+	want := "export FOO=1\n\n" + blockStart + "\n" +
+		"source <(scfw completion bash)\n" + blockEnd + "\n"
+	if string(got) != want {
 		t.Fatalf(".bashrc = %q, want %q", got, want)
+	}
+}
+
+func TestRunConfigure_UsesCompletionForEachShell(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, name := range []string{".bashrc", ".zshrc"} {
+		if err := os.WriteFile(filepath.Join(home, name), nil, 0o644); err != nil {
+			t.Fatalf("failed to seed %q: %v", name, err)
+		}
+	}
+
+	if err := runConfigure(configureCmd, nil); err != nil {
+		t.Fatalf("runConfigure() returned unexpected error: %v", err)
+	}
+
+	for name, shell := range map[string]string{".bashrc": "bash", ".zshrc": "zsh"} {
+		got, err := os.ReadFile(filepath.Join(home, name))
+		if err != nil {
+			t.Fatalf("failed to read %q: %v", name, err)
+		}
+		want := fmt.Sprintf("source <(scfw completion %s)", shell)
+		if !strings.Contains(string(got), want) {
+			t.Fatalf("%s = %q, want it to contain %q", name, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## 🚀 Motivation

Enable shell autocomplete for the SCFW Go CLI without disrupting the existing completion behavior of package-manager commands routed through SCFW.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Add an autocomplete to SCFW Go CLI](https://datadoghq.atlassian.net/browse/K9CODESEC-5048)

## 📝 Summary

Install Bash and zsh completion through `scfw configure`, with shell-specific guards for interactive startup and Bash's completion dependency. Replace npm, pip/pip3, and Poetry aliases with transparent shell functions so their native completion registrations remain intact.

## 🧪 Testing

- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
