### PR TITLE
🐛 Suppress doctor usage on diagnostic failures

### DIFF
--- a/scfw/internal/cli/doctor.go
+++ b/scfw/internal/cli/doctor.go
@@ -25,6 +25,10 @@ var doctorCmd = &cobra.Command{
 }
 
 func runDoctor(cmd *cobra.Command, args []string) error {
+	// Diagnostic failures describe an unhealthy installation rather than invalid
+	// command usage, so do not append Cobra's usage text when returning them.
+	cmd.SilenceUsage = true
+
 	apiKey, apiKeyCredentialSource, apiKeyErr := ddapi.ResolveDatadogAPIKey()
 	appKey, appKeyCredentialSource, appKeyErr := ddapi.ResolveDatadogAppKey()
 	apiKeyReportErr := reportCredential(cmd.OutOrStdout(), "API Key", apiKey, apiKeyCredentialSource, apiKeyErr)

--- a/scfw/internal/cli/doctor_test.go
+++ b/scfw/internal/cli/doctor_test.go
@@ -32,6 +32,32 @@ func TestDoctorCmdRejectsArguments(t *testing.T) {
 	}
 }
 
+func TestDoctorCmd_DiagnosticFailuresDoNotPrintUsage(t *testing.T) {
+	t.Setenv("DD_API_KEY", "api-key")
+	t.Setenv("DD_APP_KEY", "app-key")
+	t.Setenv("HOME", "")
+
+	origSilenceUsage := doctorCmd.SilenceUsage
+	t.Cleanup(func() { doctorCmd.SilenceUsage = origSilenceUsage })
+
+	cmd := RootCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"doctor"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil error, want shell-configuration diagnostic error")
+	}
+	if !strings.Contains(err.Error(), "could not locate shell configuration") {
+		t.Fatalf("Execute() error = %q, want shell-configuration diagnostic", err)
+	}
+	if strings.Contains(output.String(), "Usage:") {
+		t.Fatalf("Execute() output contains usage for a diagnostic failure: %q", output.String())
+	}
+}
+
 func TestReportCredentialDistinguishesCredentialErrors(t *testing.T) {
 	var output bytes.Buffer
 	apiErr := errors.New("API key lookup failed")


### PR DESCRIPTION
## 🚀 Motivation
Prevent `scfw doctor` from printing command usage when it detects an unhealthy or incomplete configuration, since those failures are diagnostic results rather than invocation errors.

## 📝 Summary
Suppress Cobra usage output after the `doctor` command begins its diagnostic checks, while preserving normal argument-validation behavior. Add a regression test that executes the command through the root command and verifies diagnostic errors do not append usage text.

## 🧪 Testing
- [x] New tests were added for new logic.
- [ ] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🆘 Recovery
Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?: