### PR TITLE
Remove findings field from Code Security API report payload

### DIFF
--- a/scfw/internal/ddapi/report.go
+++ b/scfw/internal/ddapi/report.go
@@ -44,14 +44,8 @@ type ddPackageReport struct {
 	Package         string            `json:"package"`
 	Version         string            `json:"version"`
 	Warning         bool              `json:"warning"`
-	Findings        []ddFinding       `json:"findings"`
 	Failures        []ddFailure       `json:"failures"`
 	MatchedPolicies []ddMatchedPolicy `json:"matched_policies"`
-}
-
-type ddFinding struct {
-	Verifier string `json:"verifier"`
-	Finding  string `json:"finding"`
 }
 
 type ddFailure struct {
@@ -143,21 +137,11 @@ func packageReports(results []PackageEvaluationResult) []ddPackageReport {
 			Package:         result.PackageName,
 			Version:         result.PackageVersion,
 			Warning:         result.Outcome == OutcomeWarn,
-			Findings:        packageFindings(result),
 			Failures:        packageFailures(result),
 			MatchedPolicies: packageMatchedPolicies(result),
 		})
 	}
 	return reports
-}
-
-// Generate the findings for a single package evaluation result's matched policies.
-func packageFindings(result PackageEvaluationResult) []ddFinding {
-	findings := make([]ddFinding, 0, len(result.MatchedPolicy))
-	for _, policy := range result.MatchedPolicy {
-		findings = append(findings, ddFinding{Verifier: policy.Type, Finding: policy.Rule})
-	}
-	return findings
 }
 
 // Generate the failures for a single package evaluation result's verifier failures.

--- a/scfw/internal/ddapi/report_test.go
+++ b/scfw/internal/ddapi/report_test.go
@@ -61,10 +61,7 @@ func TestPackageReports(t *testing.T) {
 			Package:   "requests",
 			Version:   "2.31.0",
 			Warning:   false,
-			Findings: []ddFinding{
-				{Verifier: "org_policy", Finding: "no-requests"},
-			},
-			Failures: []ddFailure{},
+			Failures:  []ddFailure{},
 			MatchedPolicies: []ddMatchedPolicy{
 				{Type: "org_policy", Rule: "no-requests", Outcome: "BLOCK"},
 			},
@@ -74,7 +71,6 @@ func TestPackageReports(t *testing.T) {
 			Package:   "left-pad",
 			Version:   "1.3.0",
 			Warning:   true,
-			Findings:  []ddFinding{},
 			Failures: []ddFailure{
 				{Verifier: "datadog_policy", Error: "advisory-db lookup timed out"},
 			},
@@ -147,42 +143,6 @@ func TestReportedResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := reportedResults(tt.evaluationReport, tt.resolvedOutcome); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("reportedResults() = %+v, want %+v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestPackageFindings(t *testing.T) {
-	tests := []struct {
-		name   string
-		result PackageEvaluationResult
-		want   []ddFinding
-	}{
-		{
-			name:   "no matched policy",
-			result: PackageEvaluationResult{},
-			want:   []ddFinding{},
-		},
-		{
-			name: "matched policy only",
-			result: PackageEvaluationResult{
-				MatchedPolicy: []matchedPolicy{{Type: "org_policy", Rule: "no-foo"}},
-			},
-			want: []ddFinding{{Verifier: "org_policy", Finding: "no-foo"}},
-		},
-		{
-			name: "failures are not included",
-			result: PackageEvaluationResult{
-				Failures: []failure{{Verifier: "datadog_policy", Error: "timed out"}},
-			},
-			want: []ddFinding{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := packageFindings(tt.result); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("packageFindings() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## 🚀 Motivation
`findings` is redundant now that the CLI reports `policies` and `failures` separately, and the field can be dropped.

## 📝 Summary
Removes the `findings` field from the Code Security API report payload emitted by the supply chain firewall CLI, since matched policies and verifier failures already convey that information.

## 🧪 Testing
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] New tests were added for new logic.
- [ ] Benchmark results prove that performance is the same or better.