### PR TITLE
🐛 Populate package artifact sources in firewall reports

### DIFF
--- a/scfw/internal/cli/run.go
+++ b/scfw/internal/cli/run.go
@@ -158,6 +158,7 @@ func runFirewall(cmd *cobra.Command, args []string) error {
 		packageManagerName,
 		packageManager.Executable(),
 		gitMetadata.RepositoryURL,
+		installTargets,
 		evaluationReport,
 		action,
 	); err != nil {

--- a/scfw/internal/ddapi/report.go
+++ b/scfw/internal/ddapi/report.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/DataDog/supply-chain-firewall/scfw/internal/pm"
 )
 
 // Code Security API endpoint for submitting SCFW run reports.
@@ -40,12 +42,13 @@ type ddReportAttributes struct {
 }
 
 type ddPackageReport struct {
-	Ecosystem       string            `json:"ecosystem"`
-	Package         string            `json:"package"`
-	Version         string            `json:"version"`
-	Warning         bool              `json:"warning"`
-	Failures        []ddFailure       `json:"failures"`
-	MatchedPolicies []ddMatchedPolicy `json:"matched_policies"`
+	Ecosystem             string            `json:"ecosystem"`
+	Package               string            `json:"package"`
+	Version               string            `json:"version"`
+	PackageArtifactSource string            `json:"package_artifact_source,omitempty"`
+	Warning               bool              `json:"warning"`
+	Failures              []ddFailure       `json:"failures"`
+	MatchedPolicies       []ddMatchedPolicy `json:"matched_policies"`
 }
 
 type ddFailure struct {
@@ -68,6 +71,7 @@ func ReportFirewallOutcome(
 	installTimestamp time.Time,
 	command []string,
 	packageManagerName, executable, repository string,
+	installTargets *pm.Set[pm.Package],
 	evaluationReport ScfwPolicyEvaluationReport,
 	resolvedOutcome Outcome,
 ) error {
@@ -97,7 +101,7 @@ func ReportFirewallOutcome(
 				Command:          strings.Join(command, " "),
 				Repository:       repository,
 				Outcome:          string(resolvedOutcome),
-				Reports:          packageReports(reportedResults(evaluationReport, resolvedOutcome)),
+				Reports:          packageReports(reportedResults(evaluationReport, resolvedOutcome), installTargets),
 			},
 		},
 	}
@@ -129,19 +133,49 @@ func reportedResults(evaluationReport ScfwPolicyEvaluationReport, resolvedOutcom
 }
 
 // Generate package reports for a set of policy evaluation results.
-func packageReports(results []PackageEvaluationResult) []ddPackageReport {
+func packageReports(results []PackageEvaluationResult, installTargets *pm.Set[pm.Package]) []ddPackageReport {
+	artifactSources := make(map[packageCoordinates]string, installTargets.Len())
+	ambiguousCoordinates := make(map[packageCoordinates]struct{})
+	for target := range installTargets.Items() {
+		coordinates := packageCoordinates{
+			ecosystem: string(target.Ecosystem),
+			name:      target.Name,
+			version:   target.Version,
+		}
+		if _, ambiguous := ambiguousCoordinates[coordinates]; ambiguous {
+			continue
+		}
+		if source, found := artifactSources[coordinates]; found && source != target.Source {
+			delete(artifactSources, coordinates)
+			ambiguousCoordinates[coordinates] = struct{}{}
+			continue
+		}
+		artifactSources[coordinates] = target.Source
+	}
+
 	reports := make([]ddPackageReport, 0, len(results))
 	for _, result := range results {
 		reports = append(reports, ddPackageReport{
-			Ecosystem:       result.Ecosystem,
-			Package:         result.PackageName,
-			Version:         result.PackageVersion,
+			Ecosystem: result.Ecosystem,
+			Package:   result.PackageName,
+			Version:   result.PackageVersion,
+			PackageArtifactSource: artifactSources[packageCoordinates{
+				ecosystem: result.Ecosystem,
+				name:      result.PackageName,
+				version:   result.PackageVersion,
+			}],
 			Warning:         result.Outcome == OutcomeWarn,
 			Failures:        packageFailures(result),
 			MatchedPolicies: packageMatchedPolicies(result),
 		})
 	}
 	return reports
+}
+
+type packageCoordinates struct {
+	ecosystem string
+	name      string
+	version   string
 }
 
 // Generate the failures for a single package evaluation result's verifier failures.

--- a/scfw/internal/ddapi/report_test.go
+++ b/scfw/internal/ddapi/report_test.go
@@ -9,6 +9,9 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/DataDog/supply-chain-firewall/scfw/internal/ecosystem"
+	"github.com/DataDog/supply-chain-firewall/scfw/internal/pm"
 )
 
 func TestDDReportAttributesMarshalsRepository(t *testing.T) {
@@ -29,6 +32,20 @@ func TestDDReportAttributesMarshalsRepository(t *testing.T) {
 }
 
 func TestPackageReports(t *testing.T) {
+	installTargets := pm.NewSet(
+		pm.Package{
+			Ecosystem: ecosystem.PYPI,
+			Name:      "requests",
+			Version:   "2.31.0",
+			Source:    "https://files.pythonhosted.org/packages/requests-2.31.0.whl",
+		},
+		pm.Package{
+			Ecosystem: ecosystem.NPM,
+			Name:      "left-pad",
+			Version:   "1.3.0",
+			Source:    "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+		},
+	)
 	evaluationReport := ScfwPolicyEvaluationReport{
 		Outcome: OutcomeBlock,
 		Results: []PackageEvaluationResult{
@@ -53,24 +70,26 @@ func TestPackageReports(t *testing.T) {
 		},
 	}
 
-	got := packageReports(evaluationReport.Results)
+	got := packageReports(evaluationReport.Results, installTargets)
 
 	want := []ddPackageReport{
 		{
-			Ecosystem: "PyPI",
-			Package:   "requests",
-			Version:   "2.31.0",
-			Warning:   false,
-			Failures:  []ddFailure{},
+			Ecosystem:             "PyPI",
+			Package:               "requests",
+			Version:               "2.31.0",
+			PackageArtifactSource: "https://files.pythonhosted.org/packages/requests-2.31.0.whl",
+			Warning:               false,
+			Failures:              []ddFailure{},
 			MatchedPolicies: []ddMatchedPolicy{
 				{Type: "org_policy", Rule: "no-requests", Outcome: "BLOCK"},
 			},
 		},
 		{
-			Ecosystem: "npm",
-			Package:   "left-pad",
-			Version:   "1.3.0",
-			Warning:   true,
+			Ecosystem:             "npm",
+			Package:               "left-pad",
+			Version:               "1.3.0",
+			PackageArtifactSource: "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			Warning:               true,
 			Failures: []ddFailure{
 				{Verifier: "datadog_policy", Error: "advisory-db lookup timed out"},
 			},
@@ -90,9 +109,44 @@ func TestPackageReports_DoesNotFilterResults(t *testing.T) {
 		{Ecosystem: "PyPI", PackageName: "six", PackageVersion: "1.17.0", Outcome: OutcomeAllow},
 	}
 
-	got := packageReports(results)
+	got := packageReports(results, pm.NewSet[pm.Package]())
 	if len(got) != 1 {
 		t.Fatalf("len(packageReports()) = %d, want 1", len(got))
+	}
+}
+
+func TestPackageReports_OmitsAmbiguousPackageArtifactSource(t *testing.T) {
+	installTargets := pm.NewSet(
+		pm.Package{Ecosystem: ecosystem.NPM, Name: "example", Version: "1.0.0", Source: "https://registry.example.com/example.tgz"},
+		pm.Package{Ecosystem: ecosystem.NPM, Name: "example", Version: "1.0.0", Source: "file:///local/example"},
+	)
+	results := []PackageEvaluationResult{
+		{Ecosystem: "npm", PackageName: "example", PackageVersion: "1.0.0", Outcome: OutcomeAllow},
+	}
+
+	got := packageReports(results, installTargets)
+	if len(got) != 1 {
+		t.Fatalf("len(packageReports()) = %d, want 1", len(got))
+	}
+	if got[0].PackageArtifactSource != "" {
+		t.Fatalf("PackageArtifactSource = %q, want empty for ambiguous package coordinates", got[0].PackageArtifactSource)
+	}
+}
+
+func TestDDPackageReportMarshalsPackageArtifactSource(t *testing.T) {
+	report := ddPackageReport{PackageArtifactSource: "https://example.com/package.tgz"}
+
+	body, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("json.Marshal() returned unexpected error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("json.Unmarshal() returned unexpected error: %v", err)
+	}
+	if got["package_artifact_source"] != report.PackageArtifactSource {
+		t.Fatalf("package_artifact_source = %v, want %q", got["package_artifact_source"], report.PackageArtifactSource)
 	}
 }
 


### PR DESCRIPTION
## 🚀 Motivation

SCFW resolves package artifact sources before policy evaluation, but drops them when constructing `/scfw/report` requests. Populate the report field so backend events retain the registry, mirror, or local source used for each package.

## 📚 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [SCFW CLI never populates package_artifact_source in /scfw/report](https://datadoghq.atlassian.net/browse/K9CODESEC-5609)

## 📝 Summary

- Pass the resolved installation targets into report construction.
- Correlate evaluation results with their resolved `package_source` and serialize it as `package_artifact_source`.
- Omit the field when the source is unknown or package coordinates map to conflicting sources, avoiding nondeterministic reporting.

## 🧪 Testing

- [x] New tests were added for new logic.
- [x] Existing tests were updated for new logic, and not only so that they pass!
- [ ] Benchmark results prove that performance is the same or better.

## 🆘 Recovery

Notes for on-call - **select only one**:
- [x] The change can be rolled back.
- [ ] Do not roll back. Why?:
