### PR TITLE
✨ Improve alias configuration in CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-** @DataDog/security-research
-** @DataDog/k9-vm-sca
+** @DataDog/security-research @DataDog/k9-sca

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This does two things:
 1. Stores your Datadog API key and application key securely in your system's keychain, so credentials don't need to be kept in plaintext or supplied on every command.
 2. Adds shell aliases to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. Restart your shell (or source the relevant rc file) for the aliases to take effect.
 
-`scfw configure` is idempotent and may be re-run at any time to change your configuration. It manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
+`scfw configure` is idempotent and may be re-run at any time to change your configuration. Alias options are additive, so aliases configured by an earlier invocation remain in place unless their corresponding `--remove-alias-*` option is passed. The command manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 
 Available `configure` options:
 
@@ -74,8 +74,11 @@ Available `configure` options:
 | `--dd-app-key` | Datadog application key used for policy evaluation and reporting. |
 | `--dd-site` | Datadog site parameter used for policy evaluation and reporting (default: `datadoghq.com`). |
 | `--alias-npm` | Add a shell alias to run all npm commands through `scfw`. |
+| `--remove-alias-npm` | Remove the npm shell alias managed by `scfw`. |
 | `--alias-pip` | Add shell aliases to run all pip/pip3 commands through `scfw`. |
+| `--remove-alias-pip` | Remove the pip/pip3 shell aliases managed by `scfw`. |
 | `--alias-poetry` | Add a shell alias to run all poetry commands through `scfw`. |
+| `--remove-alias-poetry` | Remove the poetry shell alias managed by `scfw`. |
 | `--scfw-home` | Directory Supply Chain Firewall can use as a local cache. |
 | `--remove` | Remove all Supply Chain Firewall managed configuration. |
 

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -127,7 +127,11 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 				errs = append(errs, err)
 				continue
 			}
-			content = buildManagedBlock(existingConfig)
+			content = buildManagedBlock(
+				existingConfig,
+				cmd.Flags().Changed("scfw-home"),
+				cmd.Flags().Changed("dd-site"),
+			)
 		}
 		if err := updateConfigFile(path, content); err != nil {
 			errs = append(errs, err)
@@ -146,7 +150,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 // buildManagedBlock formats the currently selected configuration options
 // into the content of SCFW's managed block. Previously configured aliases
 // remain enabled when their corresponding flags are omitted.
-func buildManagedBlock(existingConfig managedConfiguration) string {
+func buildManagedBlock(existingConfig managedConfiguration, scfwHomeChanged, ddSiteChanged bool) string {
 	var b strings.Builder
 	if !removeAliasNpm && (aliasNpm || hasConfiguredAlias(existingConfig.aliases, "npm")) {
 		b.WriteString(`alias npm="scfw run -- npm"` + "\n")
@@ -158,16 +162,16 @@ func buildManagedBlock(existingConfig managedConfiguration) string {
 	if !removeAliasPoetry && (aliasPoetry || hasConfiguredAlias(existingConfig.aliases, "poetry")) {
 		b.WriteString(`alias poetry="scfw run -- poetry"` + "\n")
 	}
-	configuredScfwHome := scfwHome
-	if configuredScfwHome == "" {
-		configuredScfwHome = existingConfig.scfwHome
+	configuredScfwHome := existingConfig.scfwHome
+	if scfwHomeChanged || scfwHome != "" {
+		configuredScfwHome = scfwHome
 	}
 	if configuredScfwHome != "" {
 		fmt.Fprintf(&b, "export SCFW_HOME=%q\n", configuredScfwHome)
 	}
-	configuredDdSite := ddSite
-	if configuredDdSite == "" {
-		configuredDdSite = existingConfig.ddSite
+	configuredDdSite := existingConfig.ddSite
+	if ddSiteChanged || ddSite != "" {
+		configuredDdSite = ddSite
 	}
 	if configuredDdSite != "" {
 		fmt.Fprintf(&b, "export DD_SITE=%q\n", configuredDdSite)

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -122,12 +122,12 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		path := filepath.Join(home, name)
 		var content string
 		if !remove {
-			existingAliases, err := readManagedBlock(path)
+			existingConfig, err := readManagedConfiguration(path)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
-			content = buildManagedBlock(existingAliases)
+			content = buildManagedBlock(existingConfig)
 		}
 		if err := updateConfigFile(path, content); err != nil {
 			errs = append(errs, err)
@@ -146,23 +146,31 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 // buildManagedBlock formats the currently selected configuration options
 // into the content of SCFW's managed block. Previously configured aliases
 // remain enabled when their corresponding flags are omitted.
-func buildManagedBlock(existingAliases map[string]string) string {
+func buildManagedBlock(existingConfig managedConfiguration) string {
 	var b strings.Builder
-	if !removeAliasNpm && (aliasNpm || hasConfiguredAlias(existingAliases, "npm")) {
+	if !removeAliasNpm && (aliasNpm || hasConfiguredAlias(existingConfig.aliases, "npm")) {
 		b.WriteString(`alias npm="scfw run -- npm"` + "\n")
 	}
-	if !removeAliasPip && (aliasPip || hasConfiguredAlias(existingAliases, "pip", "pip3")) {
+	if !removeAliasPip && (aliasPip || hasConfiguredAlias(existingConfig.aliases, "pip", "pip3")) {
 		b.WriteString(`alias pip="scfw run -- pip"` + "\n")
 		b.WriteString(`alias pip3="scfw run -- pip3"` + "\n")
 	}
-	if !removeAliasPoetry && (aliasPoetry || hasConfiguredAlias(existingAliases, "poetry")) {
+	if !removeAliasPoetry && (aliasPoetry || hasConfiguredAlias(existingConfig.aliases, "poetry")) {
 		b.WriteString(`alias poetry="scfw run -- poetry"` + "\n")
 	}
-	if scfwHome != "" {
-		fmt.Fprintf(&b, "export SCFW_HOME=%q\n", scfwHome)
+	configuredScfwHome := scfwHome
+	if configuredScfwHome == "" {
+		configuredScfwHome = existingConfig.scfwHome
 	}
-	if ddSite != "" {
-		fmt.Fprintf(&b, "export DD_SITE=%q\n", ddSite)
+	if configuredScfwHome != "" {
+		fmt.Fprintf(&b, "export SCFW_HOME=%q\n", configuredScfwHome)
+	}
+	configuredDdSite := ddSite
+	if configuredDdSite == "" {
+		configuredDdSite = existingConfig.ddSite
+	}
+	if configuredDdSite != "" {
+		fmt.Fprintf(&b, "export DD_SITE=%q\n", configuredDdSite)
 	}
 	return b.String()
 }
@@ -201,43 +209,71 @@ func updateConfigFile(path, content string) error {
 	return nil
 }
 
-// readManagedBlock returns the aliases defined in SCFW's managed
+type managedConfiguration struct {
+	aliases  map[string]string
+	scfwHome string
+	ddSite   string
+}
+
+// readManagedConfiguration returns the aliases and exports defined in SCFW's managed
 // block in path. Files without a managed block (including missing files)
-// contain no managed aliases.
-func readManagedBlock(path string) (map[string]string, error) {
+// contain no managed configuration.
+func readManagedConfiguration(path string) (managedConfiguration, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return managedConfiguration{}, nil
 		}
-		return nil, fmt.Errorf("%s: %w", path, err)
+		return managedConfiguration{}, fmt.Errorf("%s: %w", path, err)
 	}
 
 	content := string(data)
 	block, err := parseManagedBlock(content)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", path, err)
+		return managedConfiguration{}, fmt.Errorf("%s: %w", path, err)
 	}
 	if !block.found {
-		return nil, nil
+		return managedConfiguration{}, nil
 	}
 
-	aliases := make(map[string]string)
+	config := managedConfiguration{aliases: make(map[string]string)}
 	for line := range strings.Lines(content[block.contentStart:block.contentEnd]) {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "alias ") {
+		if strings.HasPrefix(line, "alias ") {
+			name, value, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(line, "alias ")), "=")
+			if name = strings.TrimSpace(name); ok && name != "" {
+				config.aliases[name] = unquoteConfigValue(value)
+			}
 			continue
 		}
-		name, value, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(line, "alias ")), "=")
-		if name = strings.TrimSpace(name); ok && name != "" {
-			value = strings.TrimSpace(value)
-			if unquoted, err := strconv.Unquote(value); err == nil {
-				value = unquoted
+		if strings.HasPrefix(line, "export ") {
+			name, value, ok := strings.Cut(strings.TrimSpace(strings.TrimPrefix(line, "export ")), "=")
+			if !ok {
+				continue
 			}
-			aliases[name] = value
+			switch strings.TrimSpace(name) {
+			case "SCFW_HOME":
+				config.scfwHome = unquoteConfigValue(value)
+			case "DD_SITE":
+				config.ddSite = unquoteConfigValue(value)
+			}
 		}
 	}
-	return aliases, nil
+	return config, nil
+}
+
+// readManagedBlock returns the aliases defined in SCFW's managed block in path.
+func readManagedBlock(path string) (map[string]string, error) {
+	config, err := readManagedConfiguration(path)
+	return config.aliases, err
+}
+
+func unquoteConfigValue(value string) string {
+	value = strings.TrimSpace(value)
+	if unquoted, err := strconv.Unquote(value); err == nil {
+		return unquoted
+	}
+	return value
 }
 
 const (

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -27,14 +27,17 @@ var configureCmd = &cobra.Command{
 }
 
 var (
-	aliasNpm    bool
-	aliasPip    bool
-	aliasPoetry bool
-	ddAPIKey    string
-	ddAppKey    string
-	ddSite      string
-	scfwHome    string
-	remove      bool
+	aliasNpm          bool
+	aliasPip          bool
+	aliasPoetry       bool
+	removeAliasNpm    bool
+	removeAliasPip    bool
+	removeAliasPoetry bool
+	ddAPIKey          string
+	ddAppKey          string
+	ddSite            string
+	scfwHome          string
+	remove            bool
 )
 
 // configureArgType is the set of flag value types registerConfigureArg
@@ -66,12 +69,18 @@ func registerConfigureArg[T configureArgType](name string, defaultValue T, help 
 func init() {
 	configureCmd.Flags().BoolVar(&remove, "remove", false, "Remove all Supply Chain Firewall managed configuration.")
 	registerConfigureArg("alias-npm", false, "Add shell aliases to run all npm commands through Supply Chain Firewall.", &aliasNpm)
+	registerConfigureArg("remove-alias-npm", false, "Remove Supply Chain Firewall's npm shell alias.", &removeAliasNpm)
 	registerConfigureArg("alias-pip", false, "Add shell aliases to run all pip commands through Supply Chain Firewall.", &aliasPip)
+	registerConfigureArg("remove-alias-pip", false, "Remove Supply Chain Firewall's pip shell aliases.", &removeAliasPip)
 	registerConfigureArg("alias-poetry", false, "Add shell aliases to run all poetry commands through Supply Chain Firewall.", &aliasPoetry)
+	registerConfigureArg("remove-alias-poetry", false, "Remove Supply Chain Firewall's poetry shell alias.", &removeAliasPoetry)
 	registerConfigureArg("dd-api-key", "", "Datadog API key used for policy evaluation and reporting.", &ddAPIKey)
 	registerConfigureArg("dd-app-key", "", "Datadog application key used for policy evaluation and reporting.", &ddAppKey)
 	registerConfigureArg("dd-site", "", "Datadog site parameter used for policy evaluation and reporting.", &ddSite)
 	registerConfigureArg("scfw-home", "", "Directory that Supply Chain Firewall can use as a local cache.", &scfwHome)
+	configureCmd.MarkFlagsMutuallyExclusive("alias-npm", "remove-alias-npm")
+	configureCmd.MarkFlagsMutuallyExclusive("alias-pip", "remove-alias-pip")
+	configureCmd.MarkFlagsMutuallyExclusive("alias-poetry", "remove-alias-poetry")
 	configureCmd.MarkFlagsOneRequired(configureArgNames...)
 }
 
@@ -109,13 +118,18 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		return errors.Join(errs...)
 	}
 
-	var content string
-	if !remove {
-		content = buildManagedBlock()
-	}
-
 	for _, name := range configFiles {
-		if err := updateConfigFile(filepath.Join(home, name), content); err != nil {
+		path := filepath.Join(home, name)
+		var content string
+		if !remove {
+			existingAliases, err := readManagedBlock(path)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			content = buildManagedBlock(existingAliases)
+		}
+		if err := updateConfigFile(path, content); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -130,17 +144,18 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 }
 
 // buildManagedBlock formats the currently selected configuration options
-// into the content of SCFW's managed block.
-func buildManagedBlock() string {
+// into the content of SCFW's managed block. Previously configured aliases
+// remain enabled when their corresponding flags are omitted.
+func buildManagedBlock(existingAliases map[string]string) string {
 	var b strings.Builder
-	if aliasNpm {
+	if !removeAliasNpm && (aliasNpm || hasConfiguredAlias(existingAliases, "npm")) {
 		b.WriteString(`alias npm="scfw run -- npm"` + "\n")
 	}
-	if aliasPip {
+	if !removeAliasPip && (aliasPip || hasConfiguredAlias(existingAliases, "pip", "pip3")) {
 		b.WriteString(`alias pip="scfw run -- pip"` + "\n")
 		b.WriteString(`alias pip3="scfw run -- pip3"` + "\n")
 	}
-	if aliasPoetry {
+	if !removeAliasPoetry && (aliasPoetry || hasConfiguredAlias(existingAliases, "poetry")) {
 		b.WriteString(`alias poetry="scfw run -- poetry"` + "\n")
 	}
 	if scfwHome != "" {
@@ -150,6 +165,15 @@ func buildManagedBlock() string {
 		fmt.Fprintf(&b, "export DD_SITE=%q\n", ddSite)
 	}
 	return b.String()
+}
+
+func hasConfiguredAlias(existingAliases map[string]string, names ...string) bool {
+	for _, name := range names {
+		if existingAliases[name] == expectedAliasTarget(name) {
+			return true
+		}
+	}
+	return false
 }
 
 // updateConfigFile merges content into path's managed block and writes the

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -200,41 +200,50 @@ func withAliasPoetry(t *testing.T, value bool) {
 	t.Cleanup(func() { aliasPoetry = original })
 }
 
+// withRemoveAliasPip temporarily sets the package-level removeAliasPip flag
+// for the duration of a test.
+func withRemoveAliasPip(t *testing.T, value bool) {
+	t.Helper()
+	original := removeAliasPip
+	removeAliasPip = value
+	t.Cleanup(func() { removeAliasPip = original })
+}
+
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	if got := buildManagedBlock(); got != "" {
+	if got := buildManagedBlock(nil); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPip(t, true)
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	if got := buildManagedBlock(nil); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 	withAliasNpm(t, false)
-	if got := buildManagedBlock(); got != "" {
+	if got := buildManagedBlock(nil); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasNpm(t, true)
 	want := `alias npm="scfw run -- npm"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	if got := buildManagedBlock(nil); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	if got := buildManagedBlock(); got != "" {
+	if got := buildManagedBlock(nil); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPoetry(t, true)
 	want := `alias poetry="scfw run -- poetry"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	if got := buildManagedBlock(nil); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -253,7 +262,7 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withDdSite(t, "datadoghq.eu")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export DD_SITE="datadoghq.eu"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	if got := buildManagedBlock(nil); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -272,7 +281,7 @@ func TestBuildManagedBlock_IncludesScfwHome(t *testing.T) {
 	withScfwHome(t, "/tmp/scfw-home")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export SCFW_HOME="/tmp/scfw-home"` + "\n"
-	if got := buildManagedBlock(); got != want {
+	if got := buildManagedBlock(nil); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -559,7 +568,7 @@ func TestRunConfigure_WritesScfwHomeExportWithoutCreatingDir(t *testing.T) {
 	}
 }
 
-func TestRunConfigure_TogglingOffRemovesExistingBlock(t *testing.T) {
+func TestRunConfigure_PreservesExistingAliases(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -569,7 +578,7 @@ func TestRunConfigure_TogglingOffRemovesExistingBlock(t *testing.T) {
 		t.Fatalf("failed to seed %q: %v", path, err)
 	}
 
-	withAliasPip(t, false)
+	withAliasNpm(t, true)
 	if err := runConfigure(configureCmd, nil); err != nil {
 		t.Fatalf("runConfigure() returned unexpected error: %v", err)
 	}
@@ -578,11 +587,45 @@ func TestRunConfigure_TogglingOffRemovesExistingBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read %q: %v", path, err)
 	}
-	if strings.Contains(string(got), blockStart) {
-		t.Fatalf(".bashrc = %q, want the managed block removed", got)
+	if !strings.Contains(string(got), `alias npm="scfw run -- npm"`) {
+		t.Fatalf(".bashrc = %q, want the newly configured npm alias", got)
 	}
-	if want := "export FOO=1\n"; string(got) != want {
-		t.Fatalf(".bashrc = %q, want %q", got, want)
+	if !strings.Contains(string(got), `alias pip="scfw run -- pip"`) {
+		t.Fatalf(".bashrc = %q, want the existing pip alias preserved", got)
+	}
+}
+
+func TestRunConfigure_RemovesOnlyRequestedAlias(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".bashrc")
+	seeded := blockStart + "\n" +
+		`alias npm="scfw run -- npm"` + "\n" +
+		`alias pip="scfw run -- pip"` + "\n" +
+		`alias pip3="scfw run -- pip3"` + "\n" +
+		`alias poetry="scfw run -- poetry"` + "\n" +
+		blockEnd + "\n"
+	if err := os.WriteFile(path, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("failed to seed %q: %v", path, err)
+	}
+
+	withRemoveAliasPip(t, true)
+	if err := runConfigure(configureCmd, nil); err != nil {
+		t.Fatalf("runConfigure() returned unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %q: %v", path, err)
+	}
+	if strings.Contains(string(got), `alias pip=`) || strings.Contains(string(got), `alias pip3=`) {
+		t.Fatalf(".bashrc = %q, want the pip aliases removed", got)
+	}
+	for _, want := range []string{`alias npm="scfw run -- npm"`, `alias poetry="scfw run -- poetry"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf(".bashrc = %q, want it to preserve %q", got, want)
+		}
 	}
 }
 
@@ -873,8 +916,14 @@ func resetConfigureCmd(t *testing.T) {
 
 	t.Cleanup(func() {
 		configureCmd.SilenceUsage, configureCmd.SilenceErrors = origSilenceUsage, origSilenceErrors
-		aliasNpm, aliasPip, aliasPoetry, ddAPIKey, ddAppKey, ddSite, scfwHome, remove = false, false, false, "", "", "", "", false
-		for _, name := range []string{"alias-npm", "alias-pip", "alias-poetry", "dd-api-key", "dd-app-key", "dd-site", "scfw-home", "remove"} {
+		aliasNpm, aliasPip, aliasPoetry = false, false, false
+		removeAliasNpm, removeAliasPip, removeAliasPoetry = false, false, false
+		ddAPIKey, ddAppKey, ddSite, scfwHome, remove = "", "", "", "", false
+		for _, name := range []string{
+			"alias-npm", "alias-pip", "alias-poetry",
+			"remove-alias-npm", "remove-alias-pip", "remove-alias-poetry",
+			"dd-api-key", "dd-app-key", "dd-site", "scfw-home", "remove",
+		} {
 			configureCmd.Flags().Lookup(name).Changed = false
 		}
 	})
@@ -888,6 +937,9 @@ func TestConfigureCmd_MutualExclusivityIsEnforced(t *testing.T) {
 		{name: "remove and alias-npm", args: []string{"--remove", "--alias-npm"}},
 		{name: "remove and alias-pip", args: []string{"--remove", "--alias-pip"}},
 		{name: "remove and alias-poetry", args: []string{"--remove", "--alias-poetry"}},
+		{name: "remove and remove-alias-npm", args: []string{"--remove", "--remove-alias-npm"}},
+		{name: "remove and remove-alias-pip", args: []string{"--remove", "--remove-alias-pip"}},
+		{name: "remove and remove-alias-poetry", args: []string{"--remove", "--remove-alias-poetry"}},
 		{name: "remove and dd-api-key", args: []string{"--remove", "--dd-api-key", "some-key"}},
 		{name: "remove and dd-app-key", args: []string{"--remove", "--dd-app-key", "some-key"}},
 		{name: "remove and dd-site", args: []string{"--remove", "--dd-site", "some-site"}},
@@ -901,6 +953,19 @@ func TestConfigureCmd_MutualExclusivityIsEnforced(t *testing.T) {
 			configureCmd.SetArgs(tc.args)
 			if err := configureCmd.Execute(); err == nil {
 				t.Fatalf("configureCmd.Execute(%v) = nil error, want error due to mutually exclusive flags", tc.args)
+			}
+		})
+	}
+}
+
+func TestConfigureCmd_AliasAdditionAndRemovalAreMutuallyExclusive(t *testing.T) {
+	for _, packageManager := range []string{"npm", "pip", "poetry"} {
+		t.Run(packageManager, func(t *testing.T) {
+			resetConfigureCmd(t)
+
+			configureCmd.SetArgs([]string{"--alias-" + packageManager, "--remove-alias-" + packageManager})
+			if err := configureCmd.Execute(); err == nil {
+				t.Fatalf("configureCmd.Execute() = nil error, want mutually exclusive flags error")
 			}
 		})
 	}

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -211,39 +211,39 @@ func withRemoveAliasPip(t *testing.T, value bool) {
 
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	if got := buildManagedBlock(nil); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPip(t, true)
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n"
-	if got := buildManagedBlock(nil); got != want {
+	if got := buildManagedBlock(managedConfiguration{}); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 	withAliasNpm(t, false)
-	if got := buildManagedBlock(nil); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasNpm(t, true)
 	want := `alias npm="scfw run -- npm"` + "\n"
-	if got := buildManagedBlock(nil); got != want {
+	if got := buildManagedBlock(managedConfiguration{}); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	if got := buildManagedBlock(nil); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPoetry(t, true)
 	want := `alias poetry="scfw run -- poetry"` + "\n"
-	if got := buildManagedBlock(nil); got != want {
+	if got := buildManagedBlock(managedConfiguration{}); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -262,7 +262,7 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withDdSite(t, "datadoghq.eu")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export DD_SITE="datadoghq.eu"` + "\n"
-	if got := buildManagedBlock(nil); got != want {
+	if got := buildManagedBlock(managedConfiguration{}); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -281,7 +281,7 @@ func TestBuildManagedBlock_IncludesScfwHome(t *testing.T) {
 	withScfwHome(t, "/tmp/scfw-home")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export SCFW_HOME="/tmp/scfw-home"` + "\n"
-	if got := buildManagedBlock(nil); got != want {
+	if got := buildManagedBlock(managedConfiguration{}); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -605,6 +605,8 @@ func TestRunConfigure_RemovesOnlyRequestedAlias(t *testing.T) {
 		`alias pip="scfw run -- pip"` + "\n" +
 		`alias pip3="scfw run -- pip3"` + "\n" +
 		`alias poetry="scfw run -- poetry"` + "\n" +
+		`export SCFW_HOME="/tmp/scfw-home"` + "\n" +
+		`export DD_SITE="datadoghq.eu"` + "\n" +
 		blockEnd + "\n"
 	if err := os.WriteFile(path, []byte(seeded), 0o644); err != nil {
 		t.Fatalf("failed to seed %q: %v", path, err)
@@ -623,6 +625,11 @@ func TestRunConfigure_RemovesOnlyRequestedAlias(t *testing.T) {
 		t.Fatalf(".bashrc = %q, want the pip aliases removed", got)
 	}
 	for _, want := range []string{`alias npm="scfw run -- npm"`, `alias poetry="scfw run -- poetry"`} {
+		if !strings.Contains(string(got), want) {
+			t.Fatalf(".bashrc = %q, want it to preserve %q", got, want)
+		}
+	}
+	for _, want := range []string{`export SCFW_HOME="/tmp/scfw-home"`, `export DD_SITE="datadoghq.eu"`} {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf(".bashrc = %q, want it to preserve %q", got, want)
 		}

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -211,39 +211,39 @@ func withRemoveAliasPip(t *testing.T, value bool) {
 
 func TestBuildManagedBlock(t *testing.T) {
 	withAliasPip(t, false)
-	if got := buildManagedBlock(managedConfiguration{}); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPip(t, true)
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n"
-	if got := buildManagedBlock(managedConfiguration{}); got != want {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasNpm(t *testing.T) {
 	withAliasNpm(t, false)
-	if got := buildManagedBlock(managedConfiguration{}); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasNpm(t, true)
 	want := `alias npm="scfw run -- npm"` + "\n"
-	if got := buildManagedBlock(managedConfiguration{}); got != want {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
 
 func TestBuildManagedBlock_AliasPoetry(t *testing.T) {
 	withAliasPoetry(t, false)
-	if got := buildManagedBlock(managedConfiguration{}); got != "" {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != "" {
 		t.Fatalf("buildManagedBlock() = %q, want empty string", got)
 	}
 
 	withAliasPoetry(t, true)
 	want := `alias poetry="scfw run -- poetry"` + "\n"
-	if got := buildManagedBlock(managedConfiguration{}); got != want {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -262,7 +262,7 @@ func TestBuildManagedBlock_IncludesDdSite(t *testing.T) {
 	withDdSite(t, "datadoghq.eu")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export DD_SITE="datadoghq.eu"` + "\n"
-	if got := buildManagedBlock(managedConfiguration{}); got != want {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -281,7 +281,7 @@ func TestBuildManagedBlock_IncludesScfwHome(t *testing.T) {
 	withScfwHome(t, "/tmp/scfw-home")
 
 	want := `alias pip="scfw run -- pip"` + "\n" + `alias pip3="scfw run -- pip3"` + "\n" + `export SCFW_HOME="/tmp/scfw-home"` + "\n"
-	if got := buildManagedBlock(managedConfiguration{}); got != want {
+	if got := buildManagedBlock(managedConfiguration{}, false, false); got != want {
 		t.Fatalf("buildManagedBlock() = %q, want %q", got, want)
 	}
 }
@@ -633,6 +633,62 @@ func TestRunConfigure_RemovesOnlyRequestedAlias(t *testing.T) {
 		if !strings.Contains(string(got), want) {
 			t.Fatalf(".bashrc = %q, want it to preserve %q", got, want)
 		}
+	}
+}
+
+func TestConfigureCmd_ExplicitEmptyExportRemovesExistingValue(t *testing.T) {
+	tests := []struct {
+		name          string
+		flag          string
+		removedExport string
+		keptExport    string
+	}{
+		{
+			name:          "scfw home",
+			flag:          "--scfw-home=",
+			removedExport: `export SCFW_HOME="/tmp/scfw-home"`,
+			keptExport:    `export DD_SITE="datadoghq.eu"`,
+		},
+		{
+			name:          "Datadog site",
+			flag:          "--dd-site=",
+			removedExport: `export DD_SITE="datadoghq.eu"`,
+			keptExport:    `export SCFW_HOME="/tmp/scfw-home"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetConfigureCmd(t)
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
+			path := filepath.Join(home, ".bashrc")
+			seeded := blockStart + "\n" +
+				`alias npm="scfw run -- npm"` + "\n" +
+				`export SCFW_HOME="/tmp/scfw-home"` + "\n" +
+				`export DD_SITE="datadoghq.eu"` + "\n" +
+				blockEnd + "\n"
+			if err := os.WriteFile(path, []byte(seeded), 0o644); err != nil {
+				t.Fatalf("failed to seed %q: %v", path, err)
+			}
+
+			configureCmd.SetArgs([]string{tc.flag})
+			if err := configureCmd.Execute(); err != nil {
+				t.Fatalf("configureCmd.Execute() returned unexpected error: %v", err)
+			}
+
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read %q: %v", path, err)
+			}
+			if strings.Contains(string(got), tc.removedExport) {
+				t.Fatalf(".bashrc = %q, want it to remove %q", got, tc.removedExport)
+			}
+			if !strings.Contains(string(got), tc.keptExport) {
+				t.Fatalf(".bashrc = %q, want it to preserve %q", got, tc.keptExport)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 🚀 Motivation

Repeated `scfw configure` runs replaced previously managed aliases, making incremental setup error-prone and preventing targeted alias removal.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Better alias configuration in CLI](https://datadoghq.atlassian.net/browse/K9CODESEC-5049)

## 📝 Summary

Preserve existing npm, pip, and Poetry aliases when configuration is run again, and add mutually exclusive flags to remove each package-manager alias selectively. Managed `SCFW_HOME` and `DD_SITE` exports are preserved unless explicitly changed or cleared. Documentation and regression coverage are updated accordingly.

The branch also contains a separate CODEOWNERS team update.

## 🧪 Testing

- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🚧 Staging validation

- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
