### PR TITLE
Report verifier failures and matched policies separately in the run report

### DIFF
--- a/scfw/internal/ddapi/report.go
+++ b/scfw/internal/ddapi/report.go
@@ -39,12 +39,13 @@ type ddReportAttributes struct {
 }
 
 type ddPackageReport struct {
-	Ecosystem string      `json:"ecosystem"`
-	Package   string      `json:"package"`
-	Version   string      `json:"version"`
-	Warning   bool        `json:"warning"`
-	Findings  []ddFinding `json:"findings"`
-	Failures  []ddFailure `json:"failures"`
+	Ecosystem       string            `json:"ecosystem"`
+	Package         string            `json:"package"`
+	Version         string            `json:"version"`
+	Warning         bool              `json:"warning"`
+	Findings        []ddFinding       `json:"findings"`
+	Failures        []ddFailure       `json:"failures"`
+	MatchedPolicies []ddMatchedPolicy `json:"matched_policies"`
 }
 
 type ddFinding struct {
@@ -55,6 +56,12 @@ type ddFinding struct {
 type ddFailure struct {
 	Verifier string `json:"verifier"`
 	Error    string `json:"error"`
+}
+
+type ddMatchedPolicy struct {
+	Type    string `json:"type"`
+	Rule    string `json:"rule,omitempty"`
+	Outcome string `json:"outcome"`
 }
 
 // Report the firewall's ultimate decision to the Code Security API. resolvedOutcome is
@@ -130,12 +137,13 @@ func packageReports(results []PackageEvaluationResult) []ddPackageReport {
 	reports := make([]ddPackageReport, 0, len(results))
 	for _, result := range results {
 		reports = append(reports, ddPackageReport{
-			Ecosystem: result.Ecosystem,
-			Package:   result.PackageName,
-			Version:   result.PackageVersion,
-			Warning:   result.Outcome == OutcomeWarn,
-			Findings:  packageFindings(result),
-			Failures:  packageFailures(result),
+			Ecosystem:       result.Ecosystem,
+			Package:         result.PackageName,
+			Version:         result.PackageVersion,
+			Warning:         result.Outcome == OutcomeWarn,
+			Findings:        packageFindings(result),
+			Failures:        packageFailures(result),
+			MatchedPolicies: packageMatchedPolicies(result),
 		})
 	}
 	return reports
@@ -157,4 +165,13 @@ func packageFailures(result PackageEvaluationResult) []ddFailure {
 		failures = append(failures, ddFailure{Verifier: f.Verifier, Error: f.Error})
 	}
 	return failures
+}
+
+// Generate the matched policies for a single package evaluation result.
+func packageMatchedPolicies(result PackageEvaluationResult) []ddMatchedPolicy {
+	policies := make([]ddMatchedPolicy, 0, len(result.MatchedPolicy))
+	for _, p := range result.MatchedPolicy {
+		policies = append(policies, ddMatchedPolicy{Type: p.Type, Rule: p.Rule, Outcome: string(p.Outcome)})
+	}
+	return policies
 }

--- a/scfw/internal/ddapi/report.go
+++ b/scfw/internal/ddapi/report.go
@@ -162,7 +162,7 @@ func packageFindings(result PackageEvaluationResult) []ddFinding {
 func packageFailures(result PackageEvaluationResult) []ddFailure {
 	failures := make([]ddFailure, 0, len(result.Failures))
 	for _, f := range result.Failures {
-		failures = append(failures, ddFailure{Verifier: f.Verifier, Error: f.Error})
+		failures = append(failures, ddFailure(f))
 	}
 	return failures
 }

--- a/scfw/internal/ddapi/report.go
+++ b/scfw/internal/ddapi/report.go
@@ -44,11 +44,17 @@ type ddPackageReport struct {
 	Version   string      `json:"version"`
 	Warning   bool        `json:"warning"`
 	Findings  []ddFinding `json:"findings"`
+	Failures  []ddFailure `json:"failures"`
 }
 
 type ddFinding struct {
 	Verifier string `json:"verifier"`
 	Finding  string `json:"finding"`
+}
+
+type ddFailure struct {
+	Verifier string `json:"verifier"`
+	Error    string `json:"error"`
 }
 
 // Report the firewall's ultimate decision to the Code Security API. resolvedOutcome is
@@ -129,20 +135,26 @@ func packageReports(results []PackageEvaluationResult) []ddPackageReport {
 			Version:   result.PackageVersion,
 			Warning:   result.Outcome == OutcomeWarn,
 			Findings:  packageFindings(result),
+			Failures:  packageFailures(result),
 		})
 	}
 	return reports
 }
 
-// Generate the findings for a single package evaluation result, combining its matched
-// policies and any verifier failures.
+// Generate the findings for a single package evaluation result's matched policies.
 func packageFindings(result PackageEvaluationResult) []ddFinding {
-	findings := make([]ddFinding, 0, len(result.MatchedPolicy)+len(result.Failures))
+	findings := make([]ddFinding, 0, len(result.MatchedPolicy))
 	for _, policy := range result.MatchedPolicy {
 		findings = append(findings, ddFinding{Verifier: policy.Type, Finding: policy.Rule})
 	}
-	for _, f := range result.Failures {
-		findings = append(findings, ddFinding{Verifier: f.Verifier, Finding: f.Error})
-	}
 	return findings
+}
+
+// Generate the failures for a single package evaluation result's verifier failures.
+func packageFailures(result PackageEvaluationResult) []ddFailure {
+	failures := make([]ddFailure, 0, len(result.Failures))
+	for _, f := range result.Failures {
+		failures = append(failures, ddFailure{Verifier: f.Verifier, Error: f.Error})
+	}
+	return failures
 }

--- a/scfw/internal/ddapi/report_test.go
+++ b/scfw/internal/ddapi/report_test.go
@@ -47,6 +47,9 @@ func TestPackageReports(t *testing.T) {
 				{Verifier: "org_policy", Finding: "no-requests"},
 			},
 			Failures: []ddFailure{},
+			MatchedPolicies: []ddMatchedPolicy{
+				{Type: "org_policy", Rule: "no-requests", Outcome: "BLOCK"},
+			},
 		},
 		{
 			Ecosystem: "npm",
@@ -57,6 +60,7 @@ func TestPackageReports(t *testing.T) {
 			Failures: []ddFailure{
 				{Verifier: "datadog_policy", Error: "advisory-db lookup timed out"},
 			},
+			MatchedPolicies: []ddMatchedPolicy{},
 		},
 	}
 
@@ -190,6 +194,35 @@ func TestPackageFailures(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := packageFailures(tt.result); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("packageFailures() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPackageMatchedPolicies(t *testing.T) {
+	tests := []struct {
+		name   string
+		result PackageEvaluationResult
+		want   []ddMatchedPolicy
+	}{
+		{
+			name:   "no matched policy",
+			result: PackageEvaluationResult{},
+			want:   []ddMatchedPolicy{},
+		},
+		{
+			name: "matched policy only",
+			result: PackageEvaluationResult{
+				MatchedPolicy: []matchedPolicy{{Type: "org_policy", Rule: "no-foo", Outcome: OutcomeBlock}},
+			},
+			want: []ddMatchedPolicy{{Type: "org_policy", Rule: "no-foo", Outcome: "BLOCK"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := packageMatchedPolicies(tt.result); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("packageMatchedPolicies() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/scfw/internal/ddapi/report_test.go
+++ b/scfw/internal/ddapi/report_test.go
@@ -46,14 +46,16 @@ func TestPackageReports(t *testing.T) {
 			Findings: []ddFinding{
 				{Verifier: "org_policy", Finding: "no-requests"},
 			},
+			Failures: []ddFailure{},
 		},
 		{
 			Ecosystem: "npm",
 			Package:   "left-pad",
 			Version:   "1.3.0",
 			Warning:   true,
-			Findings: []ddFinding{
-				{Verifier: "datadog_policy", Finding: "advisory-db lookup timed out"},
+			Findings:  []ddFinding{},
+			Failures: []ddFailure{
+				{Verifier: "datadog_policy", Error: "advisory-db lookup timed out"},
 			},
 		},
 	}
@@ -135,7 +137,7 @@ func TestPackageFindings(t *testing.T) {
 		want   []ddFinding
 	}{
 		{
-			name:   "no matched policy or failures",
+			name:   "no matched policy",
 			result: PackageEvaluationResult{},
 			want:   []ddFinding{},
 		},
@@ -147,22 +149,11 @@ func TestPackageFindings(t *testing.T) {
 			want: []ddFinding{{Verifier: "org_policy", Finding: "no-foo"}},
 		},
 		{
-			name: "failures only",
+			name: "failures are not included",
 			result: PackageEvaluationResult{
 				Failures: []failure{{Verifier: "datadog_policy", Error: "timed out"}},
 			},
-			want: []ddFinding{{Verifier: "datadog_policy", Finding: "timed out"}},
-		},
-		{
-			name: "matched policy and failures combined, in order",
-			result: PackageEvaluationResult{
-				MatchedPolicy: []matchedPolicy{{Type: "org_policy", Rule: "no-foo"}},
-				Failures:      []failure{{Verifier: "datadog_policy", Error: "timed out"}},
-			},
-			want: []ddFinding{
-				{Verifier: "org_policy", Finding: "no-foo"},
-				{Verifier: "datadog_policy", Finding: "timed out"},
-			},
+			want: []ddFinding{},
 		},
 	}
 
@@ -170,6 +161,35 @@ func TestPackageFindings(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := packageFindings(tt.result); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("packageFindings() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPackageFailures(t *testing.T) {
+	tests := []struct {
+		name   string
+		result PackageEvaluationResult
+		want   []ddFailure
+	}{
+		{
+			name:   "no failures",
+			result: PackageEvaluationResult{},
+			want:   []ddFailure{},
+		},
+		{
+			name: "failures only",
+			result: PackageEvaluationResult{
+				Failures: []failure{{Verifier: "datadog_policy", Error: "timed out"}},
+			},
+			want: []ddFailure{{Verifier: "datadog_policy", Error: "timed out"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := packageFailures(tt.result); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("packageFailures() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## 🚀 Motivation
The report payload sent to the Code Security API conflated verifier failures with matched policy findings in a single list, making it impossible for consumers to distinguish a policy match from a verifier that errored out.

## 📝 Summary
- Verifier failures are now reported in their own `failures` field instead of being merged into `findings`.
- Matched policies are now also reported explicitly via a new `matched_policies` field, capturing the policy type, rule, and outcome for each match.

## 🧪 Testing
- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!