### PR TITLE
✨ Add shell autocomplete to SCFW CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ $ scfw configure \
 
 When passing these values via shell variables, e.g. in scripts, prefer this `=` form: `--dd-api-key=$DD_API_KEY --dd-app-key=$DD_APP_KEY --dd-site=$DD_SITE`.
 
-This does two things:
+This does three things:
 
 1. Stores your Datadog API key and application key securely in your system's keychain, so credentials don't need to be kept in plaintext or supplied on every command.
 2. Adds shell aliases to your `.bashrc`, `.bash_profile`, `.zshrc`, and `.zprofile` (whichever already exist) so that `npm`, `pip`/`pip3`, and/or `poetry` transparently run through `scfw`. Restart your shell (or source the relevant rc file) for the aliases to take effect.
+3. Enables `scfw` command completion for Bash and Zsh. The package-manager aliases keep using the existing npm, pip, and Poetry completions installed in your shell.
 
 `scfw configure` is idempotent and may be re-run at any time to change your configuration. Alias options are additive, so aliases configured by an earlier invocation remain in place unless their corresponding `--remove-alias-*` option is passed. The command manages its own clearly indicated block of your shell rc files and never touches anything else you've added.
 

--- a/scfw/internal/cli/configure.go
+++ b/scfw/internal/cli/configure.go
@@ -117,6 +117,7 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		errs = append(errs, fmt.Errorf("scfw configure: %w", err))
 		return errors.Join(errs...)
 	}
+	completionFiles := shellCompletionFiles(home)
 
 	for _, name := range configFiles {
 		path := filepath.Join(home, name)
@@ -132,6 +133,9 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 				cmd.Flags().Changed("scfw-home"),
 				cmd.Flags().Changed("dd-site"),
 			)
+			if completionFiles[name] {
+				content += shellCompletionConfig(name)
+			}
 		}
 		if err := updateConfigFile(path, content); err != nil {
 			errs = append(errs, err)
@@ -145,6 +149,44 @@ func runConfigure(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("scfw configure: write restart notice: %w", err)
 	}
 	return nil
+}
+
+// shellCompletionFiles selects every Bash startup file because interactive
+// login shells may not source .bashrc. Zsh sources .zshrc for every interactive
+// shell, so .zprofile is only needed as a fallback for profile-only setups.
+func shellCompletionFiles(home string) map[string]bool {
+	selected := map[string]bool{".bashrc": true, ".bash_profile": true}
+	zshFile := ".zshrc"
+	if _, err := os.Stat(filepath.Join(home, zshFile)); os.IsNotExist(err) {
+		zshFile = ".zprofile"
+	}
+	selected[zshFile] = true
+	return selected
+}
+
+// shellCompletionConfig enables Cobra completion for the shell that sources
+// the configuration file. Package-manager aliases keep their own command names,
+// so their existing npm, pip, and Poetry completion definitions remain active.
+func shellCompletionConfig(configFile string) string {
+	switch configFile {
+	case ".bashrc", ".bash_profile":
+		return `if [[ $- == *i* ]] && ! complete -p scfw >/dev/null 2>&1; then
+  source <(scfw completion bash)
+fi
+`
+	case ".zshrc", ".zprofile":
+		return `if [[ -o interactive ]]; then
+  if (( ! $+functions[compdef] )); then
+    autoload -U compinit && compinit
+  fi
+  if [[ -z ${_comps[scfw]-} ]]; then
+    source <(scfw completion zsh)
+  fi
+fi
+`
+	default:
+		return ""
+	}
 }
 
 // buildManagedBlock formats the currently selected configuration options

--- a/scfw/internal/cli/configure_test.go
+++ b/scfw/internal/cli/configure_test.go
@@ -595,6 +595,130 @@ func TestRunConfigure_PreservesExistingAliases(t *testing.T) {
 	}
 }
 
+func TestRunConfigure_EnablesCompletionAndPreservesPackageManagerAliases(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name                string
+		completion          string
+		interactiveGuard    string
+		idempotencyGuard    string
+		completionInitGuard string
+		wantCompletion      bool
+	}{
+		{
+			name: ".bashrc", completion: "bash", interactiveGuard: "[[ $- == *i* ]]",
+			idempotencyGuard: "! complete -p scfw", wantCompletion: true,
+		},
+		{
+			name: ".bash_profile", completion: "bash", interactiveGuard: "[[ $- == *i* ]]",
+			idempotencyGuard: "! complete -p scfw", wantCompletion: true,
+		},
+		{
+			name: ".zshrc", completion: "zsh", interactiveGuard: "[[ -o interactive ]]",
+			idempotencyGuard: "${_comps[scfw]-}", completionInitGuard: "$+functions[compdef]", wantCompletion: true,
+		},
+		{name: ".zprofile", completion: "zsh"},
+	}
+	for _, tc := range tests {
+		if err := os.WriteFile(filepath.Join(home, tc.name), nil, 0o644); err != nil {
+			t.Fatalf("failed to seed %q: %v", tc.name, err)
+		}
+	}
+
+	withAliasNpm(t, true)
+	withAliasPip(t, true)
+	withAliasPoetry(t, true)
+	if err := runConfigure(configureCmd, nil); err != nil {
+		t.Fatalf("runConfigure() returned unexpected error: %v", err)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := os.ReadFile(filepath.Join(home, tc.name))
+			if err != nil {
+				t.Fatalf("failed to read %q: %v", tc.name, err)
+			}
+			for _, want := range []string{
+				`alias npm="scfw run -- npm"`,
+				`alias pip="scfw run -- pip"`,
+				`alias pip3="scfw run -- pip3"`,
+				`alias poetry="scfw run -- poetry"`,
+			} {
+				if !strings.Contains(string(got), want) {
+					t.Errorf("%s = %q, want it to contain %q", tc.name, got, want)
+				}
+			}
+			completion := "source <(scfw completion " + tc.completion + ")"
+			if tc.wantCompletion {
+				for _, want := range []string{completion, tc.interactiveGuard, tc.idempotencyGuard, tc.completionInitGuard} {
+					if want == "" {
+						continue
+					}
+					if !strings.Contains(string(got), want) {
+						t.Errorf("%s = %q, want it to contain %q", tc.name, got, want)
+					}
+				}
+			} else if strings.Contains(string(got), completion) {
+				t.Errorf("%s = %q, want completion configured only in the preferred rc file", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestRunConfigure_EnablesGuardedCompletionInProfileOnlySetups(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := []struct {
+		name                string
+		completion          string
+		interactiveGuard    string
+		idempotencyGuard    string
+		completionInitGuard string
+	}{
+		{
+			name: ".bash_profile", completion: "bash", interactiveGuard: "[[ $- == *i* ]]",
+			idempotencyGuard: "! complete -p scfw",
+		},
+		{
+			name: ".zprofile", completion: "zsh", interactiveGuard: "[[ -o interactive ]]",
+			idempotencyGuard: "${_comps[scfw]-}", completionInitGuard: "$+functions[compdef]",
+		},
+	}
+	for _, tc := range tests {
+		if err := os.WriteFile(filepath.Join(home, tc.name), nil, 0o644); err != nil {
+			t.Fatalf("failed to seed %q: %v", tc.name, err)
+		}
+	}
+
+	withAliasNpm(t, true)
+	if err := runConfigure(configureCmd, nil); err != nil {
+		t.Fatalf("runConfigure() returned unexpected error: %v", err)
+	}
+
+	for _, tc := range tests {
+		got, err := os.ReadFile(filepath.Join(home, tc.name))
+		if err != nil {
+			t.Fatalf("failed to read %q: %v", tc.name, err)
+		}
+		for _, want := range []string{
+			"source <(scfw completion " + tc.completion + ")",
+			tc.interactiveGuard,
+			tc.idempotencyGuard,
+			tc.completionInitGuard,
+		} {
+			if want == "" {
+				continue
+			}
+			if !strings.Contains(string(got), want) {
+				t.Errorf("%s = %q, want it to contain %q", tc.name, got, want)
+			}
+		}
+	}
+}
+
 func TestRunConfigure_RemovesOnlyRequestedAlias(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## 🚀 Motivation

Enable shell autocomplete for SCFW while preserving completion behavior for npm, pip, and Poetry commands routed through SCFW aliases.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [Add an autocomplete to SCFW Go CLI](https://datadoghq.atlassian.net/browse/K9CODESEC-5048)

## 📝 Summary

Update `scfw configure` to install guarded, idempotent Cobra completion for interactive Bash and Zsh shells. The startup-file handling avoids non-interactive execution and duplicate initialization while preserving existing SCFW and package-manager completion registrations. Document the new configuration behavior.

## 🧪 Testing
- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

Validated with focused CLI tests, both repository lint targets, the GoReleaser snapshot build, and direct interactive Bash/Zsh checks.

## 🚧 Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: